### PR TITLE
Gamemath

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/libs/gamemath"]
+	path = src/libs/gamemath
+	url = https://gitlab.com/OmniBlade/gamemath.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,6 +33,7 @@ endif()
 
 # This doesn't really work yet, work ongoing to make it usable
 option(STANDALONE "Build a standalone version." OFF)
+option(THYME_USE_GAMEMATH "Use own maths library rather than libc version for this platform." ON)
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${thyme_SOURCE_DIR}/cmake/modules)
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -39,8 +39,9 @@ skip_commits:
 max_jobs: 1
 
 # scripts that run after cloning repository
-#install:
-#  - ps: cd C:\projects
+install:
+  - cmd: cd C:\projects\thyme
+  - cmd: git submodule update --init --recursive
 
 # scripts to run before build
 before_build:

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,6 +16,12 @@ else()
     endif()
 endif()
 
+if(THYME_USE_GAMEMATH)
+    add_subdirectory(libs/gamemath EXCLUDE_FROM_ALL)
+    add_definitions(-DTHYME_USING_GAMEMATH)
+    set(PLATFORM_LIBS ${PLATFORM_LIBS} gamemath_static_lib)
+endif()
+
 # Build and link the DLL.
 set(GAMEENGINE_INCLUDES
     base

--- a/src/w3d/math/gamemath.h
+++ b/src/w3d/math/gamemath.h
@@ -309,7 +309,11 @@ inline int Fast_To_Int_Floor(float val)
         val -= _almost_one;
     }
 
-    return lrintf(truncf(val));
+#ifdef THYME_USING_GAMEMATH
+    return gm_lrintf(gm_truncf(val));
+#else
+    return lrintf(truncf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Random_Float()

--- a/src/w3d/math/gamemath.h
+++ b/src/w3d/math/gamemath.h
@@ -19,11 +19,16 @@
 #include "gamedebug.h"
 #include "array.h"
 #include <cfloat>
-#include <cmath>
 #include <cstdlib>
 
 #ifdef PROCESSOR_X86
 #include <xmmintrin.h>
+#endif
+
+#ifdef THYME_USING_GAMEMATH
+#include "gmath.h"
+#else
+#include <cmath>
 #endif
 
 #define GAMEMATH_EPSILON 0.0001f
@@ -66,7 +71,7 @@ void Shutdown();
 
 inline float Square(float val)
 {
-    return float(val *val);
+    return float(val * val);
 }
 
 inline float Fabs(float val)
@@ -105,12 +110,20 @@ inline int Float_To_Int_Floor(const float &f)
 
 inline float Cos(float val)
 {
+#ifdef THYME_USING_GAMEMATH
+    return gm_cosf(val);
+#else
     return float(cosf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Sin(float val)
 {
+#ifdef THYME_USING_GAMEMATH
+    return gm_sinf(val);
+#else
     return float(sinf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Inv_Sin(float val)
@@ -120,37 +133,61 @@ inline float Inv_Sin(float val)
 
 inline float Sqrt(float val)
 {
+#ifdef THYME_USING_GAMEMATH
+    return gm_sqrtf(val);
+#else
     return float(sqrtf(val)); // IEEE standard says this is predictable for all conforming implementations.
+#endif
 }
 
 inline float Inv_Sqrt(float val)
 {
-    return float(1.0f / sqrtf(val));
+    return float(1.0f / Sqrt(val));
 }
 
 inline float Acos(float val)
 {
-    return float(acosf(val));
+#ifdef THYME_USING_GAMEMATH
+    return gm_acosf(val);
+#else
+    return float(acosf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Asin(float val)
 {
-    return float(asinf(val));
+#ifdef THYME_USING_GAMEMATH
+    return gm_asinf(val);
+#else
+    return float(asinf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Atan(float val)
 {
-    return float(atanf(val));
+#ifdef THYME_USING_GAMEMATH
+    return gm_atanf(val);
+#else
+    return float(atanf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Atan2(float y, float x)
 {
-    return float(atan2f(y, x));
+#ifdef THYME_USING_GAMEMATH
+    return gm_atan2f(y, x);
+#else
+    return float(atan2f(y, x)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Tan(float val)
 {
-    return float(tanf(val));
+#ifdef THYME_USING_GAMEMATH
+    return gm_tanf(val);
+#else
+    return float(tanf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Fast_Sin(float val)
@@ -243,12 +280,20 @@ inline float Sign(float val)
 
 inline float Ceil(float val)
 {
-    return ceilf(val);
+#ifdef THYME_USING_GAMEMATH
+    return gm_ceilf(val);
+#else
+    return float(ceilf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline float Floor(float val)
 {
-    return floorf(val);
+#ifdef THYME_USING_GAMEMATH
+    return gm_floorf(val);
+#else
+    return float(floorf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
 }
 
 inline bool Fast_Is_Float_Positive(const float &val)

--- a/src/w3d/math/sphere.h
+++ b/src/w3d/math/sphere.h
@@ -1,26 +1,18 @@
-////////////////////////////////////////////////////////////////////////////////
-//                               --  THYME  --                                //
-////////////////////////////////////////////////////////////////////////////////
-//
-//  Project Name:: Thyme
-//
-//          File:: SPHERE.H
-//
-//        Author:: Tiberian Technologies
-//
-//  Contributors:: OmniBlade
-//
-//   Description:: Plane class
-//
-//       License:: Thyme is free software: you can redistribute it and/or 
-//                 modify it under the terms of the GNU General Public License 
-//                 as published by the Free Software Foundation, either version 
-//                 2 of the License, or (at your option) any later version.
-//
-//                 A full copy of the GNU General Public License can be found in
-//                 LICENSE
-//
-////////////////////////////////////////////////////////////////////////////////
+/**
+ * @file
+ *
+ * @author Tiberian Technologies
+ * @author OmniBlade
+ *
+ * @brief Sphere object.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
 #pragma once
 
 #include "gamemath.h"
@@ -141,7 +133,7 @@ inline SphereClass::SphereClass(const Vector3 *Position, const int VertCount)
         float testrad2 = dx * dx + dy * dy + dz * dz;
 
         if ( testrad2 > radsqr ) {
-            float testrad = sqrt(testrad2);
+            float testrad = GameMath::Sqrt(testrad2);
             radius = (radius + testrad) / 2.0f;
             radsqr = radius * radius;
             float oldtonew = testrad - radius;

--- a/src/w3d/math/vector2.h
+++ b/src/w3d/math/vector2.h
@@ -1,42 +1,33 @@
-////////////////////////////////////////////////////////////////////////////////
-//                               --  THYME  --                                //
-////////////////////////////////////////////////////////////////////////////////
-//
-//  Project Name:: Thyme
-//
-//          File:: VECTOR2.H
-//
-//        Author:: Tiberian Technologies
-//
-//  Contributors:: OmniBlade
-//
-//   Description:: 2D Vector class.
-//
-//       License:: Thyme is free software: you can redistribute it and/or 
-//                 modify it under the terms of the GNU General Public License 
-//                 as published by the Free Software Foundation, either version 
-//                 2 of the License, or (at your option) any later version.
-//
-//                 A full copy of the GNU General Public License can be found in
-//                 LICENSE
-//
-////////////////////////////////////////////////////////////////////////////////
+/**
+ * @file
+ *
+ * @author Tiberian Technologies
+ * @author OmniBlade
+ *
+ * @brief 2D Vector class.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
 #pragma once
 
-#include    "always.h"
-#include    "gamemath.h"
-#include    "gamedebug.h"
+#include "always.h"
+#include "gamedebug.h"
+#include "gamemath.h"
 
 class Vector2i
 {
 public:
-    Vector2i(void)
-    {
-    }
+    Vector2i() {}
 
     Vector2i(int i, int j)
     {
-        I = i; J = j;
+        I = i;
+        J = j;
     }
 
     void Set(int i, int j)
@@ -50,8 +41,6 @@ public:
     int J;
 };
 
-
-
 class Vector2
 {
 public:
@@ -61,7 +50,7 @@ public:
 
     __forceinline explicit Vector2(const float vector[2])
     {
-        DEBUG_ASSERT(vector != NULL);
+        DEBUG_ASSERT(vector != nullptr);
         X = vector[0];
         Y = vector[1];
     }
@@ -86,17 +75,11 @@ public:
         Y = v.Y;
     }
 
-    __forceinline float &operator[](int i)
-    {
-        return (&X)[i];
-    }
+    __forceinline float &operator[](int i) { return (&X)[i]; }
 
-    __forceinline const float &operator[](int i) const
-    {
-        return (&X)[i];
-    }
+    __forceinline const float &operator[](int i) const { return (&X)[i]; }
 
-    __forceinline void Normalize(void)
+    __forceinline void Normalize()
     {
         float len2 = GAMEMATH_FLOAT_TINY + Length2();
         float oolen = GameMath::Inv_Sqrt(len2);
@@ -104,25 +87,13 @@ public:
         Y *= oolen;
     }
 
-    __forceinline float Length(void) const
-    {
-        return (float)GameMath::Sqrt(Length2());
-    }
+    __forceinline float Length() const { return (float)GameMath::Sqrt(Length2()); }
 
-    __forceinline float Length2(void) const
-    {
-        return (float)(X * X + Y * Y);
-    }
+    __forceinline float Length2() const { return (float)(X * X + Y * Y); }
 
-    __forceinline Vector2 operator-() const
-    {
-        return Vector2(-X, -Y);
-    }
+    __forceinline Vector2 operator-() const { return Vector2(-X, -Y); }
 
-    __forceinline Vector2 operator+() const
-    {
-        return *this;
-    }
+    __forceinline Vector2 operator+() const { return *this; }
 
     __forceinline Vector2 &operator+=(const Vector2 &v)
     {
@@ -157,20 +128,11 @@ public:
         return *this;
     }
 
-    __forceinline static float Dot_Product(const Vector2 &a, const Vector2 &b)
-    {
-        return a * b;
-    }
+    __forceinline static float Dot_Product(const Vector2 &a, const Vector2 &b) { return a * b; }
 
-    __forceinline static float Perp_Dot_Product(const Vector2 &a, const Vector2 &b)
-    {
-        return a.X * -b.Y + a.Y * b.X;
-    }
+    __forceinline static float Perp_Dot_Product(const Vector2 &a, const Vector2 &b) { return a.X * -b.Y + a.Y * b.X; }
 
-    __forceinline void Rotate(float theta)
-    {
-        Rotate(GameMath::Sin(theta), GameMath::Cos(theta));
-    }
+    __forceinline void Rotate(float theta) { Rotate(GameMath::Sin(theta), GameMath::Cos(theta)); }
 
     __forceinline void Rotate(float s, float c)
     {
@@ -180,21 +142,21 @@ public:
         Y = new_y;
     }
 
-    __forceinline bool Rotate_Towards_Vector(Vector2 &target, float max_theta, bool & positive_turn)
+    __forceinline bool Rotate_Towards_Vector(Vector2 &target, float max_theta, bool &positive_turn)
     {
-        return Rotate_Towards_Vector(target, sin(max_theta), cos(max_theta), positive_turn);
+        return Rotate_Towards_Vector(target, GameMath::Sin(max_theta), GameMath::Cos(max_theta), positive_turn);
     }
 
-    __forceinline bool Rotate_Towards_Vector(Vector2 &target, float max_s, float max_c, bool & positive_turn)
+    __forceinline bool Rotate_Towards_Vector(Vector2 &target, float max_s, float max_c, bool &positive_turn)
     {
         positive_turn = Vector2::Perp_Dot_Product(target, *this) > 0.0f;
 
-        if ( Vector2::Dot_Product(*this, target) >= max_c ) {
+        if (Vector2::Dot_Product(*this, target) >= max_c) {
             Set(target);
 
             return true;
         } else {
-            if ( positive_turn ) {
+            if (positive_turn) {
                 Rotate(max_s, max_c);
             } else {
                 Rotate(-max_s, max_c);
@@ -206,22 +168,22 @@ public:
 
     __forceinline void Update_Min(const Vector2 &a)
     {
-        if ( a.X < X ) {
+        if (a.X < X) {
             X = a.X;
         }
 
-        if ( a.Y < Y ) {
+        if (a.Y < Y) {
             Y = a.Y;
         }
     }
 
     __forceinline void Update_Max(const Vector2 &a)
     {
-        if ( a.X > X ) {
+        if (a.X > X) {
             X = a.X;
         }
 
-        if ( a.Y > Y ) {
+        if (a.Y > Y) {
             Y = a.Y;
         }
     }
@@ -260,15 +222,15 @@ public:
 
     __forceinline void Floor()
     {
-        X = floor(X);
-        Y = floor(Y);
+        X = GameMath::Floor(X);
+        Y = GameMath::Floor(Y);
     };
 
     friend Vector2 operator*(const Vector2 &a, float k);
     friend Vector2 operator*(float k, const Vector2 &a);
     friend Vector2 operator/(const Vector2 &a, float k);
     friend Vector2 operator/(const Vector2 &a, const Vector2 &b) { return Vector2(a.X / b.X, a.Y / b.Y); }
-    friend Vector2 operator/(const Vector2 &a, const Vector2i& b) { return Vector2(a.X / b.I, a.Y / b.J); }
+    friend Vector2 operator/(const Vector2 &a, const Vector2i &b) { return Vector2(a.X / b.I, a.Y / b.J); }
     friend Vector2 operator+(const Vector2 &a, const Vector2 &b);
     friend Vector2 operator-(const Vector2 &a, const Vector2 &b);
     friend float operator*(const Vector2 &a, const Vector2 &b);
@@ -314,17 +276,17 @@ __forceinline Vector2 operator-(const Vector2 &a, const Vector2 &b)
     return Vector2(a.X - b.X, a.Y - b.Y);
 }
 
-__forceinline float operator* (const Vector2 &a, const Vector2 &b)
+__forceinline float operator*(const Vector2 &a, const Vector2 &b)
 {
     return a.X * b.X + a.Y * b.Y;
 }
 
-__forceinline bool operator== (const Vector2 &a, const Vector2 &b)
+__forceinline bool operator==(const Vector2 &a, const Vector2 &b)
 {
     return (a.X == b.X) | (a.Y == b.Y);
 }
 
-__forceinline bool operator!= (const Vector2 &a, const Vector2 &b)
+__forceinline bool operator!=(const Vector2 &a, const Vector2 &b)
 {
     return (a.X != b.X) | (a.Y != b.Y);
 }

--- a/src/w3d/math/vector3.h
+++ b/src/w3d/math/vector3.h
@@ -1,26 +1,18 @@
-////////////////////////////////////////////////////////////////////////////////
-//                               --  THYME  --                                //
-////////////////////////////////////////////////////////////////////////////////
-//
-//  Project Name:: Thyme
-//
-//          File:: VECTOR3.H
-//
-//        Author:: Tiberian Technologies
-//
-//  Contributors:: OmniBlade
-//
-//   Description:: 3D Vector class.
-//
-//       License:: Thyme is free software: you can redistribute it and/or 
-//                 modify it under the terms of the GNU General Public License 
-//                 as published by the Free Software Foundation, either version 
-//                 2 of the License, or (at your option) any later version.
-//
-//                 A full copy of the GNU General Public License can be found in
-//                 LICENSE
-//
-////////////////////////////////////////////////////////////////////////////////
+/**
+ * @file
+ *
+ * @author Tiberian Technologies
+ * @author OmniBlade
+ *
+ * @brief 3D Vector class.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
 #pragma once
 
 #include "always.h"

--- a/src/w3d/math/vector4.h
+++ b/src/w3d/math/vector4.h
@@ -1,26 +1,18 @@
-////////////////////////////////////////////////////////////////////////////////
-//                               --  THYME  --                                //
-////////////////////////////////////////////////////////////////////////////////
-//
-//  Project Name:: Thyme
-//
-//          File:: VECTOR4.H
-//
-//        Author:: Tiberian Technologies
-//
-//  Contributors:: OmniBlade
-//
-//   Description:: 4D Vector class.
-//
-//       License:: Thyme is free software: you can redistribute it and/or 
-//                 modify it under the terms of the GNU General Public License 
-//                 as published by the Free Software Foundation, either version 
-//                 2 of the License, or (at your option) any later version.
-//
-//                 A full copy of the GNU General Public License can be found in
-//                 LICENSE
-//
-////////////////////////////////////////////////////////////////////////////////
+/**
+ * @file
+ *
+ * @author Tiberian Technologies
+ * @author OmniBlade
+ *
+ * @brief 4D Vector class.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
 #pragma once
 
 #include    "always.h"


### PR DESCRIPTION
Adds the option to build the engine with an internal maths library rather than using the plaform one provided with the libc implementation. Should make engine floating point behaviour more constistent across platforms/CPUs.