### PR TITLE
Adding issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,27 @@
+<!--
+  Fill in the placeholders below. Delete any headings and placeholders that you do not fill in. 
+-->
+####Operating System: [e.g. Windows 10]
+####Commit/build: [e.g. 30376e1]
+####Original game source: [e.g. Origin or game disc]
+
+- [ ] Reproducible in the original Generals Zero Hour?
+- [ ] Multiplayer affected?
+- [ ] Are you using any mods? (like Gentool, Rise of the Reds or Contra)
+<!-- 
+  It is strongly advised not to run Thyme while using mods as this can interfere with Thyme and can cause issues.
+-->
+
+###Issue explanation
+<!-- Fill in the explanation of the issue you encountered -->
+
+###Steps to reproduce the problem
+1.
+2.
+3.
+
+###Screenshot(s) or video
+<!-- If neccesary to show us the prolem, drag & drop screenshots here. You can use https://youtube.com to upload a video. -->
+
+###Save game
+<!-- Change the file extension from .sav to .txt or package to a .zip, by using 7-Zip or WinRAR, so that it can be drag & dropped here... -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -8,17 +8,17 @@
 - [ ] Reproducible in the original Generals Zero Hour?
 - [ ] Multiplayer affected?
 - [ ] Are you using any mods? (like Gentool, Rise of the Reds or Contra)
-<!-- 
-  It is strongly advised not to run Thyme while using mods as this can interfere with Thyme and can cause issues.
--->
 
 ###Issue explanation
-<!-- Fill in the explanation of the issue you encountered -->
+<!-- Fill in the explanation of the issue you encountered. -->
 
 ###Steps to reproduce the problem
 1.
 2.
 3.
+
+###Log files
+<!--Provide the "ThymeDebugLogFile.txt" by drag & dropping it here. It can be found in the following folder: %USERPROFILE%\Documents\Command and Conquer Generals Zero Hour Data-->
 
 ###Screenshot(s) or video
 <!-- If neccesary to show us the prolem, drag & drop screenshots here. You can use https://youtube.com to upload a video. -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -3,7 +3,7 @@
 -->
 ####Operating System: [e.g. Windows 10]
 ####Commit/build: [e.g. 30376e1]
-####Original game source: [e.g. Origin or game disc]
+####Original game source: [e.g. Origin, TFD or game disc]
 
 - [ ] Reproducible in the original Generals Zero Hour?
 - [ ] Multiplayer affected?

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -18,7 +18,7 @@
 3.
 
 ###Log files
-<!--Provide the "ThymeDebugLogFile.txt" by drag & dropping it here. It can be found in the following folder: %USERPROFILE%\Documents\Command and Conquer Generals Zero Hour Data-->
+<!--Provide the "ThymeDebugLogFile.txt" (and the "ReleaseCrashInfo.txt" in case of a crash) by drag & dropping it here. It can be found in the following folder: %USERPROFILE%\Documents\Command and Conquer Generals Zero Hour Data-->
 
 ###Screenshot(s) or video
 <!-- If neccesary to show us the prolem, drag & drop screenshots here. You can use https://youtube.com to upload a video. -->

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,27 +1,27 @@
 <!--
   Fill in the placeholders below. Delete any headings and placeholders that you do not fill in. 
 -->
-####Operating System: [e.g. Windows 10]
-####Commit/build: [e.g. 30376e1]
-####Original game source: [e.g. Origin, TFD or game disc]
+#### Operating System: [e.g. Windows 10]
+#### Commit/build: [e.g. 30376e1]
+#### Original game source: [e.g. Origin, TFD or game disc]
 
 - [ ] Reproducible in the original Generals Zero Hour?
 - [ ] Multiplayer affected?
 - [ ] Are you using any mods? (like Gentool, Rise of the Reds or Contra)
 
-###Issue explanation
+### Issue explanation
 <!-- Fill in the explanation of the issue you encountered. -->
 
-###Steps to reproduce the problem
+### Steps to reproduce the problem
 1.
 2.
 3.
 
-###Log files
+### Log files
 <!--Provide the "ThymeDebugLogFile.txt" (and the "ReleaseCrashInfo.txt" in case of a crash) by drag & dropping it here. It can be found in the following folder: %USERPROFILE%\Documents\Command and Conquer Generals Zero Hour Data-->
 
-###Screenshot(s) or video
+### Screenshot(s) or video
 <!-- If neccesary to show us the prolem, drag & drop screenshots here. You can use https://youtube.com to upload a video. -->
 
-###Save game
+### Save game
 <!-- Change the file extension from .sav to .txt or package to a .zip, by using 7-Zip or WinRAR, so that it can be drag & dropped here... -->


### PR DESCRIPTION
This can be used for people to make (better) issue reports, especially for in the future. This can stimulate development as it will attract more developers to help with this project. I added it to a hidden .Github folder, so it doesn't clutter anything. What do you think of it @OmniBlade ? Any suggestions?

My only question is where to find the stackdump after Thyme crashes. I couldn't find out where it gets stored. Then I could add it to the issue template too.