### PR TITLE
ICU

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,9 @@
 #look at this at some point for structuring the project
 #https: // rix0r.nl/blog/2015/08/13/cmake-guide/
 
-cmake_minimum_required(VERSION 3.0.0)
+cmake_minimum_required(VERSION 3.7.0)
 
-cmake_policy(SET CMP0074 NEW)
+cmake_policy(VERSION 3.7.0)
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "No build type selected, default to Debug")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,9 @@
 #look at this at some point for structuring the project
-#https://rix0r.nl/blog/2015/08/13/cmake-guide/
+#https: // rix0r.nl/blog/2015/08/13/cmake-guide/
 
-cmake_minimum_required(VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.0.0)
+
+cmake_policy(SET CMP0074 NEW)
 
 if (NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
     message(STATUS "No build type selected, default to Debug")
@@ -39,6 +41,8 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${thyme_SOURCE_DIR}/cmake/modules)
 
 # Go lean and mean on windows.
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
+    option(USE_ICU_LIB "Use ICU for unicode support instead of Win32 API" OFF)
+
     add_definitions(-DWIN32_LEAN_AND_MEAN)
     add_definitions(-D_CRT_SECURE_NO_DEPRECATE)
     add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,15 +11,10 @@ if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
 
     # ICU is optional for windows builds, use only for development purposes.
     if(USE_ICU_LIB)
-        #find_package(ICU) # Can't get this to work for some reason on windows.
         if(NOT ICU_ROOT)
             message(FATAL_ERROR "You must set the path to ICU as ICU_ROOT to use ICU in windows.")
         else()
-            set(ICU_FOUND true)
-            add_definitions(-DU_STATIC_IMPLEMENTATION)
-            set(ICU_INCLUDE_DIRS ${ICU_ROOT}/include)
-            #set(ICU_LIBRARIES ${ICU_ROOT}/lib/sicudt.lib ${ICU_ROOT}/lib/sicuin.lib ${ICU_ROOT}/lib/sicuio.lib ${ICU_ROOT}/lib/sicutest.lib ${ICU_ROOT}/lib/sicutu.lib ${ICU_ROOT}/lib/sicuuc.lib)
-            set(ICU_LIBRARIES ${ICU_ROOT}/lib/sicudtd.lib ${ICU_ROOT}/lib/sicuind.lib ${ICU_ROOT}/lib/sicuiod.lib ${ICU_ROOT}/lib/sicutestd.lib ${ICU_ROOT}/lib/sicutud.lib ${ICU_ROOT}/lib/sicuucd.lib)
+            find_package(ICU REQUIRED data i18n io tu uc)
         endif()
     endif()
 else()
@@ -30,7 +25,7 @@ else()
     endif()
 
     # Finds libicu, required for unicode on none windows.
-    find_package(ICU REQUIRED)
+    find_package(ICU REQUIRED data i18n io tu uc)
 endif()
 
 if(ICU_FOUND)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,6 +1,6 @@
 # Add platform libraries needed for the build
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
-    find_package(DirectX)
+    find_package(DirectX REQUIRED)
     
     if(DirectX_D3D8_INCLUDE_FOUND)
         message("Located Direct3D8 headers.")
@@ -8,12 +8,35 @@ if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
     endif()
     
     set(PLATFORM_LIBS ${PLATFORM_LIBS} winmm dbghelp ws2_32)
+
+    # ICU is optional for windows builds, use only for development purposes.
+    if(USE_ICU_LIB)
+        #find_package(ICU) # Can't get this to work for some reason on windows.
+        if(NOT ICU_ROOT)
+            message(FATAL_ERROR "You must set the path to ICU as ICU_ROOT to use ICU in windows.")
+        else()
+            set(ICU_FOUND true)
+            add_definitions(-DU_STATIC_IMPLEMENTATION)
+            set(ICU_INCLUDE_DIRS ${ICU_ROOT}/include)
+            #set(ICU_LIBRARIES ${ICU_ROOT}/lib/sicudt.lib ${ICU_ROOT}/lib/sicuin.lib ${ICU_ROOT}/lib/sicuio.lib ${ICU_ROOT}/lib/sicutest.lib ${ICU_ROOT}/lib/sicutu.lib ${ICU_ROOT}/lib/sicuuc.lib)
+            set(ICU_LIBRARIES ${ICU_ROOT}/lib/sicudtd.lib ${ICU_ROOT}/lib/sicuind.lib ${ICU_ROOT}/lib/sicuiod.lib ${ICU_ROOT}/lib/sicutestd.lib ${ICU_ROOT}/lib/sicutud.lib ${ICU_ROOT}/lib/sicuucd.lib)
+        endif()
+    endif()
 else()
     # Find pthreads on none windows platforms.
     find_package(Threads REQUIRED)
     if(CMAKE_THREAD_LIBS_INIT)
         set(PLATFORM_LIBS ${PLATFORM_LIBS} ${CMAKE_THREAD_LIBS_INIT})
     endif()
+
+    # Finds libicu, required for unicode on none windows.
+    find_package(ICU REQUIRED)
+endif()
+
+if(ICU_FOUND)
+    add_definitions(-DTHYME_USE_ICU)
+    set(PLATFORM_LIBS ${PLATFORM_LIBS} ${ICU_LIBRARIES})
+    set(PLATFORM_INCLUDES ${PLATFORM_INCLUDES} ${ICU_INCLUDE_DIRS})
 endif()
 
 if(THYME_USE_GAMEMATH)

--- a/src/base/always.h
+++ b/src/base/always.h
@@ -43,10 +43,6 @@
 #define u_isspace iswspace
 #define u_tolower towlower
 #define U_COMPARE_CODE_POINT_ORDER 0x8000
-#else
-// Attempts to prevent lookup against icu::UnicodeString
-class UnicodeString;
-using ::UnicodeString;
 #endif
 
 //  Define nullptr when standard is less than C++x0

--- a/src/base/always.h
+++ b/src/base/always.h
@@ -1,79 +1,61 @@
-////////////////////////////////////////////////////////////////////////////////
-//                               --  THYME  --                                //
-////////////////////////////////////////////////////////////////////////////////
-//
-//  Project Name:: Thyme
-//
-//          File:: ALWAYS.H
-//
-//        Author:: CCHyper & OmniBlade
-//
-//  Contributors::
-//
-//   Description:: Basic header files and defines that are always needed.
-//
-//       License:: Thyme is free software: you can redistribute it and/or
-//                 modify it under the terms of the GNU General Public License
-//                 as published by the Free Software Foundation, either version
-//                 2 of the License, or (at your option) any later version.
-//
-//                 A full copy of the GNU General Public License can be found in
-//                 LICENSE
-//
-////////////////////////////////////////////////////////////////////////////////
+/**
+ * @file
+ *
+ * @author CCHyper
+ * @author OmniBlade
+ *
+ * @brief Basic header files and defines that are always needed.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
 #pragma once
 
-////////////////////////////////////////////////////////////////////////////////
-//
-//  Includes
-//
-////////////////////////////////////////////////////////////////////////////////
 #include "bittype.h"
 #include "config.h"
 #include "macros.h"
 #include "targetver.h"
-#include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 
-////////////////////////////////////////////////////////////////////////////////
-//
-//  External Library Includes
-//
-////////////////////////////////////////////////////////////////////////////////
 #if defined(PLATFORM_WINDOWS)
 #include <windows.h>
 #define NAME_MAX FILENAME_MAX
+
 #if !defined(PATH_MAX)
 #define PATH_MAX MAX_PATH
 #endif
 
 #endif
 
-////////////////////////////////////////////////////////////////////////////////
-//
+// Alias the ICU unicode functions when not building against it.
+#ifndef THYME_USE_ICU
+#define u_strlen wcslen
+#define u_strcpy wcscpy
+#define u_strcat wcscat
+#define u_vsnprintf_u vswprintf
+#define u_strcmp wcscmp
+#define u_strcasecmp(x, y, z) _wcsicmp(x, y)
+#define u_isspace iswspace
+#define u_tolower towlower
+#define U_COMPARE_CODE_POINT_ORDER 0x8000
+#endif
+
 //  Define nullptr when standard is less than C++x0
-//
-////////////////////////////////////////////////////////////////////////////////
 #if __cplusplus <= 199711L && !defined COMPILER_MSVC
 #define nullptr NULL
 #endif
 
-////////////////////////////////////////////////////////////////////////////////
-//
-//  General compiler specific
-//    <todo>
-//
-////////////////////////////////////////////////////////////////////////////////
 #if defined(COMPILER_MSVC)
 // Allow inline recursive functions within inline recursive functions.
 #pragma inline_recursion(on)
 
-// Compilers don't necessarily inline code with inline keyword, especially in debug builds.
-// Use FORCE_INLINE to force them to where it is possible.
-//#define FORCE_INLINE	__forceinline
 #define __noinline __declspec(noinline)
 #define __unused __pragma(warning(suppress : 4100 4101))
-// When including windows, lets just bump the warning level back to 3...
 #pragma warning(push, 3)
 
 #else // !COMPILER_MSVC
@@ -107,7 +89,6 @@
 #define __forceinline inline __attribute__((__always_inline__))
 #endif
 #else // !COMPILER_GNUC || !COMPILER_CLANG
-// otherwise, nullify fastcall
 #if !defined(__fastcall)
 #define __fastcall
 #endif
@@ -148,11 +129,7 @@ typedef struct stat stat_t;
 typedef struct stat stat_t;
 #endif // PLATFORM_WINDOWS
 
-////////////////////////////////////////////////////////////////////////////////
-//
 //  Microsoft / Visual Studio
-//
-////////////////////////////////////////////////////////////////////////////////
 // This includes the minimum set of compiler defines and pragmas in order to bring the
 // various compilers to a common behavior such that the engine will compile without
 // error or warning.

--- a/src/base/always.h
+++ b/src/base/always.h
@@ -43,6 +43,10 @@
 #define u_isspace iswspace
 #define u_tolower towlower
 #define U_COMPARE_CODE_POINT_ORDER 0x8000
+#else
+// Attempts to prevent lookup against icu::UnicodeString
+class UnicodeString;
+using ::UnicodeString;
 #endif
 
 //  Define nullptr when standard is less than C++x0

--- a/src/base/bittype.h
+++ b/src/base/bittype.h
@@ -26,7 +26,7 @@
 #endif // _MSC_VER || (__GNUC__ || __clang__ || __WATCOM__)
 
 #ifdef THYME_USE_ICU
-#include <unicode/umachine.h>
+#include <unicode/uchar.h>
 typedef UChar unichar_t;
 #else
 typedef wchar_t unichar_t;

--- a/src/base/bittype.h
+++ b/src/base/bittype.h
@@ -1,58 +1,55 @@
-////////////////////////////////////////////////////////////////////////////////
-//                               --  THYME  --                                //
-////////////////////////////////////////////////////////////////////////////////
-//
-//  Project Name:: Thyme
-//
-//			File:: BITTYPE.H
-//
-//        Author:: OmniBlade
-//
-//  Contributors:: 
-//
-//   Description:: Provides standard definitions for fixed width integers on all
-//                 supported platforms and types to use for type punning 
-//                 pointers.
-//
-//       License:: Thyme is free software: you can redistribute it and/or 
-//                 modify it under the terms of the GNU General Public License 
-//                 as published by the Free Software Foundation, either version 
-//                 2 of the License, or (at your option) any later version.
-//
-//                 A full copy of the GNU General Public License can be found in
-//                 
-//
-////////////////////////////////////////////////////////////////////////////////
+/**
+ * @file
+ *
+ * @author OmniBlade
+ *
+ * @brief Fixed width types.
+ *
+ * Provides standard definitions for fixed width integers on all supported platforms and types to use for type punning
+ * pointers.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
 #pragma once
 
-//We aren't supporting MSVC versions earlier than 2010
+// We aren't supporting MSVC versions earlier than 2010
 #if defined(__GNUC__) || defined(__clang__) || defined(__WATCOM__) || _MSC_VER >= 1600 // GNU C++ or clang
-    #include    <stdint.h>
-    #include    <limits.h>
+#include <limits.h>
+#include <stdint.h>
 #else // !_MSC_VER || !(__GNUC__ || __clang__ || __WATCOM__)
-    #error Unknown compiler.Please specify fixed - size integer types in 'bittype.h'.
+#error Unknown compiler.Please specify fixed - size integer types in 'bittype.h'.
 #endif // _MSC_VER || (__GNUC__ || __clang__ || __WATCOM__)
-    
-    //
-    // Use these as pointers to do type punning.
-    //
+
+#ifdef THYME_USE_ICU
+#include <unicode/umachine.h>
+typedef UChar unichar_t;
+#else
+typedef wchar_t unichar_t;
+#endif
+
+// Use these as pointers to do type punning.
 #if defined(__GNUC__) || defined(__clang__)
-    typedef float __attribute__((__may_alias__)) float_a;
-    typedef int32_t __attribute__((__may_alias__)) int32_a;
-    typedef uint32_t __attribute__((__may_alias__)) uint32_a;
-    typedef double __attribute__((__may_alias__)) double_a;
-    typedef int64_t __attribute__((__may_alias__)) int64_a;
-    typedef uint64_t __attribute__((__may_alias__)) uint64_a;
-    typedef wchar_t __attribute__((__may_alias__)) wchar_a;
-#else   
-    // MSVC doesn't currently enforce strict aliasing.
-    typedef float float_a;
-    typedef int32_t int32_a;
-    typedef uint32_t uint32_a;
-    typedef double double_a;
-    typedef int64_t int64_a;
-    typedef uint64_t uint64_a;
-    typedef wchar_t wchar_a;
+typedef float __attribute__((__may_alias__)) float_a;
+typedef int32_t __attribute__((__may_alias__)) int32_a;
+typedef uint32_t __attribute__((__may_alias__)) uint32_a;
+typedef double __attribute__((__may_alias__)) double_a;
+typedef int64_t __attribute__((__may_alias__)) int64_a;
+typedef uint64_t __attribute__((__may_alias__)) uint64_a;
+typedef unichar_t __attribute__((__may_alias__)) unichar_a;
+#else
+// MSVC doesn't currently enforce strict aliasing.
+typedef float float_a;
+typedef int32_t int32_a;
+typedef uint32_t uint32_a;
+typedef double double_a;
+typedef int64_t int64_a;
+typedef uint64_t uint64_a;
+typedef unichar_t unichar_a;
 #endif
 
 // Union to use for type punning.

--- a/src/game/client/displaystring.cpp
+++ b/src/game/client/displaystring.cpp
@@ -32,7 +32,7 @@ DisplayString::~DisplayString()
  * 
  * 0x007F8260
  */
-void DisplayString::Set_Text(UnicodeString text)
+void DisplayString::Set_Text(Utf16String text)
 {
 	if (text != m_textString) {
 		m_textString = text;

--- a/src/game/client/displaystring.h
+++ b/src/game/client/displaystring.h
@@ -29,8 +29,8 @@ public:
     DisplayString();
     virtual ~DisplayString();
 
-    virtual void Set_Text(UnicodeString text);
-    virtual UnicodeString Get_Text() { return m_textString; }
+    virtual void Set_Text(Utf16String text);
+    virtual Utf16String Get_Text() { return m_textString; }
     virtual int Get_Text_Length() { return m_textString.Get_Length(); }
     virtual void Notify_Text_Changed() {}
     virtual void Reset();
@@ -47,7 +47,7 @@ public:
     virtual void Add_Char(wchar_t ch);
 
 protected:
-    UnicodeString m_textString;
+    Utf16String m_textString;
     GameFont *m_font;
     DisplayString *m_next;
     DisplayString *m_prev;

--- a/src/game/client/gameclient.h
+++ b/src/game/client/gameclient.h
@@ -50,7 +50,7 @@ class GameClient : public SubsystemInterface, public SnapShot
 {
     struct DrawableTOCEntry
     {
-        AsciiString name;
+        Utf8String name;
         uint16_t number;
     };
 
@@ -78,8 +78,8 @@ public:
     virtual RayEffectData *Create_Ray_Effect_From_Template(
         const Coord3D *src, const Coord3D *dst, const ThingTemplate *temp) = 0;
     virtual void Add_Scorch(Coord3D *pos, float scale, Scorches scorch) = 0;
-    virtual bool Load_Map(AsciiString name) { return name.Is_Not_Empty() ? true : false; }
-    virtual void Unload_Map(AsciiString name) {}
+    virtual bool Load_Map(Utf8String name) { return name.Is_Not_Empty() ? true : false; }
+    virtual void Unload_Map(Utf8String name) {}
     virtual void Iterate_Drawables_In_Region(Region3D *region, void (*func)(Drawable *, void *), void *data);
     virtual Drawable *Create_Drawable(ThingTemplate *temp, DrawableStatus status) = 0;
     virtual void Destroy_Drawable(Drawable *drawable);

--- a/src/game/client/gametext.cpp
+++ b/src/game/client/gametext.cpp
@@ -752,7 +752,7 @@ void GameTextManager::Init()
 
     // Fetch the GUI window title string and set it here.
     AsciiString ntitle;
-    UnicodeString wtitle = (const unichar_t *)u"Thyme - ";
+    Utf16String wtitle = (const unichar_t *)u"Thyme - ";
     wtitle += Fetch("GUI:Command&ConquerGenerals");
 
     ntitle.Translate(wtitle);
@@ -783,14 +783,14 @@ void GameTextManager::Reset()
 
 // Find and return the unicode string corresponding to the label provided.
 // Optionally can pass a bool pointer to determine if a string was found.
-UnicodeString GameTextManager::Fetch(AsciiString args, bool *success)
+Utf16String GameTextManager::Fetch(AsciiString args, bool *success)
 {
     return Fetch(args.Str(), success);
 }
 
 // Find anr return the unicode string corresponding to the label provided.
 // Optionally can pass a bool pointer to determine if a string was found.
-UnicodeString GameTextManager::Fetch(const char *args, bool *success)
+Utf16String GameTextManager::Fetch(const char *args, bool *success)
 {
     if (m_stringInfo == nullptr) {
         if (success != nullptr) {
@@ -832,7 +832,7 @@ UnicodeString GameTextManager::Fetch(const char *args, bool *success)
     }
 
     // If we reached here, we didn't find a string from our string file.
-    UnicodeString missing;
+    Utf16String missing;
     NoString *no_string;
 
     missing.Format((const unichar_t *)u"MISSING: '%hs'", args);

--- a/src/game/client/gametext.cpp
+++ b/src/game/client/gametext.cpp
@@ -1,7 +1,7 @@
 /**
  * @file
  *
- * @Author OmniBlade
+ * @author OmniBlade
  *
  * @brief String file handler.
  *
@@ -9,7 +9,6 @@
  *            modify it under the terms of the GNU General Public License
  *            as published by the Free Software Foundation, either version
  *            2 of the License, or (at your option) any later version.
- *
  *            A full copy of the GNU General Public License can be found in
  *            LICENSE
  */
@@ -183,7 +182,7 @@ bool GameTextManager::Read_Line(char *buffer, int length, File *file)
 }
 
 // Converts an ASCII string into a usc2/utf16 string.
-void GameTextManager::Translate_Copy(char16_t *out, char *in)
+void GameTextManager::Translate_Copy(unichar_t *out, char *in)
 {
     // Unsigned allows handling latin extended code page.
     unsigned char *in_unsigned = reinterpret_cast<unsigned char *>(in);
@@ -264,13 +263,13 @@ void GameTextManager::Remove_Leading_And_Trailing(char *buffer)
 }
 
 // Strip spaces from a ucs2/utf16 string.
-void GameTextManager::Strip_Spaces(char16_t *buffer)
+void GameTextManager::Strip_Spaces(unichar_t *buffer)
 {
-    char16_t *getp = buffer;
-    char16_t *putp = buffer;
+    unichar_t *getp = buffer;
+    unichar_t *putp = buffer;
 
-    char16_t current = *getp++;
-    char16_t last = '\0';
+    unichar_t current = *getp++;
+    unichar_t last = '\0';
 
     bool prev_whitepsace = true;
 
@@ -673,7 +672,7 @@ GameTextManager::GameTextManager() :
     m_noStringList(nullptr),
     m_useStringFile(true),
     m_language(LANGUAGE_ID_US),
-    m_failed(L"***FATAL*** String Manager failed to initialize properly"),
+    m_failed((const unichar_t *)u"***FATAL*** String Manager failed to initialize properly"),
     m_mapStringInfo(nullptr),
     m_mapStringLUT(nullptr),
     m_mapTextCount(0),
@@ -753,7 +752,7 @@ void GameTextManager::Init()
 
     // Fetch the GUI window title string and set it here.
     AsciiString ntitle;
-    UnicodeString wtitle = L"Thyme - ";
+    UnicodeString wtitle = (const unichar_t *)u"Thyme - ";
     wtitle += Fetch("GUI:Command&ConquerGenerals");
 
     ntitle.Translate(wtitle);
@@ -761,7 +760,7 @@ void GameTextManager::Init()
 #ifdef PLATFORM_WINDOWS
     if (g_applicationHWnd != 0) {
         SetWindowTextA(g_applicationHWnd, ntitle.Str());
-        SetWindowTextW(g_applicationHWnd, wtitle.Str());
+        SetWindowTextW(g_applicationHWnd, (const wchar_t *)wtitle.Str());
     }
 #else
 
@@ -782,7 +781,7 @@ void GameTextManager::Reset()
     }
 }
 
-// Find anr return the unicode string corresponding to the label provided.
+// Find and return the unicode string corresponding to the label provided.
 // Optionally can pass a bool pointer to determine if a string was found.
 UnicodeString GameTextManager::Fetch(AsciiString args, bool *success)
 {
@@ -836,11 +835,11 @@ UnicodeString GameTextManager::Fetch(const char *args, bool *success)
     UnicodeString missing;
     NoString *no_string;
 
-    missing.Format(L"MISSING: '%hs'", args);
+    missing.Format((const unichar_t *)u"MISSING: '%hs'", args);
 
     // Find missing string in NoString list if it already exists.
     for (no_string = m_noStringList; no_string != nullptr; no_string = no_string->next) {
-        if (wcscmp(missing.Str(), no_string->text.Str()) == 0) {
+        if (missing == no_string->text) {
             break;
         }
     }

--- a/src/game/client/gametext.cpp
+++ b/src/game/client/gametext.cpp
@@ -695,7 +695,7 @@ void GameTextManager::Init()
         return;
     }
 
-    AsciiString csfpath;
+    Utf8String csfpath;
     bool use_csf = true;
 
     csfpath.Format("data/%s/Generals.csf", Get_Registry_Language().Str());
@@ -751,7 +751,7 @@ void GameTextManager::Init()
     qsort(m_stringLUT, m_textCount, sizeof(StringLookUp), Compare_LUT);
 
     // Fetch the GUI window title string and set it here.
-    AsciiString ntitle;
+    Utf8String ntitle;
     Utf16String wtitle = (const unichar_t *)u"Thyme - ";
     wtitle += Fetch("GUI:Command&ConquerGenerals");
 
@@ -783,7 +783,7 @@ void GameTextManager::Reset()
 
 // Find and return the unicode string corresponding to the label provided.
 // Optionally can pass a bool pointer to determine if a string was found.
-Utf16String GameTextManager::Fetch(AsciiString args, bool *success)
+Utf16String GameTextManager::Fetch(Utf8String args, bool *success)
 {
     return Fetch(args.Str(), success);
 }
@@ -800,7 +800,7 @@ Utf16String GameTextManager::Fetch(const char *args, bool *success)
         return m_failed;
     }
 
-    AsciiString argstr = args;
+    Utf8String argstr = args;
     StringLookUp key = {&argstr, nullptr};
 
     StringLookUp *found =
@@ -856,7 +856,7 @@ Utf16String GameTextManager::Fetch(const char *args, bool *success)
 }
 
 // List all string labels that start with the prefix passed to the function.
-std::vector<AsciiString> *GameTextManager::Get_Strings_With_Prefix(AsciiString label)
+std::vector<Utf8String> *GameTextManager::Get_Strings_With_Prefix(Utf8String label)
 {
     m_stringVector.clear();
 
@@ -888,7 +888,7 @@ std::vector<AsciiString> *GameTextManager::Get_Strings_With_Prefix(AsciiString l
 
 // Initialises a string file associated with a specific map. Resources
 // allocated here are freed by GameTextManager::Reset()
-void GameTextManager::Init_Map_String_File(AsciiString const &filename)
+void GameTextManager::Init_Map_String_File(Utf8String const &filename)
 {
     // Check if we can use a standard string file, if not, try the csf file.
     Get_String_Count(filename.Str(), m_mapTextCount);

--- a/src/game/client/gametext.h
+++ b/src/game/client/gametext.h
@@ -107,9 +107,9 @@ public:
 #endif
 private:
     void Read_To_End_Of_Quote(File *file, char *in, char *out, char *wave, int buff_len);
-    void Translate_Copy(char16_t *out, char *in);
+    void Translate_Copy(unichar_t *out, char *in);
     void Remove_Leading_And_Trailing(char *buffer);
-    void Strip_Spaces(char16_t *buffer);
+    void Strip_Spaces(unichar_t *buffer);
     void Reverse_Word(char *start, char *end);
     char Read_Char(File *file);
     bool Read_Line(char *buffer, int length, File *file);
@@ -125,7 +125,7 @@ private:
     char m_bufferIn[10240];
     char m_bufferOut[10240];
     char m_bufferEx[10240];
-    char16_t m_translateBuffer[20480];
+    unichar_t m_translateBuffer[20480];
     StringInfo *m_stringInfo;
     StringLookUp *m_stringLUT;
     bool m_initialized;

--- a/src/game/client/gametext.h
+++ b/src/game/client/gametext.h
@@ -61,14 +61,14 @@ struct NoString
 
 struct StringInfo
 {
-    AsciiString label;
+    Utf8String label;
     Utf16String text;
-    AsciiString speech;
+    Utf8String speech;
 };
 
 struct StringLookUp
 {
-    AsciiString *label;
+    Utf8String *label;
     StringInfo *info;
 };
 
@@ -78,9 +78,9 @@ public:
     virtual ~GameTextInterface() {}
 
     virtual Utf16String Fetch(const char *args, bool *success = nullptr) = 0;
-    virtual Utf16String Fetch(AsciiString args, bool *success = nullptr) = 0;
-    virtual std::vector<AsciiString> *Get_Strings_With_Prefix(AsciiString label) = 0;
-    virtual void Init_Map_String_File(AsciiString const &filename) = 0;
+    virtual Utf16String Fetch(Utf8String args, bool *success = nullptr) = 0;
+    virtual std::vector<Utf8String> *Get_Strings_With_Prefix(Utf8String label) = 0;
+    virtual void Init_Map_String_File(Utf8String const &filename) = 0;
     virtual void Deinit() = 0;
 };
 
@@ -95,9 +95,9 @@ public:
     virtual void Update() {}
 
     virtual Utf16String Fetch(const char *args, bool *success = nullptr);
-    virtual Utf16String Fetch(AsciiString args, bool *success = nullptr);
-    virtual std::vector<AsciiString> *Get_Strings_With_Prefix(AsciiString label);
-    virtual void Init_Map_String_File(AsciiString const &filename);
+    virtual Utf16String Fetch(Utf8String args, bool *success = nullptr);
+    virtual std::vector<Utf8String> *Get_Strings_With_Prefix(Utf8String label);
+    virtual void Init_Map_String_File(Utf8String const &filename);
     virtual void Deinit();
 
     static int Compare_LUT(void const *a, void const *b);
@@ -138,7 +138,7 @@ private:
     StringInfo *m_mapStringInfo;
     StringLookUp *m_mapStringLUT;
     int m_mapTextCount;
-    std::vector<AsciiString> m_stringVector;
+    std::vector<Utf8String> m_stringVector;
 };
 
 #ifndef THYME_STANDALONE

--- a/src/game/client/gametext.h
+++ b/src/game/client/gametext.h
@@ -56,13 +56,13 @@ struct CSFHeader
 struct NoString
 {
     NoString *next;
-    UnicodeString text;
+    Utf16String text;
 };
 
 struct StringInfo
 {
     AsciiString label;
-    UnicodeString text;
+    Utf16String text;
     AsciiString speech;
 };
 
@@ -77,8 +77,8 @@ class GameTextInterface : public SubsystemInterface
 public:
     virtual ~GameTextInterface() {}
 
-    virtual UnicodeString Fetch(const char *args, bool *success = nullptr) = 0;
-    virtual UnicodeString Fetch(AsciiString args, bool *success = nullptr) = 0;
+    virtual Utf16String Fetch(const char *args, bool *success = nullptr) = 0;
+    virtual Utf16String Fetch(AsciiString args, bool *success = nullptr) = 0;
     virtual std::vector<AsciiString> *Get_Strings_With_Prefix(AsciiString label) = 0;
     virtual void Init_Map_String_File(AsciiString const &filename) = 0;
     virtual void Deinit() = 0;
@@ -94,8 +94,8 @@ public:
     virtual void Reset();
     virtual void Update() {}
 
-    virtual UnicodeString Fetch(const char *args, bool *success = nullptr);
-    virtual UnicodeString Fetch(AsciiString args, bool *success = nullptr);
+    virtual Utf16String Fetch(const char *args, bool *success = nullptr);
+    virtual Utf16String Fetch(AsciiString args, bool *success = nullptr);
     virtual std::vector<AsciiString> *Get_Strings_With_Prefix(AsciiString label);
     virtual void Init_Map_String_File(AsciiString const &filename);
     virtual void Deinit();
@@ -134,7 +134,7 @@ private:
     bool m_useStringFile;
     // pad 3 chars
     LanguageID m_language;
-    UnicodeString m_failed;
+    Utf16String m_failed;
     StringInfo *m_mapStringInfo;
     StringLookUp *m_mapStringLUT;
     int m_mapTextCount;

--- a/src/game/client/globallanguage.cpp
+++ b/src/game/client/globallanguage.cpp
@@ -100,7 +100,7 @@ GlobalLanguage::GlobalLanguage() :
 void GlobalLanguage::Init()
 {
     INI ini;
-    AsciiString file;
+    Utf8String file;
 
     file.Format("Data/%s/Language.ini", Get_Registry_Language().Str());
 
@@ -127,7 +127,7 @@ void GlobalLanguage::Parse_Language_Defintions(INI *ini)
 
 void GlobalLanguage::Parse_Font_Filename(INI *ini, void *formal, void *store, void const *user_data)
 {
-    AsciiString font_name = ini->Get_Next_Ascii_String();
+    Utf8String font_name = ini->Get_Next_Ascii_String();
     static_cast<GlobalLanguage *>(formal)->m_localFontFiles.push_front(font_name);
 }
 

--- a/src/game/client/globallanguage.h
+++ b/src/game/client/globallanguage.h
@@ -31,15 +31,15 @@ public:
     FontDesc() : m_name("Arial Unicode MS"), m_pointSize(12), m_bold(false) {}
     FontDesc(const char *name, int size = 12, bool bold = false) : m_name(name), m_pointSize(size), m_bold(bold) {}
 
-    const AsciiString &Name() const { return m_name; }
+    const Utf8String &Name() const { return m_name; }
     int Point_Size() const { return m_pointSize; }
     bool Bold() const { return m_bold; }
-    void Set_Name(AsciiString name) { m_name = name; }
+    void Set_Name(Utf8String name) { m_name = name; }
     void Set_Point_Size(int size) { m_pointSize = size; }
     void Set_Bold(bool bold) { m_bold = bold; }
 
 private:
-    AsciiString m_name;
+    Utf8String m_name;
     int m_pointSize;
     bool m_bold;
 };
@@ -63,8 +63,8 @@ public:
     static void Parse_FontDesc(INI *ini, void *formal, void *store, void const *user_data);
 
 private:
-    AsciiString m_unicodeFontName;
-    AsciiString m_unkAsciiString;
+    Utf8String m_unicodeFontName;
+    Utf8String m_unkAsciiString;
     bool m_useHardWordWrap;
     int m_militaryCaptionSpeed;
     int m_militaryCaptionDelayMs;
@@ -86,7 +86,7 @@ private:
     FontDesc m_creditsMinorTitleFont;
     FontDesc m_creditsNormalFont;
     float m_resolutionFontAdjustment;
-    std::list<AsciiString> m_localFontFiles;
+    std::list<Utf8String> m_localFontFiles;
 
     static FieldParse s_languageParseTable[];
 };

--- a/src/game/client/gui/gamefont.h
+++ b/src/game/client/gui/gamefont.h
@@ -19,7 +19,7 @@
 
 struct GameFont
 {
-	AsciiString name_string;
+	Utf8String name_string;
 	int point_size;
 	int bold;
 	int height;

--- a/src/game/client/input/mouse.cpp
+++ b/src/game/client/input/mouse.cpp
@@ -408,7 +408,7 @@ void Mouse::Notify_Resolution_Change()
     m_tooltipDisplayString = g_theDisplayStringManger->New_Display_String();
 
     // FontDesc font;
-    AsciiString font_name;
+    Utf8String font_name;
     int font_size;
     bool font_bold;
 
@@ -606,7 +606,7 @@ void Mouse::Move_Mouse(int x, int y, int absolute)
 /**
  * @brief Gets the cursor enum value from its name. Used for parsing configuration files.
  */
-MouseCursor Mouse::Get_Cursor_Index(const AsciiString &name)
+MouseCursor Mouse::Get_Cursor_Index(const Utf8String &name)
 {
     for (MouseCursor i = CURSOR_NONE; i < CURSOR_COUNT; ++i) {
         if (name == s_cursorNames[i]) {
@@ -678,7 +678,7 @@ void Mouse::Parse_Cursor_Definitions(INI *ini)
         { "Directions", &INI::Parse_Int, nullptr, offsetof(CursorInfo, directions) }
     };
 
-    AsciiString tok = ini->Get_Next_Token();
+    Utf8String tok = ini->Get_Next_Token();
 
     if (g_theMouse != nullptr && tok.Is_Not_Empty()) {
         ini->Init_From_INI(&g_theMouse->m_cursorInfo[g_theMouse->Get_Cursor_Index(tok)], _cursor_parsers);

--- a/src/game/client/input/mouse.h
+++ b/src/game/client/input/mouse.h
@@ -187,7 +187,7 @@ protected:
     int8_t m_numButtons;
     int8_t m_numAxes;
     bool m_forceFeedback;
-    UnicodeString m_tooltipString;
+    Utf16String m_tooltipString;
     DisplayString *m_tooltipDisplayString;
     bool m_displayTooltip;
     bool m_isTooltipEmpty;

--- a/src/game/client/input/mouse.h
+++ b/src/game/client/input/mouse.h
@@ -89,14 +89,14 @@ struct MouseIO
 
 struct CursorInfo
 {
-    AsciiString unk_string;
-    AsciiString cursor_text;
+    Utf8String unk_string;
+    Utf8String cursor_text;
     RGBAColorInt cursor_text_color;
     RGBAColorInt cursor_text_drop_color;
-    AsciiString texture_name;
-    AsciiString image_name;
-    AsciiString w3d_model_name;
-    AsciiString w3d_anim_name;
+    Utf8String texture_name;
+    Utf8String image_name;
+    Utf8String w3d_model_name;
+    Utf8String w3d_anim_name;
     float w3d_scale;
     bool loop;
     Coord2D hot_spot;
@@ -157,11 +157,11 @@ protected:
 	void Update_Mouse_Data();
 	void Process_Mouse_Event(int event_num);
     void Move_Mouse(int x, int y, int absolute); // TODO Should be bool absolute, fix after verifying correctness.
-    MouseCursor Get_Cursor_Index(const AsciiString &name);
+    MouseCursor Get_Cursor_Index(const Utf8String &name);
 
 protected:
     CursorInfo m_cursorInfo[CURSOR_COUNT];
-    AsciiString m_tooltipFontName;
+    Utf8String m_tooltipFontName;
     int m_tooltipFontSize;
     bool m_tooltipFontIsBold;
     //FontDesc m_tooltipFont;

--- a/src/game/client/optionpreferences.cpp
+++ b/src/game/client/optionpreferences.cpp
@@ -142,7 +142,7 @@ int OptionPreferences::Get_Static_Game_Detail()
     return g_theGameLODManager->Get_Static_LOD_Index(it->second);
 }
 
-AsciiString OptionPreferences::Get_Preferred_3D_Provider()
+Utf8String OptionPreferences::Get_Preferred_3D_Provider()
 {
     auto it = find("3DAudioProvider");
 
@@ -155,7 +155,7 @@ AsciiString OptionPreferences::Get_Preferred_3D_Provider()
     return it->second;
 }
 
-AsciiString OptionPreferences::Get_Speaker_Type()
+Utf8String OptionPreferences::Get_Speaker_Type()
 {
     auto it = find("SpeakerType");
 
@@ -493,11 +493,11 @@ uint32_t OptionPreferences::Get_LAN_IPAddress()
 #endif
 }
 
-void OptionPreferences::Set_LAN_IPAddress(AsciiString address)
+void OptionPreferences::Set_LAN_IPAddress(Utf8String address)
 {
 #ifndef THYME_STANDALONE
     // TODO needs IPEnumeration
-    return Call_Method<void, OptionPreferences, AsciiString>(0x004630E0, this, address);
+    return Call_Method<void, OptionPreferences, Utf8String>(0x004630E0, this, address);
 #endif
 }
 
@@ -519,11 +519,11 @@ uint32_t OptionPreferences::Get_Online_IPAddress()
 #endif
 }
 
-void OptionPreferences::Set_Online_IPAddress(AsciiString address)
+void OptionPreferences::Set_Online_IPAddress(Utf8String address)
 {
 #ifndef THYME_STANDALONE
     // TODO needs IPEnumeration
-    return Call_Method<void, OptionPreferences, AsciiString>(0x004636F0, this, address);
+    return Call_Method<void, OptionPreferences, Utf8String>(0x004636F0, this, address);
 #endif
 }
 

--- a/src/game/client/optionpreferences.h
+++ b/src/game/client/optionpreferences.h
@@ -38,8 +38,8 @@ public:
     int Get_Static_Game_Detail();
     void Set_Ideal_Static_Game_Detail(int level) { (*this)["IdealStaticGameLOD"] = g_staticGameLODNames[level]; }
     void Set_Static_Game_Detail(int level) { (*this)["StaticGameLOD"] = g_staticGameLODNames[level]; }
-    AsciiString Get_Preferred_3D_Provider();
-    AsciiString Get_Speaker_Type();
+    Utf8String Get_Preferred_3D_Provider();
+    Utf8String Get_Speaker_Type();
     float Get_Sound_Volume();
     float Get_3DSound_Volume();
     float Get_Speech_Volume();
@@ -65,10 +65,10 @@ public:
     uint16_t Get_Firewall_Port_Override();
     bool Get_Firewall_Need_Refresh();
     uint32_t Get_LAN_IPAddress();
-    void Set_LAN_IPAddress(AsciiString address);
+    void Set_LAN_IPAddress(Utf8String address);
     void Set_LAN_IPAddress(uint32_t address);
     uint32_t Get_Online_IPAddress();
-    void Set_Online_IPAddress(AsciiString address);
+    void Set_Online_IPAddress(Utf8String address);
     void Set_Online_IPAddress(uint32_t address);
 private:
 

--- a/src/game/client/system/particlesystem/particlesysinfo.h
+++ b/src/game/client/system/particlesystem/particlesysinfo.h
@@ -168,7 +168,7 @@ protected:
     bool m_isOneShot;
     ParticleShaderType m_shaderType;
     ParticleType m_particleType;
-    AsciiString m_particleTypeName;
+    Utf8String m_particleTypeName;
 #ifdef THYME_STANDALONE
     GameClientRandomVariable m_angleX;
     GameClientRandomVariable m_angleY;
@@ -196,9 +196,9 @@ protected:
     GameClientRandomVariable m_initialDelay;
     Coord3D m_driftVelocity;
     float m_gravity;
-    AsciiString m_slaveSystemName;
+    Utf8String m_slaveSystemName;
     Coord3D m_slavePosOffset;
-    AsciiString m_attachedSystemName;
+    Utf8String m_attachedSystemName;
     EmissionVelocityType m_emissionVelocityType;
     ParticlePriorityType m_priority;
     EmissionVelocityUnion m_emissionVelocity;

--- a/src/game/client/system/particlesystem/particlesysmanager.cpp
+++ b/src/game/client/system/particlesystem/particlesysmanager.cpp
@@ -122,7 +122,7 @@ void ParticleSystemManager::Xfer_Snapshot(Xfer *xfer)
     xfer->xferInt(reinterpret_cast<int32_t *>(&m_uniqueSystemID));
     uint32_t count = m_particleSystemCount;
     xfer->xferUnsignedInt(&count);
-    AsciiString name;
+    Utf8String name;
 
     if (xfer->Get_Mode() == XFER_SAVE) {
         for (auto it = m_allParticleSystemList.begin(); it != m_allParticleSystemList.end(); ++it) {
@@ -131,7 +131,7 @@ void ParticleSystemManager::Xfer_Snapshot(Xfer *xfer)
                 xfer->xferAsciiString(&name);
                 xfer->xferSnapshot(*it);
             } else {
-                AsciiString empty = "";
+                Utf8String empty = "";
                 xfer->xferAsciiString(&empty);
             }
         }
@@ -155,7 +155,7 @@ void ParticleSystemManager::Xfer_Snapshot(Xfer *xfer)
  *
  * 0x004D1EB0
  */
-ParticleSystemTemplate *ParticleSystemManager::Find_Template(const AsciiString &name)
+ParticleSystemTemplate *ParticleSystemManager::Find_Template(const Utf8String &name)
 {
     auto it = m_templateStore.find(name);
 
@@ -171,7 +171,7 @@ ParticleSystemTemplate *ParticleSystemManager::Find_Template(const AsciiString &
  *
  * 0x004D1EE0
  */
-ParticleSystemTemplate *ParticleSystemManager::New_Template(const AsciiString &name)
+ParticleSystemTemplate *ParticleSystemManager::New_Template(const Utf8String &name)
 {
     ParticleSystemTemplate *retval = Find_Template(name);
 
@@ -193,7 +193,7 @@ ParticleSystemTemplate *ParticleSystemManager::New_Template(const AsciiString &n
  *
  * 0x004D2130
  */
-ParticleSystemTemplate *ParticleSystemManager::Find_Parent_Template(const AsciiString &name, int parent)
+ParticleSystemTemplate *ParticleSystemManager::Find_Parent_Template(const Utf8String &name, int parent)
 {
     if (name.Is_Not_Empty()) {
         for (auto it = m_templateStore.begin(); it != m_templateStore.end(); ++it) {

--- a/src/game/client/system/particlesystem/particlesysmanager.h
+++ b/src/game/client/system/particlesystem/particlesysmanager.h
@@ -34,11 +34,11 @@ class ParticleSystemTemplate;
 class Object;
 
 #ifdef THYME_USE_STLPORT
-    typedef std::hash_map<const AsciiString, ParticleSystemTemplate *, rts::hash<AsciiString>, rts::equal_to<AsciiString>>
+    typedef std::hash_map<const Utf8String, ParticleSystemTemplate *, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
         partsystempmap_t;
 #else
-    typedef std::unordered_map<const AsciiString, ParticleSystemTemplate *, rts::hash<AsciiString>,
-        rts::equal_to<AsciiString>>
+    typedef std::unordered_map<const Utf8String, ParticleSystemTemplate *, rts::hash<Utf8String>,
+        rts::equal_to<Utf8String>>
         partsystempmap_t;
 #endif
 
@@ -62,9 +62,9 @@ public:
     virtual void Xfer_Snapshot(Xfer *xfer) override;
     virtual void Load_Post_Process() override {}
 
-    ParticleSystemTemplate *Find_Template(const AsciiString &name);
-    ParticleSystemTemplate *New_Template(const AsciiString &name);
-    ParticleSystemTemplate *Find_Parent_Template(const AsciiString &name, int parent);
+    ParticleSystemTemplate *Find_Template(const Utf8String &name);
+    ParticleSystemTemplate *New_Template(const Utf8String &name);
+    ParticleSystemTemplate *Find_Parent_Template(const Utf8String &name, int parent);
     ParticleSystem *Create_Particle_System(const ParticleSystemTemplate *temp, bool create_slaves);
     ParticleSystem *Find_Particle_System(ParticleSystemID id) const;
     void Destroy_Particle_System_By_ID(ParticleSystemID id);

--- a/src/game/client/system/particlesystem/particlesystemplate.h
+++ b/src/game/client/system/particlesystem/particlesystemplate.h
@@ -28,18 +28,18 @@ class ParticleSystemTemplate : public MemoryPoolObject, public ParticleSystemInf
     IMPLEMENT_NAMED_POOL(ParticleSystemTemplate, ParticleSystemTemplatePool);
     
 public:
-    ParticleSystemTemplate(const AsciiString &name) : m_name(name), m_slaveTemplate(nullptr) {}
+    ParticleSystemTemplate(const Utf8String &name) : m_name(name), m_slaveTemplate(nullptr) {}
     virtual ~ParticleSystemTemplate() {}
 
     static void Parse_Random_Keyframe(INI *ini, void *formal, void *store, const void *user_data);
     static void Parse_RGB_Color_Keyframe(INI *ini, void *formal, void *store, const void *user_data);
 
-    AsciiString Get_Name() const { return m_name; }
+    Utf8String Get_Name() const { return m_name; }
 
 private:
     ParticleSystem *Create_Slave_System(bool create_slaves) const;
 
 private:
-    AsciiString m_name;
+    Utf8String m_name;
     mutable ParticleSystemTemplate *m_slaveTemplate;
 };

--- a/src/game/client/terrainroads.cpp
+++ b/src/game/client/terrainroads.cpp
@@ -180,7 +180,7 @@ TerrainRoadCollection::~TerrainRoadCollection()
     }
 }
 
-TerrainRoadType *TerrainRoadCollection::New_Road(AsciiString name)
+TerrainRoadType *TerrainRoadCollection::New_Road(Utf8String name)
 {
     TerrainRoadType *retval = new TerrainRoadType;
     TerrainRoadType *def = Find_Road("DefaultRoad");
@@ -204,7 +204,7 @@ TerrainRoadType *TerrainRoadCollection::New_Road(AsciiString name)
     return retval;
 }
 
-TerrainRoadType *TerrainRoadCollection::New_Bridge(AsciiString name)
+TerrainRoadType *TerrainRoadCollection::New_Bridge(Utf8String name)
 {
     TerrainRoadType *retval = new TerrainRoadType;
     TerrainRoadType *def = Find_Road("DefaultBridge");
@@ -255,7 +255,7 @@ TerrainRoadType *TerrainRoadCollection::New_Bridge(AsciiString name)
     return retval;
 }
 
-TerrainRoadType *TerrainRoadCollection::Find_Road(AsciiString name)
+TerrainRoadType *TerrainRoadCollection::Find_Road(Utf8String name)
 {
     TerrainRoadType *retval = m_roadList;
 
@@ -270,7 +270,7 @@ TerrainRoadType *TerrainRoadCollection::Find_Road(AsciiString name)
     return retval;
 }
 
-TerrainRoadType *TerrainRoadCollection::Find_Bridge(AsciiString name)
+TerrainRoadType *TerrainRoadCollection::Find_Bridge(Utf8String name)
 {
     TerrainRoadType *retval = m_bridgeList;
 
@@ -287,7 +287,7 @@ TerrainRoadType *TerrainRoadCollection::Find_Bridge(AsciiString name)
 
 void TerrainRoadCollection::Parse_Terrain_Road_Definitions(INI *ini)
 {
-    AsciiString token = ini->Get_Next_Token();
+    Utf8String token = ini->Get_Next_Token();
 
     ASSERT_THROW_PRINT(g_theTerrainRoads->Find_Road(token) == nullptr,
         0xDEAD0006,
@@ -300,7 +300,7 @@ void TerrainRoadCollection::Parse_Terrain_Road_Definitions(INI *ini)
 
 void TerrainRoadCollection::Parse_Terrain_Bridge_Definitions(INI *ini)
 {
-    AsciiString token = ini->Get_Next_Token();
+    Utf8String token = ini->Get_Next_Token();
 
     ASSERT_THROW_PRINT(g_theTerrainRoads->Find_Bridge(token) == nullptr,
         0xDEAD0006,

--- a/src/game/client/terrainroads.h
+++ b/src/game/client/terrainroads.h
@@ -44,47 +44,47 @@ public:
     virtual ~TerrainRoadType() {}
 
     // TODO more setters and getters as needed.
-    AsciiString Get_Name() { return m_name; }
-    AsciiString Get_Damaged_OCL(int dmg, int effect) { return m_damagedTransitionOCL[dmg][effect]; }
-    AsciiString Get_Damaged_FX(int dmg, int effect) { return m_damagedTransitionFX[dmg][effect]; }
-    AsciiString Get_Repaired_OCL(int dmg, int effect) { return m_repairedTransitionOCL[dmg][effect]; }
-    AsciiString Get_Repaired_FX(int dmg, int effect) { return m_repairedTransitionFX[dmg][effect]; }
+    Utf8String Get_Name() { return m_name; }
+    Utf8String Get_Damaged_OCL(int dmg, int effect) { return m_damagedTransitionOCL[dmg][effect]; }
+    Utf8String Get_Damaged_FX(int dmg, int effect) { return m_damagedTransitionFX[dmg][effect]; }
+    Utf8String Get_Repaired_OCL(int dmg, int effect) { return m_repairedTransitionOCL[dmg][effect]; }
+    Utf8String Get_Repaired_FX(int dmg, int effect) { return m_repairedTransitionFX[dmg][effect]; }
 
-    void Set_Name(AsciiString name) { m_name = name; }
-    void Set_Damaged_OCL(int dmg, int effect, AsciiString name) { m_damagedTransitionOCL[dmg][effect] = name; }
-    void Set_Damaged_FX(int dmg, int effect, AsciiString name) { m_damagedTransitionFX[dmg][effect] = name; }
-    void Set_Repaired_OCL(int dmg, int effect, AsciiString name) { m_repairedTransitionOCL[dmg][effect] = name; }
-    void Set_Repaired_FX(int dmg, int effect, AsciiString name) { m_repairedTransitionFX[dmg][effect] = name; }
+    void Set_Name(Utf8String name) { m_name = name; }
+    void Set_Damaged_OCL(int dmg, int effect, Utf8String name) { m_damagedTransitionOCL[dmg][effect] = name; }
+    void Set_Damaged_FX(int dmg, int effect, Utf8String name) { m_damagedTransitionFX[dmg][effect] = name; }
+    void Set_Repaired_OCL(int dmg, int effect, Utf8String name) { m_repairedTransitionOCL[dmg][effect] = name; }
+    void Set_Repaired_FX(int dmg, int effect, Utf8String name) { m_repairedTransitionFX[dmg][effect] = name; }
 
     static void Parse_Transition_To_OCL(INI *ini, void *formal, void *store, void const *user_data);
     static void Parse_Transition_To_FX(INI *ini, void *formal, void *store, void const *user_data);
 
 private:
-    AsciiString m_name;
+    Utf8String m_name;
     bool m_isBridge;
     int m_id;
     TerrainRoadType *m_next;
     float m_roadWidth;
     float m_roadWidthInTexture;
     float m_bridgeScale;
-    AsciiString m_scaffoldObjectName;
-    AsciiString m_scaffoldSupportObjectName;
+    Utf8String m_scaffoldObjectName;
+    Utf8String m_scaffoldSupportObjectName;
     RGBColor m_radarColor;
-    AsciiString m_bridgeModelName;
-    AsciiString m_texture;
-    AsciiString m_bridgeModelNameDamaged;
-    AsciiString m_textureDamaged;
-    AsciiString m_bridgeModelNameReallyDamaged;
-    AsciiString m_textureReallyDamaged;
-    AsciiString m_bridgeModelNameBroken;
-    AsciiString m_textureBroken;
-    AsciiString m_towerObjectName[BRIDGE_MAX_TOWERS];
-    AsciiString m_damagedToSounds[BODY_COUNT];
-    AsciiString m_damagedTransitionOCL[BODY_COUNT][3];
-    AsciiString m_damagedTransitionFX[BODY_COUNT][3];
-    AsciiString m_repairedToSounds[BODY_COUNT];
-    AsciiString m_repairedTransitionOCL[BODY_COUNT][3];
-    AsciiString m_repairedTransitionFX[BODY_COUNT][3];
+    Utf8String m_bridgeModelName;
+    Utf8String m_texture;
+    Utf8String m_bridgeModelNameDamaged;
+    Utf8String m_textureDamaged;
+    Utf8String m_bridgeModelNameReallyDamaged;
+    Utf8String m_textureReallyDamaged;
+    Utf8String m_bridgeModelNameBroken;
+    Utf8String m_textureBroken;
+    Utf8String m_towerObjectName[BRIDGE_MAX_TOWERS];
+    Utf8String m_damagedToSounds[BODY_COUNT];
+    Utf8String m_damagedTransitionOCL[BODY_COUNT][3];
+    Utf8String m_damagedTransitionFX[BODY_COUNT][3];
+    Utf8String m_repairedToSounds[BODY_COUNT];
+    Utf8String m_repairedTransitionOCL[BODY_COUNT][3];
+    Utf8String m_repairedTransitionFX[BODY_COUNT][3];
     float m_transitionEffectsHeight;
     int m_numFXPerType;
 };
@@ -99,11 +99,11 @@ public:
     virtual void Reset() override {}
     virtual void Update() override {}
 
-    TerrainRoadType *New_Road(AsciiString name);
-    TerrainRoadType *New_Bridge(AsciiString name);
+    TerrainRoadType *New_Road(Utf8String name);
+    TerrainRoadType *New_Bridge(Utf8String name);
 
-    TerrainRoadType *Find_Road(AsciiString name);
-    TerrainRoadType *Find_Bridge(AsciiString name);
+    TerrainRoadType *Find_Road(Utf8String name);
+    TerrainRoadType *Find_Bridge(Utf8String name);
 
     static void Parse_Terrain_Road_Definitions(INI *ini);
     static void Parse_Terrain_Bridge_Definitions(INI *ini);

--- a/src/game/client/videoplayer/videoplayer.cpp
+++ b/src/game/client/videoplayer/videoplayer.cpp
@@ -141,7 +141,7 @@ Video *VideoPlayer::Get_Video(int index)
  *
  * 0x0051B090
  */
-Video *VideoPlayer::Get_Video(AsciiString name)
+Video *VideoPlayer::Get_Video(Utf8String name)
 {
     for (auto it = m_videosAvailableToPlay.begin(); it != m_videosAvailableToPlay.end(); ++it) {
         if (it->internal_name == name) {

--- a/src/game/client/videoplayer/videoplayer.h
+++ b/src/game/client/videoplayer/videoplayer.h
@@ -24,9 +24,9 @@ class VideoStream;
 
 struct Video
 {
-    AsciiString file_name;
-    AsciiString internal_name;
-    AsciiString world_builder_comment;
+    Utf8String file_name;
+    Utf8String internal_name;
+    Utf8String world_builder_comment;
 };
 
 class VideoPlayer : public SubsystemInterface
@@ -42,15 +42,15 @@ public:
     virtual void Deinit() {}
     virtual void Lose_Focus() {}
     virtual void Regain_Focus() {}
-    virtual int Open(AsciiString title) { return 0; }
-    virtual int Load(AsciiString title) { return 0; }
+    virtual int Open(Utf8String title) { return 0; }
+    virtual int Load(Utf8String title) { return 0; }
     virtual VideoStream *First_Stream() { return m_firstStream; }
     virtual void Close_All_Streams();
     virtual void Add_Video(Video *video);
     virtual void Remove_Video(Video *video);
     virtual int Get_Video_Count();
     virtual Video *Get_Video(int index);
-    virtual Video *Get_Video(AsciiString name);
+    virtual Video *Get_Video(Utf8String name);
     virtual FieldParse *Get_Field_Parse() { return s_videoFieldParseTable; }
     virtual void Notify_Player_Of_New_Provider(bool unk) {}
 

--- a/src/game/client/water.cpp
+++ b/src/game/client/water.cpp
@@ -58,7 +58,7 @@ FieldParse WaterTransparencySetting::m_waterTransparencySettingFieldParseTable[]
 
 void WaterSetting::Parse_Water_Setting(INI *ini)
 {
-    AsciiString token = ini->Get_Next_Token();
+    Utf8String token = ini->Get_Next_Token();
     int tod;
 
     for ( tod = 0; tod < TIME_OF_DAY_COUNT; ++tod ) {

--- a/src/game/client/water.h
+++ b/src/game/client/water.h
@@ -33,8 +33,8 @@ public:
     static void Parse_Water_Setting(INI *ini);
 
 private:
-    AsciiString m_skyTextureFile;
-    AsciiString m_waterTextureFile;
+    Utf8String m_skyTextureFile;
+    Utf8String m_waterTextureFile;
     int m_waterRepeatCount;
     float m_skyTexelsPerUnit;
     RGBAColorInt m_vertex00Diffuse;
@@ -69,12 +69,12 @@ private:
     RGBColor m_standingWaterColor;
     RGBColor m_radarWaterColor;
     bool m_additiveBlending;
-    AsciiString m_standingWaterTexture;
-    AsciiString m_skyboxTextureN;
-    AsciiString m_skyboxTextureE;
-    AsciiString m_skyboxTextureS;
-    AsciiString m_skyboxTextureW;
-    AsciiString m_skyboxTextureT;
+    Utf8String m_standingWaterTexture;
+    Utf8String m_skyboxTextureN;
+    Utf8String m_skyboxTextureE;
+    Utf8String m_skyboxTextureS;
+    Utf8String m_skyboxTextureW;
+    Utf8String m_skyboxTextureT;
 
     static FieldParse m_waterTransparencySettingFieldParseTable[];
 };

--- a/src/game/common/audio/audioeventinfo.h
+++ b/src/game/common/audio/audioeventinfo.h
@@ -54,7 +54,7 @@ public:
     virtual DynamicAudioEventInfo *Get_Dynamic_Event_Info() { return nullptr; }
     virtual const DynamicAudioEventInfo *Get_Dynamic_Event_Info() const { return nullptr; }
 
-    const AsciiString &Get_Event_Name() const { return m_eventName; }
+    const Utf8String &Get_Event_Name() const { return m_eventName; }
     AudioType Get_Type() const { return m_type; }
     float Get_Volume() const { return m_volume; }
     int Get_Control() const { return m_control; }
@@ -62,8 +62,8 @@ public:
     static void Parse_Audio_Event(INI *ini);
 
 protected:
-    AsciiString m_eventName;
-    AsciiString m_filename;
+    Utf8String m_eventName;
+    Utf8String m_filename;
     float m_volume;
     float m_volumeShift;
     float m_minVolume;
@@ -76,12 +76,12 @@ protected:
     int m_priority;
     AudioType m_type;
     int m_control;
-    std::vector<AsciiString> m_soundsMorning;
-    std::vector<AsciiString> m_sounds;
-    std::vector<AsciiString> m_soundsEvening;
-    std::vector<AsciiString> m_soundsNight;
-    std::vector<AsciiString> m_attack;
-    std::vector<AsciiString> m_decay;
+    std::vector<Utf8String> m_soundsMorning;
+    std::vector<Utf8String> m_sounds;
+    std::vector<Utf8String> m_soundsEvening;
+    std::vector<Utf8String> m_soundsNight;
+    std::vector<Utf8String> m_attack;
+    std::vector<Utf8String> m_decay;
     float m_lowPassCutoff;
     float m_minRange;
     float m_maxRange;

--- a/src/game/common/audio/audioeventrts.cpp
+++ b/src/game/common/audio/audioeventrts.cpp
@@ -79,7 +79,7 @@ AudioEventRTS::AudioEventRTS(const AudioEventRTS &that) :
 {
 }
 
-AudioEventRTS::AudioEventRTS(const AsciiString &name) :
+AudioEventRTS::AudioEventRTS(const Utf8String &name) :
     m_filename(),
     m_eventInfo(nullptr),
     m_playingHandle(0),
@@ -107,7 +107,7 @@ AudioEventRTS::AudioEventRTS(const AsciiString &name) :
 {
 }
 
-AudioEventRTS::AudioEventRTS(const AsciiString &name, ObjectID id) :
+AudioEventRTS::AudioEventRTS(const Utf8String &name, ObjectID id) :
     m_filename(),
     m_eventInfo(nullptr),
     m_playingHandle(0),
@@ -138,7 +138,7 @@ AudioEventRTS::AudioEventRTS(const AsciiString &name, ObjectID id) :
     }
 }
 
-AudioEventRTS::AudioEventRTS(const AsciiString &name, const Coord3D *pos) :
+AudioEventRTS::AudioEventRTS(const Utf8String &name, const Coord3D *pos) :
     m_filename(),
     m_eventInfo(nullptr),
     m_playingHandle(0),
@@ -210,7 +210,7 @@ void AudioEventRTS::Generate_Play_Info()
 {
 }
 
-void AudioEventRTS::Set_Event_Name(AsciiString name)
+void AudioEventRTS::Set_Event_Name(Utf8String name)
 {
     if (strcmp(name, m_eventName) != 0 && m_eventInfo != nullptr) {
         m_eventInfo = nullptr;

--- a/src/game/common/audio/audioeventrts.h
+++ b/src/game/common/audio/audioeventrts.h
@@ -33,9 +33,9 @@ class AudioEventRTS
 public:
     AudioEventRTS();
     AudioEventRTS(const AudioEventRTS &that);
-    AudioEventRTS(const AsciiString &name);
-    AudioEventRTS(const AsciiString &name, ObjectID id);
-    AudioEventRTS(const AsciiString &name, const Coord3D *pos);
+    AudioEventRTS(const Utf8String &name);
+    AudioEventRTS(const Utf8String &name, ObjectID id);
+    AudioEventRTS(const Utf8String &name, const Coord3D *pos);
     virtual ~AudioEventRTS() {}
 
     AudioEventRTS &operator=(const AudioEventRTS &that);
@@ -43,14 +43,14 @@ public:
     void Generate_Filename();
     void Generate_Play_Info();
 
-    void Set_Event_Name(AsciiString name);
+    void Set_Event_Name(Utf8String name);
     void Set_Playing_Handle(int handle) { m_playingHandle = handle; }
     void Set_Current_Sound_Index(int index) const { m_currentSoundIndex = index; }
     void Set_Volume(float volume) { m_volumeAdjustFactor = volume; }
     void Set_Event_Info(AudioEventInfo *info) const { m_eventInfo = info; }
     void Set_Player_Index(int index) { m_playerIndex = index; }
 
-    const AsciiString &Get_Event_Name() const { return m_filename; }
+    const Utf8String &Get_Event_Name() const { return m_filename; }
     const AudioEventInfo *Get_Event_Info() const { return m_eventInfo; }
     AudioType Get_Event_Type() const { return m_eventType; }
     int Get_Current_Sound_Index() const { return m_currentSoundIndex; }
@@ -59,13 +59,13 @@ public:
     int Get_Playing_Handle() const { return m_playingHandle; }
 
 private:
-    AsciiString m_filename;
+    Utf8String m_filename;
     mutable AudioEventInfo *m_eventInfo;
     int m_playingHandle;
     int m_handleToKill;
-    AsciiString m_eventName;
-    AsciiString m_filenameAttack;
-    AsciiString m_filenameDecay;
+    Utf8String m_eventName;
+    Utf8String m_filenameAttack;
+    Utf8String m_filenameDecay;
     PriorityType m_priority;
     float m_volumeAdjustFactor;
     TimeOfDayType m_timeOfDay;

--- a/src/game/common/audio/audiomanager.cpp
+++ b/src/game/common/audio/audiomanager.cpp
@@ -89,7 +89,7 @@ void AudioManager::Append_Audio_Request(AudioRequest *request)
     m_audioRequestList.push_back(request);
 }
 
-AudioEventInfo *AudioManager::New_Audio_Event_Info(AsciiString name)
+AudioEventInfo *AudioManager::New_Audio_Event_Info(Utf8String name)
 {
     AudioEventInfo *info = Find_Audio_Event_Info(name);
 
@@ -113,7 +113,7 @@ void AudioManager::Add_Audio_Event_Info(AudioEventInfo *info)
     }
 }
 
-AudioEventInfo *AudioManager::Find_Audio_Event_Info(AsciiString name) const
+AudioEventInfo *AudioManager::Find_Audio_Event_Info(Utf8String name) const
 {
     auto it = m_audioInfoHashMap.find(name);
 
@@ -386,7 +386,7 @@ void AudioManager::Remove_Audio_Event(unsigned int event)
     }
 }
 
-void AudioManager::Remove_Audio_Event(AsciiString event)
+void AudioManager::Remove_Audio_Event(Utf8String event)
 {
     Remove_Playing_Audio(event);
 }
@@ -413,14 +413,14 @@ bool AudioManager::Is_Valid_Audio_Event(AudioEventRTS *event) const
     return event->Get_Event_Info() != nullptr;
 }
 
-void AudioManager::Set_Audio_Event_Enabled(AsciiString event, bool vol_override)
+void AudioManager::Set_Audio_Event_Enabled(Utf8String event, bool vol_override)
 {
     Set_Audio_Event_Volume_Override(event, vol_override ? -1.0f : 0.0f);
 }
 
-void AudioManager::Set_Audio_Event_Volume_Override(AsciiString event, float vol_override)
+void AudioManager::Set_Audio_Event_Volume_Override(Utf8String event, float vol_override)
 {
-    if (event == AsciiString::s_emptyString) {
+    if (event == Utf8String::s_emptyString) {
         m_unkList1.clear();
 
         return;
@@ -433,7 +433,7 @@ void AudioManager::Set_Audio_Event_Volume_Override(AsciiString event, float vol_
     }
 
     if (m_unkList1.empty() && vol_override != -1.0f) {
-        m_unkList1.push_back(std::pair<AsciiString, float>(event, vol_override));
+        m_unkList1.push_back(std::pair<Utf8String, float>(event, vol_override));
     } else {
         for (auto it = m_unkList1.begin(); it != m_unkList1.end(); ++it) {
             if (event == it->first && vol_override != -1.0f) {
@@ -459,7 +459,7 @@ void AudioManager::Get_Info_For_Audio_Event(const AudioEventRTS *event) const
     event->Set_Event_Info(Find_Audio_Event_Info(event->Get_Event_Name()));
 }
 
-unsigned int AudioManager::Translate_From_Speaker_Type(const AsciiString &type)
+unsigned int AudioManager::Translate_From_Speaker_Type(const Utf8String &type)
 {
     unsigned int i = 0;
 
@@ -474,7 +474,7 @@ unsigned int AudioManager::Translate_From_Speaker_Type(const AsciiString &type)
     return i;
 }
 
-AsciiString AudioManager::Translate_To_Speaker_Type(unsigned int type)
+Utf8String AudioManager::Translate_To_Speaker_Type(unsigned int type)
 {
     if (type < ARRAY_SIZE(s_speakerTypes)) {
         return s_speakerTypes[type];

--- a/src/game/common/audio/audiomanager.h
+++ b/src/game/common/audio/audiomanager.h
@@ -67,10 +67,10 @@ class MusicManager;
 class SoundManager;
 
 #ifdef THYME_USE_STLPORT
-typedef std::hash_map<const AsciiString, AudioEventInfo *, rts::hash<AsciiString>, rts::equal_to<AsciiString>>
+typedef std::hash_map<const Utf8String, AudioEventInfo *, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
     audioinfomap_t;
 #else
-typedef std::unordered_map<const AsciiString, AudioEventInfo *, rts::hash<AsciiString>, rts::equal_to<AsciiString>>
+typedef std::unordered_map<const Utf8String, AudioEventInfo *, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
     audioinfomap_t;
 #endif
 
@@ -94,17 +94,17 @@ public:
     virtual void Regain_Focus();
     virtual int Add_Audio_Event(const AudioEventRTS *event);
     virtual void Remove_Audio_Event(unsigned int event);
-    virtual void Remove_Audio_Event(AsciiString event);
+    virtual void Remove_Audio_Event(Utf8String event);
     virtual void Kill_Event_Immediately(unsigned int event) = 0;
     virtual bool Is_Valid_Audio_Event(const AudioEventRTS *event) const;
     virtual bool Is_Valid_Audio_Event(AudioEventRTS *event) const;
     virtual void Next_Music_Track() = 0;
     virtual void Prev_Music_Track() = 0;
     virtual bool Is_Music_Playing() = 0;
-    virtual bool Has_Music_Track_Completed(const AsciiString name) = 0;
-    virtual AsciiString Music_Track_Name() = 0;
-    virtual void Set_Audio_Event_Enabled(AsciiString event, bool vol_override);
-    virtual void Set_Audio_Event_Volume_Override(AsciiString event, float vol_override);
+    virtual bool Has_Music_Track_Completed(const Utf8String name) = 0;
+    virtual Utf8String Music_Track_Name() = 0;
+    virtual void Set_Audio_Event_Enabled(Utf8String event, bool vol_override);
+    virtual void Set_Audio_Event_Volume_Override(Utf8String event, float vol_override);
     virtual void Remove_Disabled_Events();
     virtual void Get_Info_For_Audio_Event(const AudioEventRTS *event) const;
     virtual bool Is_Currently_Playing() = 0;
@@ -113,15 +113,15 @@ public:
     virtual void *Get_Device() = 0;
     virtual void Notify_Of_Audio_Completion(unsigned int unk1, unsigned int unk2) = 0;
     virtual int Get_Provider_Count() = 0;
-    virtual AsciiString Get_Provider_Name(unsigned int index) const = 0;
-    virtual unsigned int Get_Provider_Index(AsciiString name) = 0;
+    virtual Utf8String Get_Provider_Name(unsigned int index) const = 0;
+    virtual unsigned int Get_Provider_Index(Utf8String name) = 0;
     virtual void Select_Provider(unsigned int provider) = 0;
     virtual void Unselect_Provider() = 0;
     virtual unsigned int Get_Selected_Provider() = 0;
     virtual void Set_Speaker_Type(unsigned int type) = 0;
     virtual unsigned int Get_Speaker_Type() = 0;
-    virtual unsigned int Translate_From_Speaker_Type(const AsciiString &type);
-    virtual AsciiString Translate_To_Speaker_Type(unsigned int type);
+    virtual unsigned int Translate_From_Speaker_Type(const Utf8String &type);
+    virtual Utf8String Translate_To_Speaker_Type(unsigned int type);
     virtual int Get_Num_2D_Samples() const = 0;
     virtual int Get_Num_3D_Samples() const = 0;
     virtual int Get_Num_Streams() const = 0;
@@ -129,8 +129,8 @@ public:
     virtual bool Is_Playing_Lower_Priority(AudioEventRTS *event) const = 0;
     virtual bool Is_Playing_Already(AudioEventRTS *event) const = 0;
     virtual bool Is_Object_Playing_Void(unsigned int obj) const = 0;
-    virtual void Adjust_Volume_Of_Playing_Audio(AsciiString name, float adjust) = 0;
-    virtual void Remove_Playing_Audio(AsciiString name) = 0;
+    virtual void Adjust_Volume_Of_Playing_Audio(Utf8String name, float adjust) = 0;
+    virtual void Remove_Playing_Audio(Utf8String name) = 0;
     virtual void Remove_All_Disabled_Audio() = 0;
     virtual bool Is_On(AudioAffect affect) const;
     virtual void Set_On(bool on, AudioAffect affect);
@@ -147,19 +147,19 @@ public:
     virtual void Release_Audio_Request(AudioRequest *request);
     virtual void Append_Audio_Request(AudioRequest *request);
     virtual void Process_Request_List() = 0;
-    virtual AudioEventInfo *New_Audio_Event_Info(AsciiString name);
+    virtual AudioEventInfo *New_Audio_Event_Info(Utf8String name);
     virtual void Add_Audio_Event_Info(AudioEventInfo *info);
-    virtual AudioEventInfo *Find_Audio_Event_Info(AsciiString name) const;
+    virtual AudioEventInfo *Find_Audio_Event_Info(Utf8String name) const;
     virtual void Release_Audio_Event_RTS(AudioEventRTS *event);
     virtual void Set_Hardware_Accelerated(bool accelerated);
     virtual bool Get_Hardware_Accelerated();
     virtual void Set_Speaker_Surround(bool surround);
     virtual bool Get_Speaker_Surround();
     virtual void Refresh_Cached_Variables();
-    virtual void Set_Preferred_3D_Provider(AsciiString provider) = 0;
-    virtual void Set_Preferred_Speaker(AsciiString speaker) = 0;
+    virtual void Set_Preferred_3D_Provider(Utf8String provider) = 0;
+    virtual void Set_Preferred_Speaker(Utf8String speaker) = 0;
     virtual float Get_Audio_Length_MS(const AudioEventRTS *event);
-    virtual float Get_File_Length_MS(AsciiString file_name) = 0;
+    virtual float Get_File_Length_MS(Utf8String file_name) = 0;
     virtual void Close_Any_Sample_Using_File(const void *handle) = 0;
     virtual bool Is_Music_Already_Loaded();
     virtual bool Is_Music_Playing_From_CD();
@@ -187,10 +187,10 @@ protected:
     Coord3D m_listenerPosition;
     Coord3D m_listenerFacing;
     std::list<AudioRequest *> m_audioRequestList;
-    std::vector<AsciiString> m_trackList;
+    std::vector<Utf8String> m_trackList;
     audioinfomap_t m_audioInfoHashMap;
     int m_audioHandleCounter;
-    std::list<std::pair<AsciiString, float>> m_unkList1; // TODO workout what list this actually is, some kind of volume list
+    std::list<std::pair<Utf8String, float>> m_unkList1; // TODO workout what list this actually is, some kind of volume list
     float m_musicVolume;
     float m_soundVolume;
     float m_3dSoundVolume;

--- a/src/game/common/audio/audiosettings.h
+++ b/src/game/common/audio/audiosettings.h
@@ -34,7 +34,7 @@ public:
     AudioSettings() {}
     ~AudioSettings() {}
 
-    AsciiString Get_Preferred_Driver(int index) const { return m_preferredDrivers[index]; }
+    Utf8String Get_Preferred_Driver(int index) const { return m_preferredDrivers[index]; }
     SpeakerType Get_Default_2D_Speaker() const { return m_default2DSpeakerType; }
     float Get_Default_Sound_Volume() const { return m_defaultSoundVolume; }
     float Get_Default_3D_Sound_Volume() const { return m_default3DSoundVolume; }
@@ -48,11 +48,11 @@ public:
     static void Parse_Audio_Settings(INI *ini);
 
 private:
-    AsciiString m_audioRoot;
-    AsciiString m_soundsFolder;
-    AsciiString m_musicFolder;
-    AsciiString m_streamingFolder;
-    AsciiString m_soundExtension;
+    Utf8String m_audioRoot;
+    Utf8String m_soundsFolder;
+    Utf8String m_musicFolder;
+    Utf8String m_streamingFolder;
+    Utf8String m_soundExtension;
     bool m_useDigital;
     bool m_useMidi;
     int m_outputRate;
@@ -67,7 +67,7 @@ private:
     int m_timeToFadeAudio;
     int m_audioFootprintInBytes;
     float m_minSampleVolume;
-    AsciiString m_preferredDrivers[5];
+    Utf8String m_preferredDrivers[5];
     float m_relative2DVolume;
     float m_defaultSoundVolume;
     float m_default3DSoundVolume;

--- a/src/game/common/audio/soundmanager.h
+++ b/src/game/common/audio/soundmanager.h
@@ -47,7 +47,7 @@ public:
     virtual void Notify_Of_3D_Sample_Completion() { if (m_3dSamplesPlaying != 0) { --m_3dSamplesPlaying; } }
     virtual int Get_Available_Samples() { return m_2dSampleSlotCount - m_2dSamplesPlaying; }
     virtual int Get_Available_3D_Samples() { return m_3dSampleSlotCount - m_3dSamplesPlaying; }
-    virtual AsciiString Get_Filename_For_Play_From_Audio_Event() { return AsciiString(); }
+    virtual Utf8String Get_Filename_For_Play_From_Audio_Event() { return Utf8String(); }
     virtual bool Can_Play_Now(AudioEventRTS *event);
     virtual bool Violates_Voice(AudioEventRTS *event);
     virtual bool Is_Interrupting(AudioEventRTS *event);

--- a/src/game/common/bitflags.h
+++ b/src/game/common/bitflags.h
@@ -83,7 +83,7 @@ public:
     void Set(unsigned bit) { m_bits.set(bit); }
     bool Get(unsigned bit) const { return m_bits.test(bit); }
 
-    void Parse(INI *ini, AsciiString *string = nullptr);
+    void Parse(INI *ini, Utf8String *string = nullptr);
     static void Parse_INI(INI *ini, void *formal, void *store, const void *user_data);
 
     static const char *s_bitNamesList[bits + 1];
@@ -96,7 +96,7 @@ private:
 //const char *BitFlags<bits>::s_bitNamesList[bits + 1];
 
 template<int bits>
-void BitFlags<bits>::Parse(INI *ini, AsciiString *string)
+void BitFlags<bits>::Parse(INI *ini, Utf8String *string)
 {
     if (string != nullptr) {
         string->Clear();
@@ -108,7 +108,7 @@ void BitFlags<bits>::Parse(INI *ini, AsciiString *string)
 
     if (token != nullptr) {
         while (strcasecmp(token, "NONE") != 0) {
-            // If we have a passed in AsciiString, add the tokens to it as we parse them.
+            // If we have a passed in Utf8String, add the tokens to it as we parse them.
             if (string != nullptr) {
                 if (string->Is_Not_Empty()) {
                     *string += " ";

--- a/src/game/common/commandline.cpp
+++ b/src/game/common/commandline.cpp
@@ -144,7 +144,7 @@ int Parse_Play_Stats(char **argv, int argc)
 int Parse_Mod(char **argv, int argc)
 {
     if (g_theWriteableGlobalData != nullptr && argc > 1) {
-        AsciiString path = argv[1];
+        Utf8String path = argv[1];
 
         // If its not an absolute path, make it relative to user data dir.
         if (!strchr(path.Str(), ':') && !path.Starts_With("/") && !path.Starts_With("\\")) {

--- a/src/game/common/dict.cpp
+++ b/src/game/common/dict.cpp
@@ -191,7 +191,7 @@ float Dict::Get_Real(NameKeyType key, bool *exists) const
     return 0.0f;
 }
 
-AsciiString Dict::Get_AsciiString(NameKeyType key, bool *exists) const
+Utf8String Dict::Get_AsciiString(NameKeyType key, bool *exists) const
 {
     DictPair *pair = Find_Pair_By_Key(key);
 
@@ -209,7 +209,7 @@ AsciiString Dict::Get_AsciiString(NameKeyType key, bool *exists) const
         DEBUG_ASSERT_PRINT(false, "Dict key missing or of wrong type.\n");
     }
 
-    return AsciiString();
+    return Utf8String();
 }
 
 Utf16String Dict::Get_UnicodeString(NameKeyType key, bool *exists) const
@@ -272,7 +272,7 @@ float Dict::Get_Nth_Real(int n) const
     return 0.0f;
 }
 
-AsciiString Dict::Get_Nth_AsciiString(int n) const
+Utf8String Dict::Get_Nth_AsciiString(int n) const
 {
     DEBUG_ASSERT_PRINT(n > 0 && m_data != nullptr && n < m_data->m_numPairsUsed, "n out of range.\n");
 
@@ -282,7 +282,7 @@ AsciiString Dict::Get_Nth_AsciiString(int n) const
 
     DEBUG_ASSERT_PRINT(false, "Dict key missing or of wrong type.\n");
 
-    return AsciiString();
+    return Utf8String();
 }
 
 Utf16String Dict::Get_Nth_UnicodeString(int n) const
@@ -319,7 +319,7 @@ void Dict::Set_Real(NameKeyType key, float value)
     Sort_Pairs();
 }
 
-void Dict::Set_AsciiString(NameKeyType key, const AsciiString &value)
+void Dict::Set_AsciiString(NameKeyType key, const Utf8String &value)
 {
     DictPair *pair = Set_Prep(key, DICT_ASCIISTRING);
     pair->Set_Value(value);

--- a/src/game/common/dict.cpp
+++ b/src/game/common/dict.cpp
@@ -212,7 +212,7 @@ AsciiString Dict::Get_AsciiString(NameKeyType key, bool *exists) const
     return AsciiString();
 }
 
-UnicodeString Dict::Get_UnicodeString(NameKeyType key, bool *exists) const
+Utf16String Dict::Get_UnicodeString(NameKeyType key, bool *exists) const
 {
     DictPair *pair = Find_Pair_By_Key(key);
 
@@ -230,7 +230,7 @@ UnicodeString Dict::Get_UnicodeString(NameKeyType key, bool *exists) const
         DEBUG_ASSERT_PRINT(false, "Dict key missing or of wrong type.\n");
     }
 
-    return UnicodeString();
+    return Utf16String();
 }
 
 bool Dict::Get_Nth_Bool(int n) const
@@ -285,7 +285,7 @@ AsciiString Dict::Get_Nth_AsciiString(int n) const
     return AsciiString();
 }
 
-UnicodeString Dict::Get_Nth_UnicodeString(int n) const
+Utf16String Dict::Get_Nth_UnicodeString(int n) const
 {
     DEBUG_ASSERT_PRINT(n > 0 && m_data != nullptr && n < m_data->m_numPairsUsed, "n out of range.\n");
 
@@ -295,7 +295,7 @@ UnicodeString Dict::Get_Nth_UnicodeString(int n) const
 
     DEBUG_ASSERT_PRINT(false, "Dict key missing or of wrong type.\n");
 
-    return UnicodeString();
+    return Utf16String();
 }
 
 void Dict::Set_Bool(NameKeyType key, bool value)
@@ -326,7 +326,7 @@ void Dict::Set_AsciiString(NameKeyType key, const AsciiString &value)
     Sort_Pairs();
 }
 
-void Dict::Set_UnicodeString(NameKeyType key, const UnicodeString &value)
+void Dict::Set_UnicodeString(NameKeyType key, const Utf16String &value)
 {
     DictPair *pair = Set_Prep(key, DICT_UNICODESTRING);
     pair->Set_Value(value);

--- a/src/game/common/dict.h
+++ b/src/game/common/dict.h
@@ -53,7 +53,7 @@ private:
         bool boolean;
         float real;
         int integer;
-        AsciiString ascii;
+        Utf8String ascii;
         Utf16String unicode;
     };
 
@@ -72,7 +72,7 @@ private:
         void Set_Value(int val) { m_value.integer = val; }
         void Set_Value(float val) { m_value.real = val; }
         void Set_Value(bool val) { m_value.boolean = val; }
-        void Set_Value(const AsciiString &val) { m_value.ascii = val; }
+        void Set_Value(const Utf8String &val) { m_value.ascii = val; }
         void Set_Value(const Utf16String &val) { m_value.unicode = val; }
 
         const DictPairValue &Get_Value() { return m_value; }
@@ -114,17 +114,17 @@ public:
     bool Get_Bool(NameKeyType key, bool *exists = nullptr) const;
     int Get_Int(NameKeyType key, bool *exists = nullptr) const;
     float Get_Real(NameKeyType key, bool *exists = nullptr) const;
-    AsciiString Get_AsciiString(NameKeyType key, bool *exists = nullptr) const;
+    Utf8String Get_AsciiString(NameKeyType key, bool *exists = nullptr) const;
     Utf16String Get_UnicodeString(NameKeyType key, bool *exists = nullptr) const;
     bool Get_Nth_Bool(int n) const;
     int Get_Nth_Int(int n) const;
     float Get_Nth_Real(int n) const;
-    AsciiString Get_Nth_AsciiString(int n) const;
+    Utf8String Get_Nth_AsciiString(int n) const;
     Utf16String Get_Nth_UnicodeString(int n) const;
     void Set_Bool(NameKeyType key, bool value);
     void Set_Int(NameKeyType key, int value);
     void Set_Real(NameKeyType key, float value);
-    void Set_AsciiString(NameKeyType key, const AsciiString &value);
+    void Set_AsciiString(NameKeyType key, const Utf8String &value);
     void Set_UnicodeString(NameKeyType key, const Utf16String &value);
     bool Remove(NameKeyType key);
     void Copy_Pair_From(Dict &that, NameKeyType key);

--- a/src/game/common/dict.h
+++ b/src/game/common/dict.h
@@ -54,7 +54,7 @@ private:
         float real;
         int integer;
         AsciiString ascii;
-        UnicodeString unicode;
+        Utf16String unicode;
     };
 
     class DictPair
@@ -73,7 +73,7 @@ private:
         void Set_Value(float val) { m_value.real = val; }
         void Set_Value(bool val) { m_value.boolean = val; }
         void Set_Value(const AsciiString &val) { m_value.ascii = val; }
-        void Set_Value(const UnicodeString &val) { m_value.unicode = val; }
+        void Set_Value(const Utf16String &val) { m_value.unicode = val; }
 
         const DictPairValue &Get_Value() { return m_value; }
 
@@ -115,17 +115,17 @@ public:
     int Get_Int(NameKeyType key, bool *exists = nullptr) const;
     float Get_Real(NameKeyType key, bool *exists = nullptr) const;
     AsciiString Get_AsciiString(NameKeyType key, bool *exists = nullptr) const;
-    UnicodeString Get_UnicodeString(NameKeyType key, bool *exists = nullptr) const;
+    Utf16String Get_UnicodeString(NameKeyType key, bool *exists = nullptr) const;
     bool Get_Nth_Bool(int n) const;
     int Get_Nth_Int(int n) const;
     float Get_Nth_Real(int n) const;
     AsciiString Get_Nth_AsciiString(int n) const;
-    UnicodeString Get_Nth_UnicodeString(int n) const;
+    Utf16String Get_Nth_UnicodeString(int n) const;
     void Set_Bool(NameKeyType key, bool value);
     void Set_Int(NameKeyType key, int value);
     void Set_Real(NameKeyType key, float value);
     void Set_AsciiString(NameKeyType key, const AsciiString &value);
-    void Set_UnicodeString(NameKeyType key, const UnicodeString &value);
+    void Set_UnicodeString(NameKeyType key, const Utf16String &value);
     bool Remove(NameKeyType key);
     void Copy_Pair_From(Dict &that, NameKeyType key);
     void Release_Data();

--- a/src/game/common/gamelod.cpp
+++ b/src/game/common/gamelod.cpp
@@ -268,7 +268,7 @@ void GameLODManager::Refresh_Custom_Static_LOD()
     m_staticLOD[STATLOD_CUSTOM].use_trees = g_theWriteableGlobalData->m_useTrees;
 }
 
-int GameLODManager::Get_Static_LOD_Index(AsciiString name)
+int GameLODManager::Get_Static_LOD_Index(Utf8String name)
 {
     int index = STATLOD_LOW;
 
@@ -351,7 +351,7 @@ void GameLODManager::Apply_Static_LOD_Level(StaticGameLODLevel level)
 #endif
 }
 
-int GameLODManager::Get_Dynamic_LOD_Index(AsciiString name)
+int GameLODManager::Get_Dynamic_LOD_Index(Utf8String name)
 {
     int index = DYNLOD_LOW;
 
@@ -450,7 +450,7 @@ void GameLODManager::Parse_Static_LOD_Definitions(INI *ini)
         { nullptr, nullptr, nullptr, 0 }
     };
 
-    AsciiString token = ini->Get_Next_Token();
+    Utf8String token = ini->Get_Next_Token();
 
     if (g_theGameLODManager != nullptr) {
         int level = g_theGameLODManager->Get_Static_LOD_Index(token);
@@ -493,7 +493,7 @@ void GameLODManager::Parse_Dynamic_LOD_Definitions(INI *ini)
         { nullptr, nullptr, nullptr, 0 }
     };
 
-    AsciiString token = ini->Get_Next_Token();
+    Utf8String token = ini->Get_Next_Token();
 
     if (g_theGameLODManager != nullptr) {
         int level = g_theGameLODManager->Get_Dynamic_LOD_Index(token);
@@ -506,7 +506,7 @@ void GameLODManager::Parse_Dynamic_LOD_Definitions(INI *ini)
 
 void GameLODManager::Parse_LOD_Preset(INI *ini)
 {
-    AsciiString token = ini->Get_Next_Token();
+    Utf8String token = ini->Get_Next_Token();
 
     if (g_theGameLODManager != nullptr) {
         int level = g_theGameLODManager->Get_Static_LOD_Index(token);

--- a/src/game/common/gamelod.h
+++ b/src/game/common/gamelod.h
@@ -133,13 +133,13 @@ public:
 
     void Init();
     void Refresh_Custom_Static_LOD();
-    int Get_Static_LOD_Index(AsciiString name);
+    int Get_Static_LOD_Index(Utf8String name);
     const char *Get_Static_LOD_Name(StaticGameLODLevel level);
     StaticGameLODLevel Find_Static_LOD_Level();
     bool Set_Static_LOD_Level(StaticGameLODLevel level);
     void Apply_Static_LOD_Level(StaticGameLODLevel level);
     StaticGameLODLevel Get_Static_LOD_Level() { return m_staticLODLevel; }
-    int Get_Dynamic_LOD_Index(AsciiString name);
+    int Get_Dynamic_LOD_Index(Utf8String name);
     const char *Get_Dynamic_LOD_Name(DynamicGameLODLevel level);
     DynamicGameLODLevel Find_Dynamic_LOD_Level(float fps);
     bool Set_Dynamic_LOD_Level(DynamicGameLODLevel level);

--- a/src/game/common/gamemessage.cpp
+++ b/src/game/common/gamemessage.cpp
@@ -102,7 +102,7 @@ ArgumentDataType GameMessage::Get_Argument_Type(int arg)
     return argobj->m_type;
 }
 
-AsciiString GameMessage::Get_Command_As_Ascii(MessageType command)
+Utf8String GameMessage::Get_Command_As_Ascii(MessageType command)
 {
     switch (command) {
         case MSG_INVALID:

--- a/src/game/common/gamemessage.h
+++ b/src/game/common/gamemessage.h
@@ -351,7 +351,7 @@ public:
     GameMessageArgument *Allocate_Arg();
     ArgumentType *Get_Argument(int arg);
     ArgumentDataType Get_Argument_Type(int arg);
-    AsciiString Get_Command_As_Ascii(MessageType command);
+    Utf8String Get_Command_As_Ascii(MessageType command);
 
     void Append_Int_Arg(int arg);
     void Append_Real_Arg(float arg);

--- a/src/game/common/globaldata.h
+++ b/src/game/common/globaldata.h
@@ -74,8 +74,8 @@ public:
     // pad indicates where padding will be added to keep 4 byte alignment
     // useful if we want to cram any extra variables in without breaking ABI
 public:
-    AsciiString m_mapName;
-    AsciiString m_moveHintName;
+    Utf8String m_mapName;
+    Utf8String m_moveHintName;
     bool m_useTrees;
     bool m_useTreeSway;
     bool m_extraAnimationsDisabled;
@@ -128,7 +128,7 @@ public:
     bool m_unkBool7;
     // char pad[1]
     float m_featherWater;
-    AsciiString m_vertexWaterAvailableMaps[4];
+    Utf8String m_vertexWaterAvailableMaps[4];
     float m_vertexWaterHeightClampLow[4];
     float m_vertexWaterHeightClampLHigh[4];
     float m_vertexWaterAngle[4];
@@ -176,10 +176,10 @@ public:
     int32_t m_maxTankTrackEdges;
     int32_t m_maxTankTrackOpaqueEdges;
     int32_t m_maxTankTrackFadeDelay;
-    AsciiString m_levelGainAnimName;
+    Utf8String m_levelGainAnimName;
     float m_levelGainAnimTime;
     float m_levelGainAnimZRise;
-    AsciiString m_getHealedAnimName;
+    Utf8String m_getHealedAnimName;
     float m_getHealedAnimTime;
     float m_getHealedAnimZRise;
     TimeOfDayType m_timeOfDay;
@@ -241,26 +241,26 @@ public:
     // char pad[2]
     int32_t m_fixedSeed;
     float m_particleScale;
-    AsciiString m_autoFireParticleSmallPrefix;
-    AsciiString m_autoFireParticleSmallSystem;
+    Utf8String m_autoFireParticleSmallPrefix;
+    Utf8String m_autoFireParticleSmallSystem;
     int32_t m_autoFireParticleSmallMax;
-    AsciiString m_autoFireParticleMediumPrefix;
-    AsciiString m_autoFireParticleMediumSystem;
+    Utf8String m_autoFireParticleMediumPrefix;
+    Utf8String m_autoFireParticleMediumSystem;
     int32_t m_autoFireParticleMediumMax;
-    AsciiString m_autoFireParticleLargePrefix;
-    AsciiString m_autoFireParticleLargeSystem;
+    Utf8String m_autoFireParticleLargePrefix;
+    Utf8String m_autoFireParticleLargeSystem;
     int32_t m_autoFireParticleLargeMax;
-    AsciiString m_autoSmokeParticleSmallPrefix;
-    AsciiString m_autoSmokeParticleSmallSystem;
+    Utf8String m_autoSmokeParticleSmallPrefix;
+    Utf8String m_autoSmokeParticleSmallSystem;
     int32_t m_autoSmokeParticleSmallMax;
-    AsciiString m_autoSmokeParticleMediumPrefix;
-    AsciiString m_autoSmokeParticleMediumSystem;
+    Utf8String m_autoSmokeParticleMediumPrefix;
+    Utf8String m_autoSmokeParticleMediumSystem;
     int32_t m_autoSmokeParticleMediumMax;
-    AsciiString m_autoSmokeParticleLargePrefix;
-    AsciiString m_autoSmokeParticleLargeSystem;
+    Utf8String m_autoSmokeParticleLargePrefix;
+    Utf8String m_autoSmokeParticleLargeSystem;
     int32_t m_autoSmokeParticleLargeMax;
-    AsciiString m_autoAFlameParticlePrefix;
-    AsciiString m_autoAFlameParticleSystem;
+    Utf8String m_autoAFlameParticlePrefix;
+    Utf8String m_autoAFlameParticleSystem;
     int32_t m_autoAFlameParticleMax;
     int32_t m_netMinPlayers; // not 100% sure, needs confirming
     int32_t m_lanIPAddress;
@@ -291,8 +291,8 @@ public:
     bool m_enforceMaxCameraHeight;
     bool m_buildMapCache; // not 100% sure, needs confirming
     // char pad[2]
-    AsciiString m_initialFile; // not 100% sure, needs confirming
-    AsciiString m_pendingFile; // not 100% sure, needs confirming
+    Utf8String m_initialFile; // not 100% sure, needs confirming
+    Utf8String m_pendingFile; // not 100% sure, needs confirming
     int32_t m_maxParticleCount;
     int32_t m_maxFieldParticleCount;
     WeaponBonusSet *m_weaponBonusSetPtr;
@@ -301,7 +301,7 @@ public:
     float m_eliteHealthBonus;
     float m_heroicHealthBonus;
     float m_defaultStructureRubbleHeight;
-    AsciiString m_shellMapName;
+    Utf8String m_shellMapName;
     bool m_shellMapOn;
     bool m_playIntro;
     bool m_playSizzle;
@@ -349,8 +349,8 @@ public:
     float m_baseRegenHealthPercentPerSecond;
     uint32_t m_baseRegenDelay;
     int32_t m_hotKeytextColor;
-    AsciiString m_specialPowerViewObject;
-    std::vector<AsciiString> m_standardPublicBones;
+    Utf8String m_specialPowerViewObject;
+    std::vector<Utf8String> m_standardPublicBones;
     float m_standardMinefieldDensity;
     float m_standardMinefieldDistance;
     bool m_showMetrics;
@@ -389,9 +389,9 @@ public:
     bool m_unkBool25;
     bool m_unkBool26;
     // char pad[1]
-    AsciiString m_userModDirectory;
-    AsciiString m_userModFile;
-    AsciiString m_userDataDirectory;
+    Utf8String m_userModDirectory;
+    Utf8String m_userModFile;
+    Utf8String m_userDataDirectory;
     GlobalData *m_next;
 
 private:

--- a/src/game/common/ini/ini.cpp
+++ b/src/game/common/ini/ini.cpp
@@ -762,7 +762,7 @@ void INI::Parse_Bit_In_Int32(INI *ini, void *formal, void *store, const void *us
 
 void INI::Parse_And_Translate_Label(INI *ini, void *formal, void *store, const void *user_data)
 {
-    UnicodeString *str = static_cast<UnicodeString*>(store);
+    Utf16String *str = static_cast<Utf16String*>(store);
     *str = g_theGameText->Fetch(ini->Get_Next_Token());
 }
 

--- a/src/game/common/ini/ini.cpp
+++ b/src/game/common/ini/ini.cpp
@@ -186,7 +186,7 @@ INI::~INI()
 {
 }
 
-void INI::Load(AsciiString filename, INILoadType type, Xfer *xfer)
+void INI::Load(Utf8String filename, INILoadType type, Xfer *xfer)
 {
     Set_FP_Mode(); // Ensure floating point mode is a consistent mode for loading.
     g_sXfer = xfer;
@@ -195,9 +195,9 @@ void INI::Load(AsciiString filename, INILoadType type, Xfer *xfer)
     while ( !m_endOfFile ) {
         Read_Line();
         
-        // Original seems to make an unused AsciiString from the
+        // Original seems to make an unused Utf8String from the
         // parsed block, possible leftover from debug code?
-        //AsciiString block(m_currentBlock);
+        //Utf8String block(m_currentBlock);
 
         char *token = strtok(m_currentBlock, m_seps);
         
@@ -220,11 +220,11 @@ void INI::Load(AsciiString filename, INILoadType type, Xfer *xfer)
     Unprep_File();
 }
 
-void INI::Load_Directory(AsciiString dir, bool search_subdirs, INILoadType type, Xfer *xfer)
+void INI::Load_Directory(Utf8String dir, bool search_subdirs, INILoadType type, Xfer *xfer)
 {
     ASSERT_THROW(!dir.Is_Empty(), 0xDEAD0006);
 
-    std::set<AsciiString, rts::less_than_nocase<AsciiString> > files;
+    std::set<Utf8String, rts::less_than_nocase<Utf8String> > files;
     dir += '/';
 
     g_theFileSystem->Get_File_List_From_Dir(dir, "*.ini", files, true);
@@ -232,7 +232,7 @@ void INI::Load_Directory(AsciiString dir, bool search_subdirs, INILoadType type,
     // Load everything from the top level directory first.
     for ( auto it = files.begin(); it != files.end(); ++it ) {
         // Create path string with initial dir stripped off.
-        AsciiString path_check = &it->Str()[strlen(dir.Str())];
+        Utf8String path_check = &it->Str()[strlen(dir.Str())];
         
         if ( strchr(path_check.Str(), '\\') == nullptr && strchr(path_check.Str(), '/') == nullptr ) {
             Load(*it, type, xfer);
@@ -242,7 +242,7 @@ void INI::Load_Directory(AsciiString dir, bool search_subdirs, INILoadType type,
     // Now process everything from sub directories.
     for ( auto it = files.begin(); it != files.end(); ++it ) {
         // Create path string with initial dir stripped off.
-        AsciiString path_check = &it->Str()[dir.Get_Length()];
+        Utf8String path_check = &it->Str()[dir.Get_Length()];
         
         if ( strchr(path_check.Str(), '\\') != nullptr || strchr(path_check.Str(), '/') != nullptr ) {
             Load(*it, type, xfer);
@@ -250,7 +250,7 @@ void INI::Load_Directory(AsciiString dir, bool search_subdirs, INILoadType type,
     }
 }
 
-void INI::Prep_File(AsciiString filename, INILoadType type)
+void INI::Prep_File(Utf8String filename, INILoadType type)
 {
     ASSERT_THROW_PRINT(
         m_backingFile == nullptr,
@@ -407,10 +407,10 @@ void INI::Read_Line()
     }
 }
 
-AsciiString INI::Get_Next_Quoted_Ascii_String()
+Utf8String INI::Get_Next_Quoted_Ascii_String()
 {
     const char *token = Get_Next_Token_Or_Null();
-    AsciiString next;
+    Utf8String next;
     char buffer[MAX_LINE_LENGTH];
 
     buffer[0] = '\0';
@@ -609,21 +609,21 @@ void INI::Parse_Angular_Velocity_Real(INI *ini, void *formal, void *store, const
 
 void INI::Parse_AsciiString(INI *ini, void *formal, void *store, const void *user_data)
 {
-    *static_cast<AsciiString*>(store) = ini->Get_Next_Ascii_String();
+    *static_cast<Utf8String*>(store) = ini->Get_Next_Ascii_String();
 }
 
 void INI::Parse_Quoted_AsciiString(INI *ini, void *formal, void *store, const void *user_data)
 {
-    *static_cast<AsciiString*>(store) = ini->Get_Next_Quoted_Ascii_String();
+    *static_cast<Utf8String*>(store) = ini->Get_Next_Quoted_Ascii_String();
 }
 
 void INI::Parse_AsciiString_Vector_Append(INI *ini, void *formal, void *store, const void *user_data)
 {
     //DEBUG_LOG("Appending Vector for ini %s.\n", ini->m_fileName.Str());
-    std::vector<AsciiString> *vec = static_cast<std::vector<AsciiString> *>(store);
+    std::vector<Utf8String> *vec = static_cast<std::vector<Utf8String> *>(store);
 
     for ( const char *i = ini->Get_Next_Token_Or_Null(); i != nullptr; i = ini->Get_Next_Token_Or_Null() ) {
-        vec->push_back(AsciiString(i));
+        vec->push_back(Utf8String(i));
     }
 }
 
@@ -914,7 +914,7 @@ void INI::Parse_Bitstring64(INI *ini, void *formal, void *store, const void *use
 
 void INI::Parse_Speaker_Type(INI *ini, void *formal, void *store, const void *user_data)
 {
-    AsciiString speaker;
+    Utf8String speaker;
     Parse_AsciiString(ini, formal, &speaker, user_data);
     *static_cast<SpeakerType*>(store) = static_cast<SpeakerType>(g_theAudio->Translate_From_Speaker_Type(speaker));
 }

--- a/src/game/common/ini/ini.h
+++ b/src/game/common/ini/ini.h
@@ -92,8 +92,8 @@ public:
     INI();
     ~INI();
 
-    void Load(AsciiString filename, INILoadType type, Xfer *xfer);
-    void Load_Directory(AsciiString dir, bool search_subdirs, INILoadType type, Xfer *xfer);
+    void Load(Utf8String filename, INILoadType type, Xfer *xfer);
+    void Load_Directory(Utf8String dir, bool search_subdirs, INILoadType type, Xfer *xfer);
 
     void Init_From_INI(void *what, FieldParse *parse_table);
     void Init_From_INI_Multi(void *what, const MultiIniFieldParse &parse_table_list);
@@ -102,9 +102,9 @@ public:
     const char *Get_Next_Token_Or_Null(const char *seps = nullptr);
     const char *Get_Next_Token(const char *seps = nullptr);
     const char *Get_Next_Sub_Token(const char *expected);
-    AsciiString Get_Next_Ascii_String();
-    AsciiString Get_Next_Quoted_Ascii_String();
-    AsciiString Get_Filename() { return m_fileName; }
+    Utf8String Get_Next_Ascii_String();
+    Utf8String Get_Next_Quoted_Ascii_String();
+    Utf8String Get_Filename() { return m_fileName; }
     INILoadType Get_Load_Type() { return m_loadType; }
     int Get_Line_Number() { return m_lineNumber; }
 
@@ -160,14 +160,14 @@ public:
 
 private:
     void Read_Line();
-    void Prep_File(AsciiString filename, INILoadType type);
+    void Prep_File(Utf8String filename, INILoadType type);
     void Unprep_File();
 
     File *m_backingFile;
     char m_buffer[MAX_BUFFER_SIZE];
     int m_bufferReadPos;
     int m_bufferData;
-    AsciiString m_fileName;
+    Utf8String m_fileName;
     INILoadType m_loadType;
     int m_lineNumber;
     char m_currentBlock[MAX_LINE_LENGTH];
@@ -246,10 +246,10 @@ inline const char *INI::Get_Next_Sub_Token(const char *expected)
     return Get_Next_Token(m_sepsColon);
 }
 
-inline AsciiString INI::Get_Next_Ascii_String()
+inline Utf8String INI::Get_Next_Ascii_String()
 {
     static char _buffer[MAX_LINE_LENGTH];
-    AsciiString next;
+    Utf8String next;
 
     const char *token = Get_Next_Token_Or_Null();
 

--- a/src/game/common/modules/modulefactory.cpp
+++ b/src/game/common/modules/modulefactory.cpp
@@ -72,7 +72,7 @@ void ModuleFactory::Xfer_Snapshot(Xfer *xfer)
 /**
  * @brief Internal method for locating a template from a module name and type.
  */
-const ModuleFactory::ModuleTemplate *ModuleFactory::Find_Module_Template(const AsciiString &name, ModuleType type) const
+const ModuleFactory::ModuleTemplate *ModuleFactory::Find_Module_Template(const Utf8String &name, ModuleType type) const
 {
     auto it = m_moduleTemplateMap.find(Make_Decorated_Name_Key(name, type));
 
@@ -88,7 +88,7 @@ const ModuleFactory::ModuleTemplate *ModuleFactory::Find_Module_Template(const A
  *
  * 0x004F2B80
  */
-int ModuleFactory::Find_Interface_Mask(const AsciiString &name, ModuleType type)
+int ModuleFactory::Find_Interface_Mask(const Utf8String &name, ModuleType type)
 {
     if (name.Is_Not_Empty()) {
         const ModuleTemplate *temp = Find_Module_Template(name, type);
@@ -106,7 +106,7 @@ int ModuleFactory::Find_Interface_Mask(const AsciiString &name, ModuleType type)
  *
  * 0x004F2DD0
  */
-Module *ModuleFactory::New_Module(Thing *thing, const AsciiString &name, ModuleData *data, ModuleType type)
+Module *ModuleFactory::New_Module(Thing *thing, const Utf8String &name, ModuleData *data, ModuleType type)
 {
     if (name.Is_Not_Empty()) {
         const ModuleTemplate *temp = Find_Module_Template(name, type);
@@ -125,7 +125,7 @@ Module *ModuleFactory::New_Module(Thing *thing, const AsciiString &name, ModuleD
  * 0x004F2C20
  */
 ModuleData *ModuleFactory::New_Module_Data_From_INI(
-    INI *ini, const AsciiString &name, ModuleType type, const AsciiString &tag)
+    INI *ini, const Utf8String &name, ModuleType type, const Utf8String &tag)
 {
     if (name.Is_Not_Empty()) {
         const ModuleTemplate *temp = Find_Module_Template(name, type);
@@ -147,7 +147,7 @@ ModuleData *ModuleFactory::New_Module_Data_From_INI(
  *
  * 0x004F2D60
  */
-NameKeyType ModuleFactory::Make_Decorated_Name_Key(const AsciiString &name, ModuleType type)
+NameKeyType ModuleFactory::Make_Decorated_Name_Key(const Utf8String &name, ModuleType type)
 {
     char tmp[256];
 
@@ -163,7 +163,7 @@ NameKeyType ModuleFactory::Make_Decorated_Name_Key(const AsciiString &name, Modu
  * 0x004F2E80
  */
 void ModuleFactory::Add_Module_Internal(
-    modcreateproc_t proc, moddatacreateproc_t data_proc, ModuleType type, const AsciiString &name, int iface)
+    modcreateproc_t proc, moddatacreateproc_t data_proc, ModuleType type, const Utf8String &name, int iface)
 {
     ModuleTemplate &data = m_moduleTemplateMap[Make_Decorated_Name_Key(name, type)];
     data.create_proc = proc;

--- a/src/game/common/modules/modulefactory.h
+++ b/src/game/common/modules/modulefactory.h
@@ -78,19 +78,19 @@ public:
     virtual void Xfer_Snapshot(Xfer *xfer) override;
     virtual void Load_Post_Process() override {}
 
-    int Find_Interface_Mask(const AsciiString &name, ModuleType type);
-    Module *New_Module(Thing *thing, const AsciiString &name, ModuleData *data, ModuleType type);
-    ModuleData *New_Module_Data_From_INI(INI *ini, const AsciiString &name, ModuleType type, const AsciiString &tag);
+    int Find_Interface_Mask(const Utf8String &name, ModuleType type);
+    Module *New_Module(Thing *thing, const Utf8String &name, ModuleData *data, ModuleType type);
+    ModuleData *New_Module_Data_From_INI(INI *ini, const Utf8String &name, ModuleType type, const Utf8String &tag);
 
 #ifndef THYME_STANDALONE
     static void Hook_Me();
 #endif
 
 protected:
-    static NameKeyType Make_Decorated_Name_Key(const AsciiString &name, ModuleType type);
+    static NameKeyType Make_Decorated_Name_Key(const Utf8String &name, ModuleType type);
     void Add_Module_Internal(
-        modcreateproc_t proc, moddatacreateproc_t data_proc, ModuleType type, const AsciiString &name, int iface);
-    const ModuleTemplate *Find_Module_Template(const AsciiString &name, ModuleType type) const;
+        modcreateproc_t proc, moddatacreateproc_t data_proc, ModuleType type, const Utf8String &name, int iface);
+    const ModuleTemplate *Find_Module_Template(const Utf8String &name, ModuleType type) const;
 
 protected:
     std::map<NameKeyType, ModuleTemplate> m_moduleTemplateMap;

--- a/src/game/common/multiplayersettings.cpp
+++ b/src/game/common/multiplayersettings.cpp
@@ -45,7 +45,7 @@ void MultiplayerColorDefinition::Set_Night_Color(RGBColor rgb)
 
 void MultiplayerColorDefinition::Parse_Color_Definition(INI *ini)
 {
-    AsciiString token = ini->Get_Next_Token();
+    Utf8String token = ini->Get_Next_Token();
     MultiplayerColorDefinition *def = g_theMultiplayerSettings->Find_Color_Definition(token);
 
     if (def == nullptr) {
@@ -76,12 +76,12 @@ MultiplayerSettings::MultiplayerSettings() :
 {
 }
 
-MultiplayerColorDefinition *MultiplayerSettings::Find_Color_Definition(AsciiString name)
+MultiplayerColorDefinition *MultiplayerSettings::Find_Color_Definition(Utf8String name)
 {
     return nullptr;
 }
 
-MultiplayerColorDefinition *MultiplayerSettings::New_Color_Definition(AsciiString name)
+MultiplayerColorDefinition *MultiplayerSettings::New_Color_Definition(Utf8String name)
 {
     return nullptr;
 }

--- a/src/game/common/multiplayersettings.h
+++ b/src/game/common/multiplayersettings.h
@@ -37,7 +37,7 @@ public:
     static void Parse_Color_Definition(INI *ini);
 
 private:
-    AsciiString m_tooltipName;
+    Utf8String m_tooltipName;
     RGBColor m_rgbValue;
     int m_color;
     RGBColor m_rgbNightValue;
@@ -78,8 +78,8 @@ public:
     virtual void Reset() override {}
     virtual void Update() override {}
 
-    MultiplayerColorDefinition *Find_Color_Definition(AsciiString name);
-    MultiplayerColorDefinition *New_Color_Definition(AsciiString name);
+    MultiplayerColorDefinition *Find_Color_Definition(Utf8String name);
+    MultiplayerColorDefinition *New_Color_Definition(Utf8String name);
 
 private:
     int m_initialCreditsMin;
@@ -90,7 +90,7 @@ private:
     bool m_showRandomPlayerTemplate;
     bool m_showRandomStartPos;
     bool m_showRandomColor;
-    std::map<AsciiString, MultiplayerColorDefinition> m_colorList;
+    std::map<Utf8String, MultiplayerColorDefinition> m_colorList;
     int m_numColors;
     MultiplayerColorDefinition m_colorDef1;
     MultiplayerColorDefinition m_colorDef2;

--- a/src/game/common/namekeygenerator.cpp
+++ b/src/game/common/namekeygenerator.cpp
@@ -48,7 +48,7 @@ void NameKeyGenerator::Reset()
     m_nextID = (NameKeyType)1;
 }
 
-AsciiString NameKeyGenerator::Key_To_Name(NameKeyType key)
+Utf8String NameKeyGenerator::Key_To_Name(NameKeyType key)
 {
     // Find the bucket that matches the provided key if it exists.
     Bucket *bucket;
@@ -65,7 +65,7 @@ AsciiString NameKeyGenerator::Key_To_Name(NameKeyType key)
         }
     }
 
-    return AsciiString::s_emptyString;
+    return Utf8String::s_emptyString;
 }
 
 NameKeyType NameKeyGenerator::Name_To_Lower_Case_Key(const char *name)

--- a/src/game/common/namekeygenerator.h
+++ b/src/game/common/namekeygenerator.h
@@ -44,7 +44,7 @@ public:
 public:
     Bucket *m_nextInSocket;
     NameKeyType m_key;
-    AsciiString m_nameString;
+    Utf8String m_nameString;
 };
 
 class NameKeyGenerator : public SubsystemInterface
@@ -64,7 +64,7 @@ public:
     virtual void Update() {}
 
     // Key to name functions
-    AsciiString Key_To_Name(NameKeyType key);
+    Utf8String Key_To_Name(NameKeyType key);
     NameKeyType Name_To_Lower_Case_Key(const char *name);
     NameKeyType Name_To_Key(const char *name);
 

--- a/src/game/common/registry.cpp
+++ b/src/game/common/registry.cpp
@@ -15,9 +15,9 @@
 
 #include "registry.h"
 
-AsciiString Get_Registry_Language()
+Utf8String Get_Registry_Language()
 {
-    static AsciiString lang = "english";
+    static Utf8String lang = "english";
     static bool retrieved = false;
     
     if(retrieved) {
@@ -30,16 +30,16 @@ AsciiString Get_Registry_Language()
     }
 }
 
-void Get_String_From_Registry(AsciiString subkey, AsciiString value, AsciiString const &destination)
+void Get_String_From_Registry(Utf8String subkey, Utf8String value, Utf8String const &destination)
 {
 #ifndef THYME_STANDALONE
-    Call_Function<void, AsciiString, AsciiString, AsciiString const &>(0x00498A80, subkey, value, destination);
+    Call_Function<void, Utf8String, Utf8String, Utf8String const &>(0x00498A80, subkey, value, destination);
 #endif
 }
 
-void Get_String_From_Generals_Registry(AsciiString subkey, AsciiString value, AsciiString const &destination)
+void Get_String_From_Generals_Registry(Utf8String subkey, Utf8String value, Utf8String const &destination)
 {
 #ifndef THYME_STANDALONE
-    Call_Function<void, AsciiString, AsciiString, AsciiString const &>(0x004988A0, subkey, value, destination);
+    Call_Function<void, Utf8String, Utf8String, Utf8String const &>(0x004988A0, subkey, value, destination);
 #endif
 }

--- a/src/game/common/registry.h
+++ b/src/game/common/registry.h
@@ -17,9 +17,9 @@
 #include "always.h"
 #include "asciistring.h"
 
-AsciiString Get_Registry_Language();
-void Get_String_From_Registry(AsciiString subkey, AsciiString value, AsciiString const &destination);
-void Get_String_From_Generals_Registry(AsciiString subkey, AsciiString value, AsciiString const &destination);
+Utf8String Get_Registry_Language();
+void Get_String_From_Registry(Utf8String subkey, Utf8String value, Utf8String const &destination);
+void Get_String_From_Generals_Registry(Utf8String subkey, Utf8String value, Utf8String const &destination);
 
 #ifndef THYME_STANDALONE
 #include "hooker.h"

--- a/src/game/common/rts/buildinfo.h
+++ b/src/game/common/rts/buildinfo.h
@@ -47,23 +47,23 @@ public:
 
     BuildListInfo *Get_Next() { return m_nextBuildList; }
     void Set_Next(BuildListInfo *next) { m_nextBuildList = next; }
-    void Set_Building_Name(AsciiString name) { m_buildingName = name; }
-    void Set_Template_Name(AsciiString name) { m_templateName = name; }
+    void Set_Building_Name(Utf8String name) { m_buildingName = name; }
+    void Set_Template_Name(Utf8String name) { m_templateName = name; }
     void Set_Location(Coord3D &location) { m_location = location; }
     void Set_Angle(float angle) { m_angle = angle; }
     void Set_Intially_Built(bool built) { m_isInitiallyBuilt = built; }
     void Parse_Data_Chunk(DataChunkInput &input, DataChunkInfo *info);
 
 private:
-    AsciiString m_buildingName;
-    AsciiString m_templateName;
+    Utf8String m_buildingName;
+    Utf8String m_templateName;
     Coord3D m_location;
     Coord2D m_rallyPointOffset;
     float m_angle;
     bool m_isInitiallyBuilt;
     unsigned m_numRebuilds;
     BuildListInfo *m_nextBuildList;
-    AsciiString m_script;
+    Utf8String m_script;
     int m_health;
     bool m_whiner;
     bool m_repairable;

--- a/src/game/common/rts/handicap.cpp
+++ b/src/game/common/rts/handicap.cpp
@@ -47,7 +47,7 @@ void Handicap::Read_From_Dict(const Dict *dict)
 
     for (int i = 0; i < HANDICAP_TYPE_COUNT; ++i) {
         for (int j = 0; j < THING_TYPE_COUNT; ++j) {
-            AsciiString key_name = "HANDICAP_";
+            Utf8String key_name = "HANDICAP_";
             key_name += _ht_names[i];
             key_name += "_";
             key_name += _tt_names[j];

--- a/src/game/common/rts/playertemplate.cpp
+++ b/src/game/common/rts/playertemplate.cpp
@@ -133,7 +133,7 @@ void PlayerTemplate::Parse_Start_Money(INI *ini, void *formal, void *store, cons
  *
  * 0x004D3170
  */
-int PlayerTemplateStore::Get_Template_Number_By_Name(AsciiString name)
+int PlayerTemplateStore::Get_Template_Number_By_Name(Utf8String name)
 {
     for (unsigned i = 0; i < m_playerTemplates.size(); ++i) {
         if (m_playerTemplates[i].Get_Name().Compare_No_Case(name) == 0) {
@@ -204,17 +204,17 @@ PlayerTemplate *PlayerTemplateStore::Get_Nth_Player_Template(int index)
  *
  * 0x004D3630
  */
-void PlayerTemplateStore::Get_All_Side_Strings(std::list<AsciiString> *list)
+void PlayerTemplateStore::Get_All_Side_Strings(std::list<Utf8String> *list)
 {
     if (list == nullptr) {
         return;
     }
 
-    std::list<AsciiString> tmp;
+    std::list<Utf8String> tmp;
 
     // Go through the template vector and add all the sides present in it to the list.
     for (unsigned i = 0; i < m_playerTemplates.size(); ++i) {
-        AsciiString side_name = m_playerTemplates[i].Get_Side_Name();
+        Utf8String side_name = m_playerTemplates[i].Get_Side_Name();
         auto found = std::find(tmp.begin(), tmp.end(), side_name);
 
         // If a matching entry isn't found already, add this side name to the list.

--- a/src/game/common/rts/playertemplate.h
+++ b/src/game/common/rts/playertemplate.h
@@ -58,7 +58,7 @@ public:
 
 private:
     NameKeyType m_nameKey;
-    UnicodeString m_displayName;
+    Utf16String m_displayName;
     AsciiString m_side;
     AsciiString m_baseSide;
     Handicap m_handicap;

--- a/src/game/common/rts/playertemplate.h
+++ b/src/game/common/rts/playertemplate.h
@@ -47,8 +47,8 @@ public:
     Image *Get_Side_Icon_Image();
     Image *Get_General_Image();
     Image *Get_Enabled_Image();
-    AsciiString Get_Name() { return g_theNameKeyGenerator->Key_To_Name(m_nameKey); }
-    AsciiString Get_Side_Name() { return m_side; }
+    Utf8String Get_Name() { return g_theNameKeyGenerator->Key_To_Name(m_nameKey); }
+    Utf8String Get_Side_Name() { return m_side; }
     bool Check_Name_Key(NameKeyType key) { return key == m_nameKey; }
 
     static void Parse_Production_Cost_Change(INI *ini, void *formal, void *store, const void *user_data);
@@ -59,42 +59,42 @@ public:
 private:
     NameKeyType m_nameKey;
     Utf16String m_displayName;
-    AsciiString m_side;
-    AsciiString m_baseSide;
+    Utf8String m_side;
+    Utf8String m_baseSide;
     Handicap m_handicap;
     Money m_money;
     RGBColor m_preferredColor;
-    AsciiString m_startingBuilding;
-    AsciiString m_startingUnits[STARTING_UNIT_COUNT];
+    Utf8String m_startingBuilding;
+    Utf8String m_startingUnits[STARTING_UNIT_COUNT];
     std::map<const NameKeyType, float> m_productionCostChanges;
     std::map<const NameKeyType, float> m_productionTimeChanges;
     std::map<const NameKeyType, VeterancyLevel> m_productionVeterancyLevels;
     std::vector<ScienceType> m_intrinsicSciences;
-    AsciiString m_purchaseCommandSetRankOne;
-    AsciiString m_purchaseCommandSetRankThree;
-    AsciiString m_purchaseCommandSetRankEight;
-    AsciiString m_specialPowerShortcutCommandSet;
-    AsciiString m_specialPowerShortcutWinName;
+    Utf8String m_purchaseCommandSetRankOne;
+    Utf8String m_purchaseCommandSetRankThree;
+    Utf8String m_purchaseCommandSetRankEight;
+    Utf8String m_specialPowerShortcutCommandSet;
+    Utf8String m_specialPowerShortcutWinName;
     int m_specialPowerShortcutButtonCount;
-    AsciiString m_loadScreenMusic;
-    AsciiString m_scoreScreenMusic;
-    AsciiString m_armyTooltip;
+    Utf8String m_loadScreenMusic;
+    Utf8String m_scoreScreenMusic;
+    Utf8String m_armyTooltip;
     bool m_isObserver;
     bool m_isPlayableSide;
     bool m_oldFaction;
     int m_intrinsicSciencePurchasePoints;
-    AsciiString m_scoreScreenImage;
-    AsciiString m_loadScreenImage;
-    AsciiString m_headWaterMark;
-    AsciiString m_flagWaterMark;
-    AsciiString m_enabledImage;
-    AsciiString m_sideIconImage;
-    AsciiString m_generalImage;
-    AsciiString m_beaconName;
-    AsciiString m_features;
-    AsciiString m_medallionRegular;
-    AsciiString m_medallionHilite;
-    AsciiString m_medallionSelect;
+    Utf8String m_scoreScreenImage;
+    Utf8String m_loadScreenImage;
+    Utf8String m_headWaterMark;
+    Utf8String m_flagWaterMark;
+    Utf8String m_enabledImage;
+    Utf8String m_sideIconImage;
+    Utf8String m_generalImage;
+    Utf8String m_beaconName;
+    Utf8String m_features;
+    Utf8String m_medallionRegular;
+    Utf8String m_medallionHilite;
+    Utf8String m_medallionSelect;
 };
 
 class PlayerTemplateStore : public SubsystemInterface
@@ -107,10 +107,10 @@ public:
     virtual void Reset() override {}
     virtual void Update() override {}
 
-    int Get_Template_Number_By_Name(AsciiString name);
+    int Get_Template_Number_By_Name(Utf8String name);
     PlayerTemplate *Find_Player_Template(NameKeyType key);
     PlayerTemplate *Get_Nth_Player_Template(int index);
-    void Get_All_Side_Strings(std::list<AsciiString> *list);
+    void Get_All_Side_Strings(std::list<Utf8String> *list);
 
     static void Parse_Player_Template_Definitions(INI *ini);
 

--- a/src/game/common/rts/productionprerequisite.h
+++ b/src/game/common/rts/productionprerequisite.h
@@ -30,7 +30,7 @@ class ProductionPrerequisite
     {
         ThingTemplate *unit;
         int flags;
-        AsciiString name;
+        Utf8String name;
     };
 public:
     ProductionPrerequisite() {}

--- a/src/game/common/rts/science.h
+++ b/src/game/common/rts/science.h
@@ -64,8 +64,8 @@ public:
 
 private:
     NameKeyType m_nameKey;
-    UnicodeString m_displayName;
-    UnicodeString m_description;
+    Utf16String m_displayName;
+    Utf16String m_description;
     std::vector<ScienceType> m_unkVec1;
     std::vector<ScienceType> m_prerequisites;
     int m_purchaseCost;

--- a/src/game/common/rts/sideslist.cpp
+++ b/src/game/common/rts/sideslist.cpp
@@ -243,7 +243,7 @@ bool SidesList::Validate_Ally_Enemy_List(const AsciiString &team, AsciiString &a
 void SidesList::Add_Player_By_Template(AsciiString template_name)
 {
     AsciiString player_name;
-    UnicodeString display_name;
+    Utf16String display_name;
     bool is_human;
 
     if (template_name.Is_Empty()) {

--- a/src/game/common/rts/sideslist.cpp
+++ b/src/game/common/rts/sideslist.cpp
@@ -248,7 +248,7 @@ void SidesList::Add_Player_By_Template(AsciiString template_name)
 
     if (template_name.Is_Empty()) {
         player_name = "";
-        display_name = L"Neutral";
+        display_name = (const unichar_t *)u"Neutral";
         is_human = false;
     } else {
         player_name = "Plyr";

--- a/src/game/common/rts/sideslist.cpp
+++ b/src/game/common/rts/sideslist.cpp
@@ -133,8 +133,8 @@ bool SidesList::Validate_Sides()
     // Validates side info.
     for (index = 0; index < m_numSides; ++index) {
         SidesInfo *info = Get_Sides_Info(index);
-        AsciiString player_name = info->Get_Dict().Get_AsciiString(g_playerNameKey);
-        AsciiString team_name = "team";
+        Utf8String player_name = info->Get_Dict().Get_AsciiString(g_playerNameKey);
+        Utf8String team_name = "team";
         team_name += player_name;
         TeamsInfo *team_info = Find_Team_Info(team_name, nullptr);
 
@@ -157,8 +157,8 @@ bool SidesList::Validate_Sides()
             modified = true;
         }
 
-        AsciiString allies = info->Get_Dict().Get_AsciiString(g_playerAlliesKey);
-        AsciiString enemies = info->Get_Dict().Get_AsciiString(g_playerEnemiesKey);
+        Utf8String allies = info->Get_Dict().Get_AsciiString(g_playerAlliesKey);
+        Utf8String enemies = info->Get_Dict().Get_AsciiString(g_playerEnemiesKey);
 
         // Allies and enemies are whitespace separated lists.
         if (Validate_Ally_Enemy_List(player_name, allies)) {
@@ -173,7 +173,7 @@ bool SidesList::Validate_Sides()
     // Validates team names.
     for (index = 0; index < m_teamRec.Count(); ++index) {
         TeamsInfo *tinfo = m_teamRec.Get_Team_Info(index);
-        AsciiString team_name = tinfo->dict.Get_AsciiString(g_teamNameKey);
+        Utf8String team_name = tinfo->dict.Get_AsciiString(g_teamNameKey);
 
         if (Find_Side_Info(team_name) != nullptr) {
             DEBUG_LOG("Duplicate name '%s' between player and team, removing...\n", team_name.Str());
@@ -191,12 +191,12 @@ bool SidesList::Validate_Sides()
     // Validates team owner
     for (index = 0; index < m_teamRec.Count(); ++index) {
         TeamsInfo *tinfo = m_teamRec.Get_Team_Info(index);
-        AsciiString team_name = tinfo->dict.Get_AsciiString(g_teamNameKey);
-        AsciiString team_owner = tinfo->dict.Get_AsciiString(g_teamOwnerKey);
+        Utf8String team_name = tinfo->dict.Get_AsciiString(g_teamNameKey);
+        Utf8String team_owner = tinfo->dict.Get_AsciiString(g_teamOwnerKey);
 
         if (Find_Side_Info(team_owner) == nullptr || team_name == team_owner) {
             DEBUG_LOG("Bad owner '%s', reset to neutral.\n", team_owner.Str());
-            tinfo->dict.Set_AsciiString(g_teamOwnerKey, AsciiString::s_emptyString);
+            tinfo->dict.Set_AsciiString(g_teamOwnerKey, Utf8String::s_emptyString);
             modified = true;
         }
     }
@@ -209,12 +209,12 @@ bool SidesList::Validate_Sides()
  *
  * 0x004D79A0
  */
-bool SidesList::Validate_Ally_Enemy_List(const AsciiString &team, AsciiString &allies)
+bool SidesList::Validate_Ally_Enemy_List(const Utf8String &team, Utf8String &allies)
 {
     bool modified = false;
-    AsciiString str = allies;
-    AsciiString token;
-    AsciiString new_str;
+    Utf8String str = allies;
+    Utf8String token;
+    Utf8String new_str;
 
     // Goes through string constructing a new space separated list from the old one, skipping ones that don't match existing
     // side info.
@@ -240,9 +240,9 @@ bool SidesList::Validate_Ally_Enemy_List(const AsciiString &team, AsciiString &a
  *
  * 0x004D7BC0
  */
-void SidesList::Add_Player_By_Template(AsciiString template_name)
+void SidesList::Add_Player_By_Template(Utf8String template_name)
 {
-    AsciiString player_name;
+    Utf8String player_name;
     Utf16String display_name;
     bool is_human;
 
@@ -273,7 +273,7 @@ void SidesList::Add_Player_By_Template(AsciiString template_name)
     Add_Side(&dict);
     dict.Clear();
 
-    AsciiString team_name = "team";
+    Utf8String team_name = "team";
     team_name += player_name;
     dict.Set_AsciiString(g_teamNameKey, team_name);
     dict.Set_AsciiString(g_teamOwnerKey, player_name);
@@ -286,7 +286,7 @@ void SidesList::Add_Player_By_Template(AsciiString template_name)
  *
  * 0x004D6A60
  */
-SidesInfo *SidesList::Find_Side_Info(AsciiString name, int *index)
+SidesInfo *SidesList::Find_Side_Info(Utf8String name, int *index)
 {
     for (int i = 0; i < m_numSides; ++i) {
         if (m_sides[i].Get_Dict().Get_AsciiString(g_playerNameKey) == name) {
@@ -306,7 +306,7 @@ SidesInfo *SidesList::Find_Side_Info(AsciiString name, int *index)
  *
  * 0x004D6BD0
  */
-SidesInfo *SidesList::Find_Skirmish_Side_Info(AsciiString name, int *index)
+SidesInfo *SidesList::Find_Skirmish_Side_Info(Utf8String name, int *index)
 {
     for (int i = 0; i < m_numSkirmishSides; ++i) {
         if (m_skirmishSides[i].Get_Dict().Get_AsciiString(g_playerNameKey) == name) {

--- a/src/game/common/rts/sideslist.h
+++ b/src/game/common/rts/sideslist.h
@@ -49,12 +49,12 @@ public:
     void Empty_Teams();
     void Empty_Sides();
     bool Validate_Sides();
-    bool Validate_Ally_Enemy_List(const AsciiString &team, AsciiString &allies);
-    void Add_Player_By_Template(AsciiString template_name);
-    SidesInfo *Find_Side_Info(AsciiString name, int *index = nullptr);
-    SidesInfo *Find_Skirmish_Side_Info(AsciiString name, int *index = nullptr);
+    bool Validate_Ally_Enemy_List(const Utf8String &team, Utf8String &allies);
+    void Add_Player_By_Template(Utf8String template_name);
+    SidesInfo *Find_Side_Info(Utf8String name, int *index = nullptr);
+    SidesInfo *Find_Skirmish_Side_Info(Utf8String name, int *index = nullptr);
     SidesInfo *Get_Sides_Info(int index);
-    TeamsInfo *Find_Team_Info(AsciiString name, int *index) { return m_teamRec.Find_Team(name, index); }
+    TeamsInfo *Find_Team_Info(Utf8String name, int *index) { return m_teamRec.Find_Team(name, index); }
 
     static bool Parse_Sides_Chunk(DataChunkInput &input, DataChunkInfo *info, void *data);
 

--- a/src/game/common/rts/teamsinfo.cpp
+++ b/src/game/common/rts/teamsinfo.cpp
@@ -89,7 +89,7 @@ void TeamsInfoRec::Remove_Team(int id)
 /**
  * @brief Finds team info by name.
  */
-TeamsInfo *TeamsInfoRec::Find_Team(AsciiString name, int *id)
+TeamsInfo *TeamsInfoRec::Find_Team(Utf8String name, int *id)
 {
     if (m_numTeams <= 0) {
         return nullptr;
@@ -97,7 +97,7 @@ TeamsInfo *TeamsInfoRec::Find_Team(AsciiString name, int *id)
 
     for (int i = 0; i < m_numTeams; ++i) {
         NameKeyType key = g_teamNameKey.Key();
-        AsciiString string = m_teams[i].dict.Get_AsciiString(key);
+        Utf8String string = m_teams[i].dict.Get_AsciiString(key);
 
         if (string == name) {
             if (id != nullptr) {

--- a/src/game/common/rts/teamsinfo.h
+++ b/src/game/common/rts/teamsinfo.h
@@ -40,7 +40,7 @@ public:
 
     void Add_Team(const Dict *team);
     void Remove_Team(int id);
-    TeamsInfo *Find_Team(AsciiString name, int *id);
+    TeamsInfo *Find_Team(Utf8String name, int *id);
     void Clear();
     int Count() { return m_numTeams; }
     TeamsInfoRec &operator=(const TeamsInfoRec &that);

--- a/src/game/common/system/archivefile.cpp
+++ b/src/game/common/system/archivefile.cpp
@@ -16,10 +16,10 @@
 #include "archivefile.h"
 #include "file.h"
 
-ArchivedFileInfo *ArchiveFile::Get_Archived_File_Info(AsciiString const &filename)
+ArchivedFileInfo *ArchiveFile::Get_Archived_File_Info(Utf8String const &filename)
 {
-    AsciiString path = filename;
-    AsciiString token;
+    Utf8String path = filename;
+    Utf8String token;
     DetailedArchiveDirectoryInfo *dirp = &m_archiveInfo;
 
     // Lower case for matching and get first item of the path.
@@ -49,11 +49,11 @@ ArchivedFileInfo *ArchiveFile::Get_Archived_File_Info(AsciiString const &filenam
     return &file_it->second;
 }
 
-void ArchiveFile::Add_File(AsciiString const &filepath, ArchivedFileInfo const *info)
+void ArchiveFile::Add_File(Utf8String const &filepath, ArchivedFileInfo const *info)
 {
     // DEBUG_LOG("Adding '%s' to interal archive for '%s'.\n", filepath.Str(), info->archive_name.Str());
-    AsciiString path = filepath;
-    AsciiString token;
+    Utf8String path = filepath;
+    Utf8String token;
     DetailedArchiveDirectoryInfo *dirp = &m_archiveInfo;
 
     // Lower case for matching and get first item of the path.
@@ -83,11 +83,11 @@ void ArchiveFile::Attach_File(File *file)
     m_backingFile = file;
 }
 
-void ArchiveFile::Get_File_List_From_Dir(AsciiString const &subdir, AsciiString const &dirpath, AsciiString const &filter,
-    std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdir) const
+void ArchiveFile::Get_File_List_From_Dir(Utf8String const &subdir, Utf8String const &dirpath, Utf8String const &filter,
+    std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdir) const
 {
-    AsciiString path = dirpath;
-    AsciiString token;
+    Utf8String path = dirpath;
+    Utf8String token;
     DetailedArchiveDirectoryInfo const *dirp = &m_archiveInfo;
 
     // Lower case for matching and get first item of the path.
@@ -106,12 +106,12 @@ void ArchiveFile::Get_File_List_From_Dir(AsciiString const &subdir, AsciiString 
     Get_File_List_From_Dir(dirp, dirpath, filter, filelist, search_subdir);
 }
 
-void ArchiveFile::Get_File_List_From_Dir(DetailedArchiveDirectoryInfo const *dir_info, AsciiString const &dirpath,
-    AsciiString const &filter, std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdir) const
+void ArchiveFile::Get_File_List_From_Dir(DetailedArchiveDirectoryInfo const *dir_info, Utf8String const &dirpath,
+    Utf8String const &filter, std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdir) const
 {
     // Add the files from any subdirectories, recursive call.
     for (auto it = dir_info->directories.begin(); it != dir_info->directories.end(); ++it) {
-        AsciiString path = dirpath;
+        Utf8String path = dirpath;
 
         if (!path.Is_Empty() && !path.Ends_With("\\") && !path.Ends_With("/")) {
             path += "/";
@@ -124,7 +124,7 @@ void ArchiveFile::Get_File_List_From_Dir(DetailedArchiveDirectoryInfo const *dir
     // Add all the files that match the search pattern.
     for (auto it = dir_info->files.begin(); it != dir_info->files.end(); ++it) {
         if (Search_String_Matches(it->second.file_name, filter)) {
-            AsciiString path = dirpath;
+            Utf8String path = dirpath;
 
             if (!path.Is_Empty() && !path.Ends_With("\\") && !path.Ends_With("/")) {
                 path += "/";
@@ -137,7 +137,7 @@ void ArchiveFile::Get_File_List_From_Dir(DetailedArchiveDirectoryInfo const *dir
 }
 
 // Helper funtion to check if a string matches the search string.
-bool Search_String_Matches(AsciiString string, AsciiString search)
+bool Search_String_Matches(Utf8String string, Utf8String search)
 {
     // Trivial case if first string is empty.
     if (string.Is_Empty()) {

--- a/src/game/common/system/archivefile.h
+++ b/src/game/common/system/archivefile.h
@@ -27,17 +27,17 @@ class File;
 
 struct ArchivedFileInfo
 {
-    AsciiString file_name;
-    AsciiString archive_name;
+    Utf8String file_name;
+    Utf8String archive_name;
     int position;
     int size;
 };
 
 struct DetailedArchiveDirectoryInfo
 {
-    AsciiString name;
-    mutable std::map<AsciiString, DetailedArchiveDirectoryInfo> directories; // Mutable to use operator[] in const functions
-    std::map<AsciiString, ArchivedFileInfo> files;
+    Utf8String name;
+    mutable std::map<Utf8String, DetailedArchiveDirectoryInfo> directories; // Mutable to use operator[] in const functions
+    std::map<Utf8String, ArchivedFileInfo> files;
 };
 
 class ArchiveFile
@@ -46,27 +46,27 @@ public:
     ArchiveFile() : m_backingFile(nullptr), m_archiveInfo() {}
     virtual ~ArchiveFile() {}
 
-    virtual bool Get_File_Info(AsciiString const &name, FileInfo *info) = 0;
+    virtual bool Get_File_Info(Utf8String const &name, FileInfo *info) = 0;
     virtual File *Open_File(const char *filename, int mode) = 0;
     virtual void Close_All_Files() = 0;
-    virtual AsciiString Get_Name() = 0;
-    virtual AsciiString Get_Path() = 0;
+    virtual Utf8String Get_Name() = 0;
+    virtual Utf8String Get_Path() = 0;
     virtual void Set_Search_Priority(int priority) = 0;
     virtual void Close() = 0;
 
-    ArchivedFileInfo *Get_Archived_File_Info(AsciiString const &filename);
-    void Add_File(AsciiString const &filename, ArchivedFileInfo const *info);
+    ArchivedFileInfo *Get_Archived_File_Info(Utf8String const &filename);
+    void Add_File(Utf8String const &filename, ArchivedFileInfo const *info);
     void Attach_File(File *file);
-    void Get_File_List_From_Dir(AsciiString const &subdir, AsciiString const &dirpath, AsciiString const &filter,
-        std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdir) const;
+    void Get_File_List_From_Dir(Utf8String const &subdir, Utf8String const &dirpath, Utf8String const &filter,
+        std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdir) const;
 
 protected:
-    void Get_File_List_From_Dir(DetailedArchiveDirectoryInfo const *dir_info, AsciiString const &dirpath,
-        AsciiString const &filter, std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist,
+    void Get_File_List_From_Dir(DetailedArchiveDirectoryInfo const *dir_info, Utf8String const &dirpath,
+        Utf8String const &filter, std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist,
         bool search_subdir) const;
 
     File *m_backingFile;
     DetailedArchiveDirectoryInfo m_archiveInfo;
 };
 
-bool Search_String_Matches(AsciiString string, AsciiString search);
+bool Search_String_Matches(Utf8String string, Utf8String search);

--- a/src/game/common/system/archivefilesystem.cpp
+++ b/src/game/common/system/archivefilesystem.cpp
@@ -25,7 +25,7 @@ ArchiveFileSystem *g_theArchiveFileSystem = nullptr;
 
 File *ArchiveFileSystem::Open_File(const char *filename, int mode)
 {
-    AsciiString archive = Get_Archive_Filename_For_File(filename);
+    Utf8String archive = Get_Archive_Filename_For_File(filename);
 
     if (archive.Is_Empty()) {
         return nullptr;
@@ -40,8 +40,8 @@ File *ArchiveFileSystem::Open_File(const char *filename, int mode)
 
 bool ArchiveFileSystem::Does_File_Exist(const char *filename)
 {
-    AsciiString path = filename;
-    AsciiString token;
+    Utf8String path = filename;
+    Utf8String token;
     ArchivedDirectoryInfo *dirp = &m_archiveDirInfo;
 
     // Lower case for matching and get first item of the path.
@@ -72,17 +72,17 @@ bool ArchiveFileSystem::Does_File_Exist(const char *filename)
 
 // Loads an archive file into the virtual directory tree. The over write option allows it to use this archive to
 // replace the backing for a file name if it already has an entry in the tree.
-void ArchiveFileSystem::Load_Into_Dir_Tree(ArchiveFile const *file, AsciiString const &archive_path, bool overwrite)
+void ArchiveFileSystem::Load_Into_Dir_Tree(ArchiveFile const *file, Utf8String const &archive_path, bool overwrite)
 {
-    std::set<AsciiString, rts::less_than_nocase<AsciiString>> file_list;
+    std::set<Utf8String, rts::less_than_nocase<Utf8String>> file_list;
 
     // Retrieve a list of files in the archive
     file->Get_File_List_From_Dir("", "", "*", file_list, true);
 
     for (auto it = file_list.begin(); it != file_list.end(); ++it) {
-        AsciiString path = *it;
-        AsciiString token;
-        // AsciiString fullname;
+        Utf8String path = *it;
+        Utf8String token;
+        // Utf8String fullname;
         ArchivedDirectoryInfo *dirp = &m_archiveDirInfo;
 
         // Lower case for matching.
@@ -109,14 +109,14 @@ void ArchiveFileSystem::Load_Into_Dir_Tree(ArchiveFile const *file, AsciiString 
     }
 }
 
-bool ArchiveFileSystem::Get_File_Info(AsciiString const &name, FileInfo *info)
+bool ArchiveFileSystem::Get_File_Info(Utf8String const &name, FileInfo *info)
 {
     if (info == nullptr || name.Is_Empty()) {
         return false;
     }
 
     // Find the archive that corresponds to this file name.
-    AsciiString archive = Get_Archive_Filename_For_File(name);
+    Utf8String archive = Get_Archive_Filename_For_File(name);
 
     // Find the archive file pointer for the archive name we retrieved.
     if (m_archiveFiles.find(archive) == m_archiveFiles.end()) {
@@ -127,10 +127,10 @@ bool ArchiveFileSystem::Get_File_Info(AsciiString const &name, FileInfo *info)
 }
 
 // Returns the filname of the archive file containing the passed in file name.
-AsciiString ArchiveFileSystem::Get_Archive_Filename_For_File(AsciiString const &filename)
+Utf8String ArchiveFileSystem::Get_Archive_Filename_For_File(Utf8String const &filename)
 {
-    AsciiString path = filename;
-    AsciiString token;
+    Utf8String path = filename;
+    Utf8String token;
     ArchivedDirectoryInfo *dirp = &m_archiveDirInfo;
 
     // Lower case for matching and get first item of the path.
@@ -142,7 +142,7 @@ AsciiString ArchiveFileSystem::Get_Archive_Filename_For_File(AsciiString const &
     // that do.
     while (strchr(token.Str(), '.') == nullptr || strchr(path.Str(), '.') != nullptr) {
         if (dirp->directories.find(token) == dirp->directories.end()) {
-            return AsciiString();
+            return Utf8String();
         }
 
         dirp = &dirp->directories[token];
@@ -152,15 +152,15 @@ AsciiString ArchiveFileSystem::Get_Archive_Filename_For_File(AsciiString const &
     // Assuming we didn't run out of directories to try, find the file
     // in the reached directory.
     if (dirp->files.find(token) == dirp->files.end()) {
-        return AsciiString();
+        return Utf8String();
     }
 
     return dirp->files[token];
 }
 
 // Populates a std::set of file paths based on the passed in filter and path to examine.
-void ArchiveFileSystem::Get_File_List_From_Dir(AsciiString const &subdir, AsciiString const &dirpath,
-    AsciiString const &filter, std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdirs)
+void ArchiveFileSystem::Get_File_List_From_Dir(Utf8String const &subdir, Utf8String const &dirpath,
+    Utf8String const &filter, std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdirs)
 {
     // Get files from all archive files.
     for (auto it = m_archiveFiles.begin(); it != m_archiveFiles.end(); ++it) {

--- a/src/game/common/system/archivefilesystem.h
+++ b/src/game/common/system/archivefilesystem.h
@@ -31,9 +31,9 @@ struct FileInfo;
 
 struct ArchivedDirectoryInfo
 {
-    AsciiString name;
-    std::map<AsciiString, ArchivedDirectoryInfo> directories;
-    std::map<AsciiString, AsciiString> files; // Maps the filenames in the archive to the actual filename on disk
+    Utf8String name;
+    std::map<Utf8String, ArchivedDirectoryInfo> directories;
+    std::map<Utf8String, Utf8String> files; // Maps the filenames in the archive to the actual filename on disk
 };
 
 class ArchiveFileSystem : public SubsystemInterface
@@ -47,20 +47,20 @@ public:
     virtual File *Open_File(const char *filename, int mode);
     virtual void Close_All_Files() = 0;
     virtual bool Does_File_Exist(const char *filename);
-    virtual void Load_Archives_From_Dir(AsciiString dir, AsciiString filter, bool read_subdirs) = 0;
-    virtual void Load_Into_Dir_Tree(ArchiveFile const *file, AsciiString const &dir, bool unk);
+    virtual void Load_Archives_From_Dir(Utf8String dir, Utf8String filter, bool read_subdirs) = 0;
+    virtual void Load_Into_Dir_Tree(ArchiveFile const *file, Utf8String const &dir, bool unk);
 
-    bool Get_File_Info(AsciiString const &name, FileInfo *info);
-    AsciiString Get_Archive_Filename_For_File(AsciiString const &filename);
-    void Get_File_List_From_Dir(AsciiString const &subdir, AsciiString const &dirpath, AsciiString const &filter,
-        std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdirs);
+    bool Get_File_Info(Utf8String const &name, FileInfo *info);
+    Utf8String Get_Archive_Filename_For_File(Utf8String const &filename);
+    void Get_File_List_From_Dir(Utf8String const &subdir, Utf8String const &dirpath, Utf8String const &filter,
+        std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdirs);
     void Load_Mods();
 
 #ifndef THYME_STANDALONE
     static void Hook_Me();
 #endif
 protected:
-    std::map<AsciiString, ArchiveFile *> m_archiveFiles;
+    std::map<Utf8String, ArchiveFile *> m_archiveFiles;
     ArchivedDirectoryInfo m_archiveDirInfo;
 };
 

--- a/src/game/common/system/asciistring.cpp
+++ b/src/game/common/system/asciistring.cpp
@@ -184,7 +184,7 @@ void AsciiString::Set(AsciiString const &string)
     }
 }
 
-void AsciiString::Translate(UnicodeString const &string)
+void AsciiString::Translate(Utf16String const &string)
 {
     Release_Buffer();
     
@@ -213,9 +213,9 @@ void AsciiString::Translate(UnicodeString const &string)
         //This is a debug assert from the look of it.
         /*if ( v4 < 8 || (!stringSrc.m_data ? (v6 = 0) : (v5 = stringSrc.Peek(), v6 = wcslen(v5)), v3 >= v6) )
         {
-            if ( `UnicodeString::Get_Char'::`14'::allowCrash )
+            if ( `Utf16String::Get_Char'::`14'::allowCrash )
             {
-                TheCurrentAllowCrashPtr = &`UnicodeString::Get_Char'::`14'::allowCrash;
+                TheCurrentAllowCrashPtr = &`Utf16String::Get_Char'::`14'::allowCrash;
                 DebugCrash(aBadIndexInGetch);
                 TheCurrentAllowCrashPtr = 0;
             }

--- a/src/game/common/system/asciistring.cpp
+++ b/src/game/common/system/asciistring.cpp
@@ -3,7 +3,7 @@
  *
  * @author OmniBlade
  *
- * @brief Class for handling strings that have a single byte as a code point.
+ * @brief Class for handling strings that have a series of bytes as a code point.
  *
  * @copyright Thyme is free software: you can redistribute it and/or
  *            modify it under the terms of the GNU General Public License
@@ -19,14 +19,14 @@
 #include <cctype>
 #include <cstdio>
 
-AsciiString const AsciiString::s_emptyString(nullptr);
+Utf8String const Utf8String::s_emptyString(nullptr);
 
-AsciiString::AsciiString() :
+Utf8String::Utf8String() :
     m_data(nullptr)
 {
 }
 
-AsciiString::AsciiString(const char *s) :
+Utf8String::Utf8String(const char *s) :
     m_data(nullptr)
 {
     if ( s != nullptr ) {
@@ -37,7 +37,7 @@ AsciiString::AsciiString(const char *s) :
     }
 }
 
-AsciiString::AsciiString(AsciiString const &string) :
+Utf8String::Utf8String(Utf8String const &string) :
     m_data(string.m_data)
 {
     if ( m_data != nullptr ) {
@@ -45,12 +45,12 @@ AsciiString::AsciiString(AsciiString const &string) :
     }
 }
 
-void AsciiString::Validate()
+void Utf8String::Validate()
 {
     //TODO, doesnt seem to be implimented anywhere? It is called though...
 }
 
-char *AsciiString::Peek() const
+char *Utf8String::Peek() const
 {
     ASSERT_PRINT(m_data != nullptr, "null string ptr");
     
@@ -58,7 +58,7 @@ char *AsciiString::Peek() const
 }
 
 
-void AsciiString::Release_Buffer()
+void Utf8String::Release_Buffer()
 {
     if ( m_data != nullptr ) {
         m_data->Dec_Ref_Count();
@@ -71,7 +71,7 @@ void AsciiString::Release_Buffer()
     }
 }
 
-void AsciiString::Ensure_Unique_Buffer_Of_Size(int chars_needed, bool keep_data, const char *str_to_cpy, const char *str_to_cat)
+void Utf8String::Ensure_Unique_Buffer_Of_Size(int chars_needed, bool keep_data, const char *str_to_cpy, const char *str_to_cat)
 {
     if ( m_data != nullptr && m_data->ref_count == 1 && m_data->num_chars_allocated >= chars_needed ) {
         if ( str_to_cpy != nullptr ) {
@@ -119,7 +119,7 @@ void AsciiString::Ensure_Unique_Buffer_Of_Size(int chars_needed, bool keep_data,
     }
 }
 
-int AsciiString::Get_Length() const
+int Utf8String::Get_Length() const
 {
     if ( m_data != nullptr ) {
         int len = strlen(Str());
@@ -131,7 +131,7 @@ int AsciiString::Get_Length() const
     return 0;
 }
 
-char AsciiString::Get_Char(int index) const
+char Utf8String::Get_Char(int index) const
 {
     ASSERT_PRINT(index >= 0, "bad index in getCharAt.");
     ASSERT_PRINT(Get_Length() > 0, "strlen returned less than or equal to 0 in getCharAt.");
@@ -139,7 +139,7 @@ char AsciiString::Get_Char(int index) const
     return Peek()[index];
 }
 
-const char *AsciiString::Str() const
+const char *Utf8String::Str() const
 {
     static char const TheNullChr[4] = "";
 
@@ -150,7 +150,7 @@ const char *AsciiString::Str() const
     return TheNullChr;
 }
 
-char *AsciiString::Get_Buffer_For_Read(int len)
+char *Utf8String::Get_Buffer_For_Read(int len)
 {
     
     // Generate buffer sufficient to read requested size into.
@@ -159,7 +159,7 @@ char *AsciiString::Get_Buffer_For_Read(int len)
     return Peek();
 }
 
-void AsciiString::Set(const char *s)
+void Utf8String::Set(const char *s)
 {
     if ( m_data == nullptr || s != m_data->Peek() ) {
         size_t len;
@@ -172,7 +172,7 @@ void AsciiString::Set(const char *s)
     }
 }
 
-void AsciiString::Set(AsciiString const &string)
+void Utf8String::Set(Utf8String const &string)
 {
     if ( &string != this ) {
         Release_Buffer();
@@ -184,7 +184,7 @@ void AsciiString::Set(AsciiString const &string)
     }
 }
 
-void AsciiString::Translate(Utf16String const &string)
+void Utf8String::Translate(Utf16String const &string)
 {
     Release_Buffer();
     
@@ -249,7 +249,7 @@ void AsciiString::Translate(Utf16String const &string)
 #endif
 }
 
-void AsciiString::Concat(char c)
+void Utf8String::Concat(char c)
 {
     char str[2];
  
@@ -258,7 +258,7 @@ void AsciiString::Concat(char c)
     Concat(str);
 }
 
-void AsciiString::Concat(const char *s)
+void Utf8String::Concat(const char *s)
 {
     int len = strlen(s);
 
@@ -271,7 +271,7 @@ void AsciiString::Concat(const char *s)
     }
 }
 
-void AsciiString::Trim()
+void Utf8String::Trim()
 {
     // No string, no Trim.
     if ( m_data == nullptr ) {
@@ -306,7 +306,7 @@ void AsciiString::Trim()
     }
 }
 
-void AsciiString::To_Lower()
+void Utf8String::To_Lower()
 {
     char buf[MAX_FORMAT_BUF_LEN];
 
@@ -326,7 +326,7 @@ void AsciiString::To_Lower()
 /**
  * @brief Convert any windows path separators to posix ('\' to '/').
  */
-AsciiString AsciiString::Posix_Path() const
+Utf8String Utf8String::Posix_Path() const
 {
     char buf[MAX_FORMAT_BUF_LEN];
 
@@ -348,7 +348,7 @@ AsciiString AsciiString::Posix_Path() const
 /**
  * @brief Convert any posix path separators to windows ('/' to '\').
  */
-AsciiString AsciiString::Windows_Path() const
+Utf8String Utf8String::Windows_Path() const
 {
     char buf[MAX_FORMAT_BUF_LEN];
 
@@ -367,7 +367,7 @@ AsciiString AsciiString::Windows_Path() const
     return buf;
 }
 
-void AsciiString::Remove_Last_Char()
+void Utf8String::Remove_Last_Char()
 {
     if ( m_data == nullptr ) {
         return;
@@ -381,7 +381,7 @@ void AsciiString::Remove_Last_Char()
     }
 }
 
-void AsciiString::Format(const char *format, ...)
+void Utf8String::Format(const char *format, ...)
 {
     va_list va;
 
@@ -389,7 +389,7 @@ void AsciiString::Format(const char *format, ...)
     Format_VA(format, va);
 }
 
-void AsciiString::Format(AsciiString format, ...)
+void Utf8String::Format(Utf8String format, ...)
 {
     va_list va;
 
@@ -397,7 +397,7 @@ void AsciiString::Format(AsciiString format, ...)
     Format_VA(format, va);
 }
 
-void AsciiString::Format_VA(const char *format, va_list args)
+void Utf8String::Format_VA(const char *format, va_list args)
 {
     char buf[MAX_FORMAT_BUF_LEN];
 
@@ -406,7 +406,7 @@ void AsciiString::Format_VA(const char *format, va_list args)
     Set(buf);
 }
 
-void AsciiString::Format_VA(AsciiString &format, va_list args)
+void Utf8String::Format_VA(Utf8String &format, va_list args)
 {
     char buf[MAX_FORMAT_BUF_LEN];
 
@@ -415,7 +415,7 @@ void AsciiString::Format_VA(AsciiString &format, va_list args)
     Set(buf);
 }
 
-bool AsciiString::Starts_With(const char *p) const
+bool Utf8String::Starts_With(const char *p) const
 {
     if ( *p == '\0' ) {
         return true;
@@ -431,7 +431,7 @@ bool AsciiString::Starts_With(const char *p) const
     return strncmp(Peek(), p, thatlen) == 0;
 }
 
-bool AsciiString::Ends_With(const char *p) const
+bool Utf8String::Ends_With(const char *p) const
 {
     if ( *p == '\0' ) {
         return true;
@@ -447,7 +447,7 @@ bool AsciiString::Ends_With(const char *p) const
     return strncmp(Peek() + thislen - thatlen, p, thatlen) == 0;
 }
 
-bool AsciiString::Starts_With_No_Case(const char *p) const
+bool Utf8String::Starts_With_No_Case(const char *p) const
 {
     if ( *p == '\0' ) {
         return true;
@@ -463,7 +463,7 @@ bool AsciiString::Starts_With_No_Case(const char *p) const
     return strncasecmp(Peek(), p, thatlen) == 0;
 }
 
-bool AsciiString::Ends_With_No_Case(const char *p) const
+bool Utf8String::Ends_With_No_Case(const char *p) const
 {
     if ( *p == '\0' ) {
         return true;
@@ -479,7 +479,7 @@ bool AsciiString::Ends_With_No_Case(const char *p) const
     return strncasecmp(Peek() + thislen - thatlen, p, thatlen) == 0;
 }
 
-bool AsciiString::Next_Token(AsciiString *tok, const char *delims)
+bool Utf8String::Next_Token(Utf8String *tok, const char *delims)
 {
     if ( m_data == nullptr ) {
         return false;
@@ -533,7 +533,7 @@ bool AsciiString::Next_Token(AsciiString *tok, const char *delims)
     }
     
     //
-    // Copy found region into provided AsciiString, then move this string
+    // Copy found region into provided Utf8String, then move this string
     // to start of next section.
     //
     char *tokstr = tok->Get_Buffer_For_Read(end - start + 1);
@@ -545,7 +545,7 @@ bool AsciiString::Next_Token(AsciiString *tok, const char *delims)
 }
 
 #ifdef GAME_DEBUG
-void AsciiString::Debug_Ignore_Leaks()
+void Utf8String::Debug_Ignore_Leaks()
 {
     //TODO, doesnt seem to be implimented anywhere? It is called though...
 }

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -3,7 +3,7 @@
  *
  * @author OmniBlade
  *
- * @brief Class for handling strings that have a single byte as a code point.
+ * @brief Class for handling strings that have a series of bytes as a code point.
  *
  * @copyright Thyme is free software: you can redistribute it and/or
  *            modify it under the terms of the GNU General Public License
@@ -21,7 +21,7 @@
 
 class Utf16String;
 
-class AsciiString
+class Utf8String
 {
     // So we can hook functions we think should be private.
     friend void Setup_Hooks();
@@ -72,21 +72,21 @@ public:
         }
     };
 
-    AsciiString();
-    AsciiString(const char *s);
-    AsciiString(AsciiString const &string);
-    // AsciiString(Utf16String const &stringSrc);
-    ~AsciiString() { Release_Buffer(); }
+    Utf8String();
+    Utf8String(const char *s);
+    Utf8String(Utf8String const &string);
+    // Utf8String(Utf16String const &stringSrc);
+    ~Utf8String() { Release_Buffer(); }
 
-    AsciiString &operator=(char *s);
-    AsciiString &operator=(const char *s);
-    AsciiString &operator=(AsciiString const &stringSrc);
-    // AsciiString &operator=(Utf16String const &stringSrc);
+    Utf8String &operator=(char *s);
+    Utf8String &operator=(const char *s);
+    Utf8String &operator=(Utf8String const &stringSrc);
+    // Utf8String &operator=(Utf16String const &stringSrc);
 
-    AsciiString &operator+=(char s);
-    AsciiString &operator+=(const char *s);
-    AsciiString &operator+=(AsciiString const &s);
-    // AsciiString &operator+=(Utf16String const &stringSrc);
+    Utf8String &operator+=(char s);
+    Utf8String &operator+=(const char *s);
+    Utf8String &operator+=(Utf8String const &s);
+    // Utf8String &operator+=(Utf16String const &stringSrc);
 
     operator const char *() const { return Str(); }
 
@@ -101,29 +101,29 @@ public:
     char *Get_Buffer_For_Read(int len);
     // These two should probably be private with the = operator being the preferred interface?
     void Set(const char *s);
-    void Set(AsciiString const &string);
+    void Set(Utf8String const &string);
 
     void Translate(Utf16String const &stringSrc);
 
     // Concat should probably be private and += used as the preferred interface.
     void Concat(char c);
     void Concat(const char *s);
-    void Concat(AsciiString const &string) { Concat(string.Str()); }
+    void Concat(Utf8String const &string) { Concat(string.Str()); }
 
     void Trim();
     void To_Lower();
     void Remove_Last_Char();
 
     void Format(const char *format, ...);
-    void Format(AsciiString format, ...);
+    void Format(Utf8String format, ...);
 
     // Compare funcs should probably be private and operators should be friends and the
     // preferred interface.
     int Compare(const char *s) const { return strcmp(Str(), s); }
-    int Compare(AsciiString const &string) const { return strcmp(Str(), string.Str()); }
+    int Compare(Utf8String const &string) const { return strcmp(Str(), string.Str()); }
 
     int Compare_No_Case(const char *s) const { return strcasecmp(Str(), s); }
-    int Compare_No_Case(AsciiString const &string) const { return strcasecmp(Str(), string.Str()); }
+    int Compare_No_Case(Utf8String const &string) const { return strcasecmp(Str(), string.Str()); }
 
     // I assume these do this, though have no examples in binaries.
     char *Find(char c) { return strchr(Peek(), c); }
@@ -135,32 +135,32 @@ public:
     bool Starts_With_No_Case(const char *p) const;
     bool Ends_With_No_Case(const char *p) const;
 
-    bool Next_Token(AsciiString *tok, const char *seps = nullptr);
+    bool Next_Token(Utf8String *tok, const char *seps = nullptr);
 
     bool Is_None() const { return m_data != nullptr && strcasecmp(Peek(), "None") == 0; }
     bool Is_Empty() const { return  m_data == nullptr || *m_data->Peek() == '\0'; }
     bool Is_Not_Empty() const { return !Is_Empty(); }
     bool Is_Not_None() const { return !Is_None(); }
 
-    AsciiString Posix_Path() const;
-    AsciiString Windows_Path() const;
+    Utf8String Posix_Path() const;
+    Utf8String Windows_Path() const;
 
-    friend bool operator==(AsciiString const &left, AsciiString const &right) { return left.Compare(right) == 0; }
-    friend bool operator==(AsciiString const &left, const char *right) { return left.Compare(right) == 0; }
-    friend bool operator==(const char *left, AsciiString const &right) { return right.Compare(left) == 0; }
-    friend bool operator!=(AsciiString const &left, AsciiString const &right) { return left.Compare(right) != 0; }
-    friend bool operator!=(AsciiString const &left, const char *right) { return left.Compare(right) != 0; }
-    friend bool operator!=(const char *left, AsciiString const &right) { return right.Compare(left) != 0; }
-    friend bool operator<(AsciiString const &left, AsciiString const &right) { return left.Compare(right) < 0; }
-    friend bool operator<(AsciiString const &left, const char *right) { return left.Compare(right) < 0; }
-    friend bool operator<(const char *left, AsciiString const &right) { return right.Compare(left) >= 0; }
-    friend bool operator>(AsciiString const &left, AsciiString const &right) { return left.Compare(right) > 0; }
-    friend bool operator>(AsciiString const &left, const char *right) { return left.Compare(right) < 0; }
-    friend bool operator>(const char *left, AsciiString const &right) { return right.Compare(left) >= 0; }
+    friend bool operator==(Utf8String const &left, Utf8String const &right) { return left.Compare(right) == 0; }
+    friend bool operator==(Utf8String const &left, const char *right) { return left.Compare(right) == 0; }
+    friend bool operator==(const char *left, Utf8String const &right) { return right.Compare(left) == 0; }
+    friend bool operator!=(Utf8String const &left, Utf8String const &right) { return left.Compare(right) != 0; }
+    friend bool operator!=(Utf8String const &left, const char *right) { return left.Compare(right) != 0; }
+    friend bool operator!=(const char *left, Utf8String const &right) { return right.Compare(left) != 0; }
+    friend bool operator<(Utf8String const &left, Utf8String const &right) { return left.Compare(right) < 0; }
+    friend bool operator<(Utf8String const &left, const char *right) { return left.Compare(right) < 0; }
+    friend bool operator<(const char *left, Utf8String const &right) { return right.Compare(left) >= 0; }
+    friend bool operator>(Utf8String const &left, Utf8String const &right) { return left.Compare(right) > 0; }
+    friend bool operator>(Utf8String const &left, const char *right) { return left.Compare(right) < 0; }
+    friend bool operator>(const char *left, Utf8String const &right) { return right.Compare(left) >= 0; }
 
-    friend AsciiString operator+(const AsciiString &a, const AsciiString &b)
+    friend Utf8String operator+(const Utf8String &a, const Utf8String &b)
     {
-        AsciiString retval = a;
+        Utf8String retval = a;
         retval += b;
 
         return retval;
@@ -170,7 +170,7 @@ public:
     void Debug_Ignore_Leaks();
 #endif // GAME_DEBUG
 public:
-    static AsciiString const s_emptyString;
+    static Utf8String const s_emptyString;
 
 private:
     // Probably supposed to be private
@@ -178,49 +178,49 @@ private:
         int chars_needed, bool keep_data = false, const char *str_to_copy = nullptr, const char *str_to_cat = nullptr);
 
     void Format_VA(const char *format, va_list args);
-    void Format_VA(AsciiString &format, va_list args);
+    void Format_VA(Utf8String &format, va_list args);
 
     AsciiStringData *m_data;
 };
 
-inline AsciiString &AsciiString::operator=(char *s)
+inline Utf8String &Utf8String::operator=(char *s)
 {
     Set(s);
 
     return *this;
 }
 
-inline AsciiString &AsciiString::operator=(const char *s)
+inline Utf8String &Utf8String::operator=(const char *s)
 {
     Set(s);
 
     return *this;
 }
 
-inline AsciiString &AsciiString::operator=(AsciiString const &stringSrc)
+inline Utf8String &Utf8String::operator=(Utf8String const &stringSrc)
 {
     Set(stringSrc);
 
     return *this;
 }
 
-// AsciiString &operator=(Utf16String const &stringSrc);
+// Utf8String &operator=(Utf16String const &stringSrc);
 
-inline AsciiString &AsciiString::operator+=(char s)
+inline Utf8String &Utf8String::operator+=(char s)
 {
     Concat(s);
 
     return *this;
 }
 
-inline AsciiString &AsciiString::operator+=(const char *s)
+inline Utf8String &Utf8String::operator+=(const char *s)
 {
     Concat(s);
 
     return *this;
 }
 
-inline AsciiString &AsciiString::operator+=(AsciiString const &s)
+inline Utf8String &Utf8String::operator+=(Utf8String const &s)
 {
     Concat(s);
 

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -145,6 +145,27 @@ public:
     AsciiString Posix_Path() const;
     AsciiString Windows_Path() const;
 
+    friend bool operator==(AsciiString const &left, AsciiString const &right) { return left.Compare(right) == 0; }
+    friend bool operator==(AsciiString const &left, const char *right) { return left.Compare(right) == 0; }
+    friend bool operator==(const char *left, AsciiString const &right) { return right.Compare(left) == 0; }
+    friend bool operator!=(AsciiString const &left, AsciiString const &right) { return left.Compare(right) != 0; }
+    friend bool operator!=(AsciiString const &left, const char *right) { return left.Compare(right) != 0; }
+    friend bool operator!=(const char *left, AsciiString const &right) { return right.Compare(left) != 0; }
+    friend bool operator<(AsciiString const &left, AsciiString const &right) { return left.Compare(right) < 0; }
+    friend bool operator<(AsciiString const &left, const char *right) { return left.Compare(right) < 0; }
+    friend bool operator<(const char *left, AsciiString const &right) { return right.Compare(left) >= 0; }
+    friend bool operator>(AsciiString const &left, AsciiString const &right) { return left.Compare(right) > 0; }
+    friend bool operator>(AsciiString const &left, const char *right) { return left.Compare(right) < 0; }
+    friend bool operator>(const char *left, AsciiString const &right) { return right.Compare(left) >= 0; }
+
+    friend AsciiString operator+(const AsciiString &a, const AsciiString &b)
+    {
+        AsciiString retval = a;
+        retval += b;
+
+        return retval;
+    }
+
 #ifdef GAME_DEBUG
     void Debug_Ignore_Leaks();
 #endif // GAME_DEBUG
@@ -204,72 +225,4 @@ inline AsciiString &AsciiString::operator+=(AsciiString const &s)
     Concat(s);
 
     return *this;
-}
-
-inline bool operator==(AsciiString const &left, AsciiString const &right)
-{
-    return left.Compare(right) == 0;
-}
-
-inline bool operator==(AsciiString const &left, const char *right)
-{
-    return left.Compare(right) == 0;
-}
-
-inline bool operator==(const char *left, AsciiString const &right)
-{
-    return right.Compare(left) == 0;
-}
-
-inline bool operator!=(AsciiString const &left, AsciiString const &right)
-{
-    return left.Compare(right) != 0;
-}
-
-inline bool operator!=(AsciiString const &left, const char *right)
-{
-    return left.Compare(right) != 0;
-}
-
-inline bool operator!=(const char *left, AsciiString const &right)
-{
-    return right.Compare(left) != 0;
-}
-
-inline bool operator<(AsciiString const &left, AsciiString const &right)
-{
-    return left.Compare(right) < 0;
-}
-
-inline bool operator<(AsciiString const &left, const char *right)
-{
-    return left.Compare(right) < 0;
-}
-
-inline bool operator<(const char *left, AsciiString const &right)
-{
-    return right.Compare(left) >= 0;
-}
-
-inline bool operator>(AsciiString const &left, AsciiString const &right)
-{
-    return left.Compare(right) > 0;
-}
-
-inline bool operator>(AsciiString const &left, const char *right)
-{
-    return left.Compare(right) < 0;
-}
-
-inline bool operator>(const char *left, AsciiString const &right)
-{
-    return right.Compare(left) >= 0;
-}
-
-inline AsciiString operator+(const AsciiString &a, const AsciiString &b)
-{
-    AsciiString retval = a;
-    retval += b;
-
-    return retval;
 }

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -19,13 +19,13 @@
 #include <cstdarg>
 #include <cstring>
 
-class UnicodeString;
+class Utf16String;
 
 class AsciiString
 {
     // So we can hook functions we think should be private.
     friend void Setup_Hooks();
-    friend class UnicodeString;
+    friend class Utf16String;
 
 public:
     enum
@@ -75,18 +75,18 @@ public:
     AsciiString();
     AsciiString(const char *s);
     AsciiString(AsciiString const &string);
-    // AsciiString(UnicodeString const &stringSrc);
+    // AsciiString(Utf16String const &stringSrc);
     ~AsciiString() { Release_Buffer(); }
 
     AsciiString &operator=(char *s);
     AsciiString &operator=(const char *s);
     AsciiString &operator=(AsciiString const &stringSrc);
-    // AsciiString &operator=(UnicodeString const &stringSrc);
+    // AsciiString &operator=(Utf16String const &stringSrc);
 
     AsciiString &operator+=(char s);
     AsciiString &operator+=(const char *s);
     AsciiString &operator+=(AsciiString const &s);
-    // AsciiString &operator+=(UnicodeString const &stringSrc);
+    // AsciiString &operator+=(Utf16String const &stringSrc);
 
     operator const char *() const { return Str(); }
 
@@ -103,7 +103,7 @@ public:
     void Set(const char *s);
     void Set(AsciiString const &string);
 
-    void Translate(UnicodeString const &stringSrc);
+    void Translate(Utf16String const &stringSrc);
 
     // Concat should probably be private and += used as the preferred interface.
     void Concat(char c);
@@ -183,7 +183,7 @@ inline AsciiString &AsciiString::operator=(AsciiString const &stringSrc)
     return *this;
 }
 
-// AsciiString &operator=(UnicodeString const &stringSrc);
+// AsciiString &operator=(Utf16String const &stringSrc);
 
 inline AsciiString &AsciiString::operator+=(char s)
 {

--- a/src/game/common/system/cachedfileinputstream.cpp
+++ b/src/game/common/system/cachedfileinputstream.cpp
@@ -78,7 +78,7 @@ bool CachedFileInputStream::Eof()
 /**
  * @brief Open a file as an input stream.
  */
-bool CachedFileInputStream::Open(AsciiString filename)
+bool CachedFileInputStream::Open(Utf8String filename)
 {
     File *file = g_theFileSystem->Open(filename, File::BINARY | File::READ);
     m_cachedSize = 0;

--- a/src/game/common/system/cachedfileinputstream.h
+++ b/src/game/common/system/cachedfileinputstream.h
@@ -33,7 +33,7 @@ public:
     virtual bool Absolute_Seek(unsigned pos) override;
     virtual bool Eof() override;
 
-    bool Open(AsciiString filename);
+    bool Open(Utf8String filename);
     void Rewind() { m_cachePos = 0; }
     void Close();
 

--- a/src/game/common/system/datachunk.cpp
+++ b/src/game/common/system/datachunk.cpp
@@ -52,7 +52,7 @@ DataChunkInput::~DataChunkInput() {}
 /**
  * @brief Registers a chunk parsing function to handle chunks with the given label and parent label.
  */
-void DataChunkInput::Register_Parser(const AsciiString &label, const AsciiString &parent_label,
+void DataChunkInput::Register_Parser(const Utf8String &label, const Utf8String &parent_label,
     bool (*parser)(DataChunkInput &, DataChunkInfo *, void *), void *user_data)
 {
     UserParser *user_parser = new UserParser;
@@ -69,8 +69,8 @@ void DataChunkInput::Register_Parser(const AsciiString &label, const AsciiString
  */
 bool DataChunkInput::Parse(void *user_data)
 {
-    AsciiString label;
-    AsciiString parent_label;
+    Utf8String label;
+    Utf8String parent_label;
 
     // We can't parse if the header chunk hasn't been opened yet.
     if (!Is_Valid_File()) {
@@ -125,7 +125,7 @@ bool DataChunkInput::Parse(void *user_data)
 /**
  * @brief Opens a data chunk and returns the label associated with it. Optionally returns version in passed pointer.
  */
-AsciiString DataChunkInput::Open_Data_Chunk(uint16_t *version)
+Utf8String DataChunkInput::Open_Data_Chunk(uint16_t *version)
 {
     InputChunk *chunk = new InputChunk;
     chunk->id = 0;
@@ -154,7 +154,7 @@ AsciiString DataChunkInput::Open_Data_Chunk(uint16_t *version)
     m_chunkStack = chunk;
 
     if (m_file->Eof()) {
-        return AsciiString::s_emptyString;
+        return Utf8String::s_emptyString;
     }
 
     return m_contents.Get_Name(chunk->id);
@@ -188,13 +188,13 @@ void DataChunkInput::Reset()
     m_file->Absolute_Seek(m_fileposOfFirstChunk);
 }
 
-AsciiString DataChunkInput::Get_Chunk_Label()
+Utf8String DataChunkInput::Get_Chunk_Label()
 {
     if (m_chunkStack != nullptr) {
         return m_contents.Get_Name(m_chunkStack->id);
     }
 
-    return AsciiString::s_emptyString;
+    return Utf8String::s_emptyString;
 }
 
 /**
@@ -249,18 +249,18 @@ uint8_t DataChunkInput::Read_Byte()
 /**
  * @brief Reads an ascii string from the chunk.
  */
-AsciiString DataChunkInput::Read_AsciiString()
+Utf8String DataChunkInput::Read_AsciiString()
 {
     uint16_t size;
-    AsciiString string;
+    Utf8String string;
 
-    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= sizeof(size), "Read past end of chunk reading AsciiString length.\n");
+    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= sizeof(size), "Read past end of chunk reading Utf8String length.\n");
 
     m_file->Read(&size, sizeof(size));
     Decrement_Data_Left(sizeof(size));
     size = le16toh(size);
 
-    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= size, "Read past end of chunk reading AsciiString string.\n");
+    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= size, "Read past end of chunk reading Utf8String string.\n");
 
     m_file->Read(string.Get_Buffer_For_Read(size), size);
     Decrement_Data_Left(size);
@@ -278,7 +278,7 @@ Utf16String DataChunkInput::Read_UnicodeString()
     char16_t ch;
     Utf16String string;
 
-    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= sizeof(size), "Read past end of chunk reading AsciiString length.\n");
+    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= sizeof(size), "Read past end of chunk reading Utf8String length.\n");
 
     m_file->Read(&size, sizeof(size));
     Decrement_Data_Left(sizeof(size));
@@ -308,7 +308,7 @@ Dict DataChunkInput::Read_Dict()
 {
     uint16_t size = 0;
 
-    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= sizeof(size), "Read past end of chunk reading AsciiString length.\n");
+    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= sizeof(size), "Read past end of chunk reading Utf8String length.\n");
 
     m_file->Read(&size, sizeof(size));
     Decrement_Data_Left(sizeof(size));
@@ -352,7 +352,7 @@ Dict DataChunkInput::Read_Dict()
  */
 void DataChunkInput::Read_Byte_Array(uint8_t *ptr, int length)
 {
-    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= length, "Read past end of chunk reading AsciiString string.\n");
+    DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= length, "Read past end of chunk reading Utf8String string.\n");
 
     m_file->Read(ptr, length);
     Decrement_Data_Left(length);

--- a/src/game/common/system/datachunk.cpp
+++ b/src/game/common/system/datachunk.cpp
@@ -272,11 +272,11 @@ AsciiString DataChunkInput::Read_AsciiString()
 /**
  * @brief Reads a UCS-16 string from the chunk.
  */
-UnicodeString DataChunkInput::Read_UnicodeString()
+Utf16String DataChunkInput::Read_UnicodeString()
 {
     uint16_t size;
     char16_t ch;
-    UnicodeString string;
+    Utf16String string;
 
     DEBUG_ASSERT_PRINT(m_chunkStack->data_left >= sizeof(size), "Read past end of chunk reading AsciiString length.\n");
 
@@ -285,7 +285,7 @@ UnicodeString DataChunkInput::Read_UnicodeString()
     size = le16toh(size);
 
     DEBUG_ASSERT_PRINT(
-        m_chunkStack->data_left >= int(sizeof(ch) * size), "Read past end of chunk reading UnicodeString string.\n");
+        m_chunkStack->data_left >= int(sizeof(ch) * size), "Read past end of chunk reading Utf16String string.\n");
 
     // Data is stored as LE UCS-16, so only BMP unicode chars can be stored.
     // TODO revamp unicode handling for none windows systems using libicu or libiconv.

--- a/src/game/common/system/datachunk.h
+++ b/src/game/common/system/datachunk.h
@@ -27,8 +27,8 @@
 
 struct DataChunkInfo
 {
-    AsciiString label;
-    AsciiString parent_label;
+    Utf8String label;
+    Utf8String parent_label;
     uint16_t version;
     int data_size;
 };
@@ -55,8 +55,8 @@ class DataChunkInput
 
         UserParser *next;
         bool (*parser)(DataChunkInput &, DataChunkInfo *, void *);
-        AsciiString label;
-        AsciiString parent_label;
+        Utf8String label;
+        Utf8String parent_label;
         void *user_data;
     };
 
@@ -64,23 +64,23 @@ public:
     DataChunkInput(ChunkInputStream *stream);
     ~DataChunkInput();
 
-    void Register_Parser(const AsciiString &label, const AsciiString &parent_label,
+    void Register_Parser(const Utf8String &label, const Utf8String &parent_label,
         bool (*parser)(DataChunkInput &, DataChunkInfo *, void *), void *user_data);
     bool Parse(void *user_data);
     bool Is_Valid_File() { return m_contents.Header_Opened(); }
-    AsciiString Open_Data_Chunk(uint16_t *version);
+    Utf8String Open_Data_Chunk(uint16_t *version);
     void Close_Data_Chunk();
     bool At_End_Of_File() { return m_file->Eof(); }
     bool At_End_Of_Chunk() { return m_chunkStack != nullptr ? m_chunkStack->data_left <= 0 : true; }
     void Reset();
-    AsciiString Get_Chunk_Label();
+    Utf8String Get_Chunk_Label();
     uint16_t Get_Chunk_Version() { return m_chunkStack != nullptr ? m_chunkStack->version : 0; }
     int Get_Chunk_Data_Size() { return m_chunkStack != nullptr ? m_chunkStack->data_size : 0; }
     int Get_Chunk_Data_Left() { return m_chunkStack != nullptr ? m_chunkStack->data_left : 0; }
     float Read_Real32();
     int32_t Read_Int32();
     uint8_t Read_Byte();
-    AsciiString Read_AsciiString();
+    Utf8String Read_AsciiString();
     Utf16String Read_UnicodeString();
     Dict Read_Dict();
     void Read_Byte_Array(uint8_t *ptr, int length);

--- a/src/game/common/system/datachunk.h
+++ b/src/game/common/system/datachunk.h
@@ -81,7 +81,7 @@ public:
     int32_t Read_Int32();
     uint8_t Read_Byte();
     AsciiString Read_AsciiString();
-    UnicodeString Read_UnicodeString();
+    Utf16String Read_UnicodeString();
     Dict Read_Dict();
     void Read_Byte_Array(uint8_t *ptr, int length);
     NameKeyType Read_Name_Key();

--- a/src/game/common/system/datachunktoc.cpp
+++ b/src/game/common/system/datachunktoc.cpp
@@ -34,7 +34,7 @@ DataChunkTableOfContents::~DataChunkTableOfContents()
 /**
  * @brief Get the ID of an entry with the given name.
  */
-unsigned DataChunkTableOfContents::Get_ID(const AsciiString &name)
+unsigned DataChunkTableOfContents::Get_ID(const Utf8String &name)
 {
     Mapping *map = Find_Mapping(name);
 
@@ -50,7 +50,7 @@ unsigned DataChunkTableOfContents::Get_ID(const AsciiString &name)
 /**
  * @brief Get the name of an entry with the given ID.
  */
-AsciiString DataChunkTableOfContents::Get_Name(unsigned id)
+Utf8String DataChunkTableOfContents::Get_Name(unsigned id)
 {
     Mapping *map = m_list;
 
@@ -64,13 +64,13 @@ AsciiString DataChunkTableOfContents::Get_Name(unsigned id)
 
     DEBUG_LOG("ID '%u' not found trying to get name from DataChunk TOC.\n", id);
 
-    return AsciiString::s_emptyString;
+    return Utf8String::s_emptyString;
 }
 
 /**
  * @brief Get the ID of an entry with the given name or create it if it doesn't exist.
  */
-unsigned DataChunkTableOfContents::Allocate_ID(const AsciiString &name)
+unsigned DataChunkTableOfContents::Allocate_ID(const Utf8String &name)
 {
     Mapping *map = Find_Mapping(name);
 
@@ -158,7 +158,7 @@ void DataChunkTableOfContents::Write(OutputStream &stream)
 /**
  * @brief Find the Mapping entry corresponding to the given name.
  */
-DataChunkTableOfContents::Mapping *DataChunkTableOfContents::Find_Mapping(const AsciiString &name)
+DataChunkTableOfContents::Mapping *DataChunkTableOfContents::Find_Mapping(const Utf8String &name)
 {
     Mapping *map = m_list;
 

--- a/src/game/common/system/datachunktoc.h
+++ b/src/game/common/system/datachunktoc.h
@@ -35,7 +35,7 @@ class DataChunkTableOfContents
 
     private:
         Mapping *m_next;
-        AsciiString m_name;
+        Utf8String m_name;
         unsigned m_id;
     };
 
@@ -43,15 +43,15 @@ public:
     DataChunkTableOfContents() : m_list(nullptr), m_listLength(0), m_nextID(1), m_headerOpened(false) {}
     ~DataChunkTableOfContents();
 
-    unsigned Get_ID(const AsciiString &name);
-    AsciiString Get_Name(unsigned id);
-    unsigned Allocate_ID(const AsciiString &name);
+    unsigned Get_ID(const Utf8String &name);
+    Utf8String Get_Name(unsigned id);
+    unsigned Allocate_ID(const Utf8String &name);
     void Read(ChunkInputStream &stream);
     void Write(OutputStream &stream);
     bool Header_Opened() { return m_headerOpened; }
 
 private:
-    Mapping *Find_Mapping(const AsciiString &name);
+    Mapping *Find_Mapping(const Utf8String &name);
 
 private:
     Mapping *m_list;

--- a/src/game/common/system/file.h
+++ b/src/game/common/system/file.h
@@ -59,7 +59,7 @@ public:
     virtual void Next_Line(char *dst, int bytes) = 0;
     virtual bool Scan_Int(int &integer) = 0;
     virtual bool Scan_Real(float &real) = 0;
-    virtual bool Scan_String(AsciiString &string) = 0;
+    virtual bool Scan_String(Utf8String &string) = 0;
     virtual bool Print(const char *format, ...);
     virtual int Size();
     virtual int Position();
@@ -67,7 +67,7 @@ public:
     virtual void *Read_All_And_Close() = 0;
     virtual File *Convert_To_RAM() = 0;
 
-    AsciiString &Get_File_Name() { return m_filename; }
+    Utf8String &Get_File_Name() { return m_filename; }
     int Get_File_Mode() { return m_openMode; }
     void Set_Del_On_Close(bool del) { m_deleteOnClose = del; }
 
@@ -75,7 +75,7 @@ protected:
     File() : m_filename("<no file>"), m_openMode(0), m_access(false), m_deleteOnClose(false) {}
 
 protected:
-    AsciiString m_filename;
+    Utf8String m_filename;
     int m_openMode;
     bool m_access;
     bool m_deleteOnClose;

--- a/src/game/common/system/filesystem.cpp
+++ b/src/game/common/system/filesystem.cpp
@@ -84,14 +84,14 @@ bool FileSystem::Does_File_Exist(const char *filename)
     return false;
 }
 
-void FileSystem::Get_File_List_From_Dir(AsciiString const &dir, AsciiString const &filter,
-    std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdirs)
+void FileSystem::Get_File_List_From_Dir(Utf8String const &dir, Utf8String const &filter,
+    std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdirs)
 {
     g_theLocalFileSystem->Get_File_List_From_Dir("", dir, filter, filelist, search_subdirs);
     g_theArchiveFileSystem->Get_File_List_From_Dir("", dir, filter, filelist, search_subdirs);
 }
 
-bool FileSystem::Create_Dir(AsciiString name)
+bool FileSystem::Create_Dir(Utf8String name)
 {
     if (g_theLocalFileSystem == nullptr) {
         return false;

--- a/src/game/common/system/filesystem.h
+++ b/src/game/common/system/filesystem.h
@@ -39,10 +39,10 @@ public:
     // Filesystem
     File *Open(const char *filename, int mode);
     bool Does_File_Exist(const char *filename);
-    void Get_File_List_From_Dir(AsciiString const &dir, AsciiString const &filter,
-        std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool a5);
+    void Get_File_List_From_Dir(Utf8String const &dir, Utf8String const &filter,
+        std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool a5);
 
-    static bool Create_Dir(AsciiString name);
+    static bool Create_Dir(Utf8String name);
     static bool Are_Music_Files_On_CD();
     static bool Load_Music_Files_From_CD();
     static void Unload_Music_Files_From_CD();

--- a/src/game/common/system/gamestate.cpp
+++ b/src/game/common/system/gamestate.cpp
@@ -34,18 +34,18 @@ void GameState::Reset() {}
 
 void GameState::Xfer_Snapshot(Xfer *xfer) {}
 
-AsciiString GameState::Get_Save_Dir()
+Utf8String GameState::Get_Save_Dir()
 {
-    AsciiString ret = g_theWriteableGlobalData->m_userDataDirectory;
+    Utf8String ret = g_theWriteableGlobalData->m_userDataDirectory;
     ret += "Save/";
 
     return ret;
 }
 
-AsciiString GameState::Real_To_Portable_Map_Path(const AsciiString &path)
+Utf8String GameState::Real_To_Portable_Map_Path(const Utf8String &path)
 {
-    AsciiString ret;
-    AsciiString ppath = path.Posix_Path();
+    Utf8String ret;
+    Utf8String ppath = path.Posix_Path();
 
     DEBUG_LOG("'%s' to portable:\n", path.Str());
 
@@ -72,9 +72,9 @@ AsciiString GameState::Real_To_Portable_Map_Path(const AsciiString &path)
     return ret.Windows_Path();
 }
 
-AsciiString GameState::Portable_To_Real_Map_Path(const AsciiString &path)
+Utf8String GameState::Portable_To_Real_Map_Path(const Utf8String &path)
 {
-    AsciiString ret;
+    Utf8String ret;
 
     DEBUG_LOG("'%s' to real:\n", path.Str());
 
@@ -100,7 +100,7 @@ AsciiString GameState::Portable_To_Real_Map_Path(const AsciiString &path)
 }
 
 // Returns file and last two containing directories from path in the form "path/to/file"
-AsciiString Get_Leaf_And_Dir_Name(const AsciiString &path)
+Utf8String Get_Leaf_And_Dir_Name(const Utf8String &path)
 {
     int len = path.Get_Length();
     const char *str = path.Str();
@@ -134,5 +134,5 @@ AsciiString Get_Leaf_And_Dir_Name(const AsciiString &path)
         return path;
     }
 
-    return AsciiString(++leaf);
+    return Utf8String(++leaf);
 }

--- a/src/game/common/system/gamestate.h
+++ b/src/game/common/system/gamestate.h
@@ -40,9 +40,9 @@ public:
     virtual void Xfer_Snapshot(Xfer *xfer);
     virtual void Load_Post_Process() {}
 
-    AsciiString Get_Save_Dir();
-    AsciiString Real_To_Portable_Map_Path(const AsciiString &path);
-    AsciiString Portable_To_Real_Map_Path(const AsciiString &path);
+    Utf8String Get_Save_Dir();
+    Utf8String Real_To_Portable_Map_Path(const Utf8String &path);
+    Utf8String Portable_To_Real_Map_Path(const Utf8String &path);
 
 #ifndef THYME_STANDALONE
     static void Hook_Me();
@@ -50,7 +50,7 @@ public:
 private:
 };
 
-AsciiString Get_Leaf_And_Dir_Name(const AsciiString &path);
+Utf8String Get_Leaf_And_Dir_Name(const Utf8String &path);
 
 #ifndef THYME_STANDALONE
 extern GameState *&g_theGameState;

--- a/src/game/common/system/localfilesystem.h
+++ b/src/game/common/system/localfilesystem.h
@@ -32,10 +32,10 @@ public:
 
     virtual File *Open_File(const char *filename, int mode) = 0;
     virtual bool Does_File_Exist(const char *filename) = 0;
-    virtual void Get_File_List_From_Dir(AsciiString const &subdir, AsciiString const &dirpath, AsciiString const &filter,
-        std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdirs) = 0;
-    virtual bool Get_File_Info(AsciiString const &filename, FileInfo *info) = 0;
-    virtual bool Create_Directory(AsciiString) = 0;
+    virtual void Get_File_List_From_Dir(Utf8String const &subdir, Utf8String const &dirpath, Utf8String const &filter,
+        std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdirs) = 0;
+    virtual bool Get_File_Info(Utf8String const &filename, FileInfo *info) = 0;
+    virtual bool Create_Directory(Utf8String) = 0;
 };
 
 #ifndef THYME_STANDALONE

--- a/src/game/common/system/ramfile.cpp
+++ b/src/game/common/system/ramfile.cpp
@@ -141,7 +141,7 @@ void RAMFile::Next_Line(char *dst, int bytes)
 bool RAMFile::Scan_Int(int &integer)
 {
     char tmp;
-    AsciiString number;
+    Utf8String number;
 
     integer = 0;
 
@@ -179,7 +179,7 @@ bool RAMFile::Scan_Int(int &integer)
 bool RAMFile::Scan_Real(float &real)
 {
     char tmp;
-    AsciiString number;
+    Utf8String number;
 
     real = 0.0f;
 
@@ -221,7 +221,7 @@ bool RAMFile::Scan_Real(float &real)
     return true;
 }
 
-bool RAMFile::Scan_String(AsciiString &string)
+bool RAMFile::Scan_String(Utf8String &string)
 {
     string.Clear();
 
@@ -239,7 +239,7 @@ bool RAMFile::Scan_String(AsciiString &string)
         return false;
     }
 
-    // Read into AsciiString
+    // Read into Utf8String
     for (; Pos < Size; ++Pos) {
         if (isspace(Data[Pos])) {
             break;
@@ -296,7 +296,7 @@ bool RAMFile::Open(File *file)
     return false;
 }
 
-bool RAMFile::Open_From_Archive(File *file, AsciiString const &name, int pos, int size)
+bool RAMFile::Open_From_Archive(File *file, Utf8String const &name, int pos, int size)
 {
     if (file == nullptr) {
         return false;

--- a/src/game/common/system/ramfile.h
+++ b/src/game/common/system/ramfile.h
@@ -32,12 +32,12 @@ public:
     virtual void Next_Line(char *dst, int bytes) override;
     virtual bool Scan_Int(int &integer) override;
     virtual bool Scan_Real(float &real) override;
-    virtual bool Scan_String(AsciiString &string) override;
+    virtual bool Scan_String(Utf8String &string) override;
 
     virtual void *Read_All_And_Close() override;
     virtual RAMFile *Convert_To_RAM() override { return this; }
     virtual bool Open(File *file);
-    virtual bool Open_From_Archive(File *file, AsciiString const &name, int pos, int size);
+    virtual bool Open_From_Archive(File *file, Utf8String const &name, int pos, int size);
     virtual bool Copy_To_File(File *file);
 
 protected:

--- a/src/game/common/system/stackdump.cpp
+++ b/src/game/common/system/stackdump.cpp
@@ -20,9 +20,9 @@
 #include <stdio.h>
 
 #ifndef THYME_STANDALONE
-AsciiString &g_exceptionFileBuffer = Make_Global<AsciiString>(0x00A29FB8);
+Utf8String &g_exceptionFileBuffer = Make_Global<Utf8String>(0x00A29FB8);
 #else
-AsciiString g_exceptionFileBuffer;
+Utf8String g_exceptionFileBuffer;
 #endif
 
 #ifdef PLATFORM_WINDOWS
@@ -287,7 +287,7 @@ void Stack_Dump_Handler(const char *data)
 
 void Dump_Exception_Info(unsigned int u, struct _EXCEPTION_POINTERS *e_info)
 {
-    AsciiString tmp;
+    Utf8String tmp;
     g_exceptionFileBuffer.Clear();
     unsigned int e_code = e_info->ExceptionRecord->ExceptionCode;
 

--- a/src/game/common/system/stackdump.h
+++ b/src/game/common/system/stackdump.h
@@ -32,7 +32,7 @@ void Make_Stack_Trace(uintptr_t myeip, uintptr_t myesp, uintptr_t myebp, int ski
 #ifndef THYME_STANDALONE
 #include "hooker.h"
 
-extern AsciiString &g_exceptionFileBuffer;
+extern Utf8String &g_exceptionFileBuffer;
 #else
-extern AsciiString g_exceptionFileBuffer;
+extern Utf8String g_exceptionFileBuffer;
 #endif

--- a/src/game/common/system/streamingarchivefile.cpp
+++ b/src/game/common/system/streamingarchivefile.cpp
@@ -97,7 +97,7 @@ bool StreamingArchiveFile::Scan_Real(float &real)
     return false;
 }
 
-bool StreamingArchiveFile::Scan_String(AsciiString &string)
+bool StreamingArchiveFile::Scan_String(Utf8String &string)
 {
     return false;
 }
@@ -112,7 +112,7 @@ bool StreamingArchiveFile::Open(File *file)
     return true;
 }
 
-bool StreamingArchiveFile::Open_From_Archive(File *file, AsciiString const &name, int pos, int size)
+bool StreamingArchiveFile::Open_From_Archive(File *file, Utf8String const &name, int pos, int size)
 {
     if (file == nullptr || !File::Open(name.Str(), READ | BINARY | STREAMING)) {
         return false;

--- a/src/game/common/system/streamingarchivefile.h
+++ b/src/game/common/system/streamingarchivefile.h
@@ -33,12 +33,12 @@ public:
     virtual void Next_Line(char *dst, int bytes) override;
     virtual bool Scan_Int(int &integer) override;
     virtual bool Scan_Real(float &real) override;
-    virtual bool Scan_String(AsciiString &string) override;
+    virtual bool Scan_String(Utf8String &string) override;
 
     virtual void *Read_All_And_Close() override;
     virtual RAMFile *Convert_To_RAM() override { return this; }
     virtual bool Open(File *file) override;
-    virtual bool Open_From_Archive(File *file, AsciiString const &name, int pos, int size) override;
+    virtual bool Open_From_Archive(File *file, Utf8String const &name, int pos, int size) override;
     virtual bool Copy_To_File(File *file) override { return false; }
 
 protected:

--- a/src/game/common/system/subsysteminterface.cpp
+++ b/src/game/common/system/subsysteminterface.cpp
@@ -26,7 +26,7 @@ SubsystemInterfaceList *g_theSubsystemList = nullptr;
 ////////////
 // Interface
 ////////////
-void SubsystemInterface::Set_Name(AsciiString name)
+void SubsystemInterface::Set_Name(Utf8String name)
 {
     m_subsystemName = name;
 }
@@ -35,7 +35,7 @@ void SubsystemInterface::Set_Name(AsciiString name)
 // Interface List
 /////////////////
 void SubsystemInterfaceList::Init_Subsystem(SubsystemInterface *sys, const char *default_ini_path, const char *ini_path,
-    const char *dir_path, Xfer *xfer, AsciiString sys_name)
+    const char *dir_path, Xfer *xfer, Utf8String sys_name)
 {
     INI ini;
 

--- a/src/game/common/system/subsysteminterface.h
+++ b/src/game/common/system/subsysteminterface.h
@@ -36,10 +36,10 @@ public:
     virtual void Update() = 0;
     virtual void Draw() {}
 
-    void Set_Name(AsciiString name); // Needs confirming.
+    void Set_Name(Utf8String name); // Needs confirming.
 
 private:
-    AsciiString m_subsystemName; // Needs confirming.
+    Utf8String m_subsystemName; // Needs confirming.
 };
 
 class SubsystemInterfaceList
@@ -48,7 +48,7 @@ public:
     SubsystemInterfaceList() : m_subsystems(), m_unksubsystems() {}
 
     void Init_Subsystem(SubsystemInterface *sys, const char *default_ini_path, const char *ini_path, const char *dir_path,
-        Xfer *xfer, AsciiString sys_name);
+        Xfer *xfer, Utf8String sys_name);
     void Post_Process_Load_All();
     void Reset_All();
     void Shutdown_All();

--- a/src/game/common/system/unicodestring.cpp
+++ b/src/game/common/system/unicodestring.cpp
@@ -198,7 +198,7 @@ void Utf16String::Set(Utf16String const &string)
     }
 }
 
-void Utf16String::Translate(AsciiString const &string)
+void Utf16String::Translate(Utf8String const &string)
 {
     Release_Buffer();
 
@@ -427,7 +427,7 @@ bool Utf16String::Next_Token(Utf16String *tok, Utf16String delims)
         return false;
     }
 
-    // Copy found region into provided AsciiString, then move this string
+    // Copy found region into provided Utf8String, then move this string
     // to start of next section.
     unichar_t *tokstr = tok->Get_Buffer_For_Read(end - start + 1);
     memcpy(tokstr, start, end - start);

--- a/src/game/common/system/unicodestring.cpp
+++ b/src/game/common/system/unicodestring.cpp
@@ -29,9 +29,9 @@ SimpleCriticalSectionClass *&g_unicodeStringCriticalSection = Make_Global<Simple
 SimpleCriticalSectionClass *g_unicodeStringCriticalSection = nullptr;
 #endif
 
-UnicodeString const UnicodeString::EmptyString;
+Utf16String const Utf16String::EmptyString;
 
-UnicodeString::UnicodeString(const unichar_t *s) : m_data(nullptr)
+Utf16String::Utf16String(const unichar_t *s) : m_data(nullptr)
 {
     if (s != nullptr) {
         size_t len = u_strlen(s);
@@ -42,7 +42,7 @@ UnicodeString::UnicodeString(const unichar_t *s) : m_data(nullptr)
     }
 }
 
-UnicodeString::UnicodeString(UnicodeString const &string) : m_data(string.m_data)
+Utf16String::Utf16String(Utf16String const &string) : m_data(string.m_data)
 {
     ScopedCriticalSectionClass cs(g_unicodeStringCriticalSection);
 
@@ -51,14 +51,14 @@ UnicodeString::UnicodeString(UnicodeString const &string) : m_data(string.m_data
     }
 }
 
-UnicodeString::~UnicodeString()
+Utf16String::~Utf16String()
 {
     Release_Buffer();
 }
 
-void UnicodeString::Validate() {}
+void Utf16String::Validate() {}
 
-unichar_t *UnicodeString::Peek() const
+unichar_t *Utf16String::Peek() const
 {
     ASSERT_PRINT(m_data != nullptr, "null string ptr");
 
@@ -66,7 +66,7 @@ unichar_t *UnicodeString::Peek() const
     return m_data->Peek();
 }
 
-void UnicodeString::Release_Buffer()
+void Utf16String::Release_Buffer()
 {
     ScopedCriticalSectionClass cs(g_unicodeStringCriticalSection);
 
@@ -79,7 +79,7 @@ void UnicodeString::Release_Buffer()
     }
 }
 
-void UnicodeString::Ensure_Unique_Buffer_Of_Size(
+void Utf16String::Ensure_Unique_Buffer_Of_Size(
     int chars_needed, bool keep_data, const unichar_t *str_to_cpy, const unichar_t *str_to_cat)
 {
     if (m_data != nullptr && m_data->ref_count == 1 && m_data->num_chars_allocated >= chars_needed) {
@@ -128,7 +128,7 @@ void UnicodeString::Ensure_Unique_Buffer_Of_Size(
     }
 }
 
-int UnicodeString::Get_Length() const
+int Utf16String::Get_Length() const
 {
     if (m_data != nullptr) {
         return u_strlen(m_data->Peek());
@@ -137,12 +137,12 @@ int UnicodeString::Get_Length() const
     return 0;
 }
 
-void UnicodeString::Clear()
+void Utf16String::Clear()
 {
     Release_Buffer();
 }
 
-unichar_t UnicodeString::Get_Char(int index) const
+unichar_t Utf16String::Get_Char(int index) const
 {
     if (m_data != nullptr) {
         return m_data->Peek()[index];
@@ -151,7 +151,7 @@ unichar_t UnicodeString::Get_Char(int index) const
     return u'\0';
 }
 
-const unichar_t *UnicodeString::Str() const
+const unichar_t *Utf16String::Str() const
 {
     static const unichar_t *TheNullChr = (const unichar_t *)u"";
 
@@ -162,7 +162,7 @@ const unichar_t *UnicodeString::Str() const
     return TheNullChr;
 }
 
-unichar_t *UnicodeString::Get_Buffer_For_Read(int len)
+unichar_t *Utf16String::Get_Buffer_For_Read(int len)
 {
     ASSERT_PRINT(len > 0, "No need to allocate 0 len strings.");
 
@@ -171,7 +171,7 @@ unichar_t *UnicodeString::Get_Buffer_For_Read(int len)
     return Peek();
 }
 
-void UnicodeString::Set(const unichar_t *s)
+void Utf16String::Set(const unichar_t *s)
 {
     if (m_data != nullptr || s != m_data->Peek()) {
         size_t len;
@@ -184,7 +184,7 @@ void UnicodeString::Set(const unichar_t *s)
     }
 }
 
-void UnicodeString::Set(UnicodeString const &string)
+void Utf16String::Set(Utf16String const &string)
 {
     ScopedCriticalSectionClass cs(g_unicodeStringCriticalSection);
 
@@ -198,7 +198,7 @@ void UnicodeString::Set(UnicodeString const &string)
     }
 }
 
-void UnicodeString::Translate(AsciiString const &string)
+void Utf16String::Translate(AsciiString const &string)
 {
     Release_Buffer();
 
@@ -217,7 +217,7 @@ void UnicodeString::Translate(AsciiString const &string)
     }
 }
 
-void UnicodeString::Translate(const char *string)
+void Utf16String::Translate(const char *string)
 {
     Release_Buffer();
 
@@ -256,7 +256,7 @@ void UnicodeString::Translate(const char *string)
 #endif
 }
 
-void UnicodeString::Concat(unichar_t c)
+void Utf16String::Concat(unichar_t c)
 {
     unichar_t str[2];
 
@@ -265,7 +265,7 @@ void UnicodeString::Concat(unichar_t c)
     Concat(str);
 }
 
-void UnicodeString::Concat(const unichar_t *s)
+void Utf16String::Concat(const unichar_t *s)
 {
     size_t len = u_strlen(s);
 
@@ -278,7 +278,7 @@ void UnicodeString::Concat(const unichar_t *s)
     }
 }
 
-void UnicodeString::Trim()
+void Utf16String::Trim()
 {
     // No string, no Trim.
     if (m_data == nullptr) {
@@ -313,7 +313,7 @@ void UnicodeString::Trim()
     }
 }
 
-void UnicodeString::To_Lower()
+void Utf16String::To_Lower()
 {
     unichar_t buf[MAX_FORMAT_BUF_LEN];
 
@@ -331,7 +331,7 @@ void UnicodeString::To_Lower()
     Set(buf);
 }
 
-void UnicodeString::Remove_Last_Char()
+void Utf16String::Remove_Last_Char()
 {
     if (m_data == nullptr) {
         return;
@@ -345,7 +345,7 @@ void UnicodeString::Remove_Last_Char()
     }
 }
 
-void UnicodeString::Format(const unichar_t *format, ...)
+void Utf16String::Format(const unichar_t *format, ...)
 {
     va_list va;
 
@@ -353,7 +353,7 @@ void UnicodeString::Format(const unichar_t *format, ...)
     Format_VA(format, va);
 }
 
-void UnicodeString::Format(UnicodeString format, ...)
+void Utf16String::Format(Utf16String format, ...)
 {
     va_list va;
 
@@ -361,7 +361,7 @@ void UnicodeString::Format(UnicodeString format, ...)
     Format_VA(format, va);
 }
 
-void UnicodeString::Format_VA(const unichar_t *format, va_list args)
+void Utf16String::Format_VA(const unichar_t *format, va_list args)
 {
     unichar_t buf[MAX_FORMAT_BUF_LEN];
 
@@ -370,7 +370,7 @@ void UnicodeString::Format_VA(const unichar_t *format, va_list args)
     Set(buf);
 }
 
-void UnicodeString::Format_VA(UnicodeString &format, va_list args)
+void Utf16String::Format_VA(Utf16String &format, va_list args)
 {
     unichar_t buf[MAX_FORMAT_BUF_LEN];
 
@@ -379,7 +379,7 @@ void UnicodeString::Format_VA(UnicodeString &format, va_list args)
     Set(buf);
 }
 
-bool UnicodeString::Next_Token(UnicodeString *tok, UnicodeString delims)
+bool Utf16String::Next_Token(Utf16String *tok, Utf16String delims)
 {
     if (m_data == nullptr) {
         return false;

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -27,12 +27,12 @@
 #error Support for utf16<->utf8 conversion not found for this platform.
 #endif
 
-class AsciiString;
+class Utf8String;
 
 class Utf16String
 {
 public:
-    friend class AsciiString;
+    friend class Utf8String;
 
     enum
     {
@@ -60,7 +60,7 @@ public:
     Utf16String() : m_data(nullptr) {}
     Utf16String(const unichar_t *s);
     Utf16String(Utf16String const &string);
-    // Utf16String(AsciiString const &string);
+    // Utf16String(Utf8String const &string);
     ~Utf16String();
 
     Utf16String &operator=(const unichar_t *s)
@@ -75,7 +75,7 @@ public:
         return *this;
     }
 
-    Utf16String &operator=(AsciiString const &string)
+    Utf16String &operator=(Utf8String const &string)
     {
         Translate(string);
         return *this;
@@ -87,7 +87,7 @@ public:
         return *this;
     }
 
-    // Utf16String &operator=(AsciiString const &string) { Set(string); return *this; }
+    // Utf16String &operator=(Utf8String const &string) { Set(string); return *this; }
 
     Utf16String &operator+=(unichar_t s)
     {
@@ -106,7 +106,7 @@ public:
         Concat(s);
         return *this;
     }
-    // Utf16String &operator+=(AsciiString const &string);
+    // Utf16String &operator+=(Utf8String const &string);
 
     operator const unichar_t *() const { return Str(); }
 
@@ -126,7 +126,7 @@ public:
     void Set(const unichar_t *s);
     void Set(Utf16String const &string);
 
-    void Translate(AsciiString const &string);
+    void Translate(Utf8String const &string);
     void Translate(const char *string);
 
     void Concat(unichar_t c);

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -20,7 +20,6 @@
 
 #ifdef THYME_USE_ICU
 #include <unicode/ustring.h>
-#include <unicode/stringoptions.h>
 #include <unicode/ustdio.h>
 
 #elif defined PLATFORM_WINDOWS

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -162,63 +162,27 @@ public:
     bool Is_Not_Empty() { return !Is_Empty(); }
     bool Is_Not_None() { return !Is_None(); }
 
+    friend bool operator==(UnicodeString const &left, UnicodeString const &right) { return left.Compare(right) == 0; }
+    friend bool operator==(UnicodeString const &left, const unichar_t *right) { return left.Compare(right) == 0; }
+    friend bool operator==(const unichar_t *left, UnicodeString const &right) { return right.Compare(left) == 0; }
+
+    friend bool operator!=(UnicodeString const &left, UnicodeString const &right) { return left.Compare(right) != 0; }
+    friend bool operator!=(UnicodeString const &left, const unichar_t *right) { return left.Compare(right) != 0; }
+    friend bool operator!=(const unichar_t *left, UnicodeString const &right) { return right.Compare(left) != 0; }
+
+    friend bool operator<(UnicodeString const &left, UnicodeString const &right) { return left.Compare(right) < 0; }
+    friend bool operator<(UnicodeString const &left, const unichar_t *right) { return left.Compare(right) < 0; }
+    friend bool operator<(const unichar_t *left, UnicodeString const &right) { return right.Compare(left) < 0; }
+
+    friend bool operator>(UnicodeString const &left, UnicodeString const &right) { return left.Compare(right) > 0; }
+    friend bool operator>(UnicodeString const &left, const unichar_t *right) { return left.Compare(right) > 0; }
+    friend bool operator>(const unichar_t *left, UnicodeString const &right) { return right.Compare(left) > 0; }
+
 private:
     static UnicodeString const EmptyString;
 
     UnicodeStringData *m_data;
 };
-
-inline bool operator==(UnicodeString const &left, UnicodeString const &right)
-{
-    return left.Compare(right) == 0;
-}
-inline bool operator==(UnicodeString const &left, const unichar_t *right)
-{
-    return left.Compare(right) == 0;
-}
-inline bool operator==(const unichar_t *left, UnicodeString const &right)
-{
-    return right.Compare(left) == 0;
-}
-
-inline bool operator!=(UnicodeString const &left, UnicodeString const &right)
-{
-    return left.Compare(right) != 0;
-}
-inline bool operator!=(UnicodeString const &left, const unichar_t *right)
-{
-    return left.Compare(right) != 0;
-}
-inline bool operator!=(const unichar_t *left, UnicodeString const &right)
-{
-    return right.Compare(left) != 0;
-}
-
-inline bool operator<(UnicodeString const &left, UnicodeString const &right)
-{
-    return left.Compare(right) < 0;
-}
-inline bool operator<(UnicodeString const &left, const unichar_t *right)
-{
-    return left.Compare(right) < 0;
-}
-inline bool operator<(const unichar_t *left, UnicodeString const &right)
-{
-    return right.Compare(left) < 0;
-}
-
-inline bool operator>(UnicodeString const &left, UnicodeString const &right)
-{
-    return left.Compare(right) > 0;
-}
-inline bool operator>(UnicodeString const &left, const unichar_t *right)
-{
-    return left.Compare(right) > 0;
-}
-inline bool operator>(const unichar_t *left, UnicodeString const &right)
-{
-    return right.Compare(left) > 0;
-}
 
 #ifndef THYME_STANDALONE
 extern SimpleCriticalSectionClass *&g_unicodeStringCriticalSection;

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -21,7 +21,6 @@
 #ifdef THYME_USE_ICU
 #include <unicode/ustring.h>
 #include <unicode/ustdio.h>
-
 #elif defined PLATFORM_WINDOWS
 #include <wchar.h>
 #else

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -29,7 +29,7 @@
 
 class AsciiString;
 
-class UnicodeString
+class Utf16String
 {
 public:
     friend class AsciiString;
@@ -57,56 +57,56 @@ public:
         }
     };
 
-    UnicodeString() : m_data(nullptr) {}
-    UnicodeString(const unichar_t *s);
-    UnicodeString(UnicodeString const &string);
-    // UnicodeString(AsciiString const &string);
-    ~UnicodeString();
+    Utf16String() : m_data(nullptr) {}
+    Utf16String(const unichar_t *s);
+    Utf16String(Utf16String const &string);
+    // Utf16String(AsciiString const &string);
+    ~Utf16String();
 
-    UnicodeString &operator=(const unichar_t *s)
+    Utf16String &operator=(const unichar_t *s)
     {
         Set(s);
         return *this;
     }
 
-    UnicodeString &operator=(UnicodeString const &string)
+    Utf16String &operator=(Utf16String const &string)
     {
         Set(string);
         return *this;
     }
 
-    UnicodeString &operator=(AsciiString const &string)
+    Utf16String &operator=(AsciiString const &string)
     {
         Translate(string);
         return *this;
     }
 
-    UnicodeString &operator=(const char *s)
+    Utf16String &operator=(const char *s)
     {
         Translate(s);
         return *this;
     }
 
-    // UnicodeString &operator=(AsciiString const &string) { Set(string); return *this; }
+    // Utf16String &operator=(AsciiString const &string) { Set(string); return *this; }
 
-    UnicodeString &operator+=(unichar_t s)
+    Utf16String &operator+=(unichar_t s)
     {
         Concat(s);
         return *this;
     }
 
-    UnicodeString &operator+=(const unichar_t *s)
+    Utf16String &operator+=(const unichar_t *s)
     {
         Concat(s);
         return *this;
     }
 
-    UnicodeString &operator+=(UnicodeString const &s)
+    Utf16String &operator+=(Utf16String const &s)
     {
         Concat(s);
         return *this;
     }
-    // UnicodeString &operator+=(AsciiString const &string);
+    // Utf16String &operator+=(AsciiString const &string);
 
     operator const unichar_t *() const { return Str(); }
 
@@ -124,34 +124,34 @@ public:
     const unichar_t *Str() const;
     unichar_t *Get_Buffer_For_Read(int len);
     void Set(const unichar_t *s);
-    void Set(UnicodeString const &string);
+    void Set(Utf16String const &string);
 
     void Translate(AsciiString const &string);
     void Translate(const char *string);
 
     void Concat(unichar_t c);
     void Concat(const unichar_t *s);
-    void Concat(UnicodeString const &string) { Concat(string.Str()); }
+    void Concat(Utf16String const &string) { Concat(string.Str()); }
 
     void Trim();
     void To_Lower();
     void Remove_Last_Char();
 
     void Format(const unichar_t *format, ...);
-    void Format(UnicodeString format, ...);
+    void Format(Utf16String format, ...);
     void Format_VA(const unichar_t *format, va_list args);
-    void Format_VA(UnicodeString &format, va_list args);
+    void Format_VA(Utf16String &format, va_list args);
 
     int Compare(const unichar_t *s) const { return u_strcmp(Str(), s); };
-    int Compare(UnicodeString const &string) const { return u_strcmp(Str(), string.Str()); };
+    int Compare(Utf16String const &string) const { return u_strcmp(Str(), string.Str()); };
 
     int Compare_No_Case(const unichar_t *s) const { return u_strcasecmp(Str(), s, U_COMPARE_CODE_POINT_ORDER); };
-    int Compare_No_Case(UnicodeString const &string) const
+    int Compare_No_Case(Utf16String const &string) const
     {
         return u_strcasecmp(Str(), string.Str(), U_COMPARE_CODE_POINT_ORDER);
     };
 
-    bool Next_Token(UnicodeString *tok, UnicodeString delims);
+    bool Next_Token(Utf16String *tok, Utf16String delims);
 
     bool Is_None()
     {
@@ -161,24 +161,24 @@ public:
     bool Is_Not_Empty() { return !Is_Empty(); }
     bool Is_Not_None() { return !Is_None(); }
 
-    friend bool operator==(UnicodeString const &left, UnicodeString const &right) { return left.Compare(right) == 0; }
-    friend bool operator==(UnicodeString const &left, const unichar_t *right) { return left.Compare(right) == 0; }
-    friend bool operator==(const unichar_t *left, UnicodeString const &right) { return right.Compare(left) == 0; }
+    friend bool operator==(Utf16String const &left, Utf16String const &right) { return left.Compare(right) == 0; }
+    friend bool operator==(Utf16String const &left, const unichar_t *right) { return left.Compare(right) == 0; }
+    friend bool operator==(const unichar_t *left, Utf16String const &right) { return right.Compare(left) == 0; }
 
-    friend bool operator!=(UnicodeString const &left, UnicodeString const &right) { return left.Compare(right) != 0; }
-    friend bool operator!=(UnicodeString const &left, const unichar_t *right) { return left.Compare(right) != 0; }
-    friend bool operator!=(const unichar_t *left, UnicodeString const &right) { return right.Compare(left) != 0; }
+    friend bool operator!=(Utf16String const &left, Utf16String const &right) { return left.Compare(right) != 0; }
+    friend bool operator!=(Utf16String const &left, const unichar_t *right) { return left.Compare(right) != 0; }
+    friend bool operator!=(const unichar_t *left, Utf16String const &right) { return right.Compare(left) != 0; }
 
-    friend bool operator<(UnicodeString const &left, UnicodeString const &right) { return left.Compare(right) < 0; }
-    friend bool operator<(UnicodeString const &left, const unichar_t *right) { return left.Compare(right) < 0; }
-    friend bool operator<(const unichar_t *left, UnicodeString const &right) { return right.Compare(left) < 0; }
+    friend bool operator<(Utf16String const &left, Utf16String const &right) { return left.Compare(right) < 0; }
+    friend bool operator<(Utf16String const &left, const unichar_t *right) { return left.Compare(right) < 0; }
+    friend bool operator<(const unichar_t *left, Utf16String const &right) { return right.Compare(left) < 0; }
 
-    friend bool operator>(UnicodeString const &left, UnicodeString const &right) { return left.Compare(right) > 0; }
-    friend bool operator>(UnicodeString const &left, const unichar_t *right) { return left.Compare(right) > 0; }
-    friend bool operator>(const unichar_t *left, UnicodeString const &right) { return right.Compare(left) > 0; }
+    friend bool operator>(Utf16String const &left, Utf16String const &right) { return left.Compare(right) > 0; }
+    friend bool operator>(Utf16String const &left, const unichar_t *right) { return left.Compare(right) > 0; }
+    friend bool operator>(const unichar_t *left, Utf16String const &right) { return right.Compare(left) > 0; }
 
 private:
-    static UnicodeString const EmptyString;
+    static Utf16String const EmptyString;
 
     UnicodeStringData *m_data;
 };

--- a/src/game/common/system/xfer.cpp
+++ b/src/game/common/system/xfer.cpp
@@ -103,7 +103,7 @@ void Xfer::xferAsciiString(AsciiString *thing)
 
 void Xfer::xferUnicodeString(UnicodeString *thing)
 {
-    xferImplementation(const_cast<wchar_t *>(thing->Str()), thing->Get_Length() * 2);
+    xferImplementation(const_cast<unichar_t *>(thing->Str()), thing->Get_Length() * 2);
 }
 
 void Xfer::xferCoord3D(Coord3D *thing)

--- a/src/game/common/system/xfer.cpp
+++ b/src/game/common/system/xfer.cpp
@@ -18,7 +18,7 @@
 #include "matrix3d.h"
 #include "randomvalue.h"
 
-void Xfer::Open(AsciiString filename)
+void Xfer::Open(Utf8String filename)
 {
     m_filename = filename;
 }
@@ -91,12 +91,12 @@ void Xfer::xferReal(float *thing)
     *thing = temp.real;
 }
 
-void Xfer::xferMarkerLabel(AsciiString thing)
+void Xfer::xferMarkerLabel(Utf8String thing)
 {
     // Empty
 }
 
-void Xfer::xferAsciiString(AsciiString *thing)
+void Xfer::xferAsciiString(Utf8String *thing)
 {
     xferImplementation(const_cast<char *>(thing->Str()), thing->Get_Length());
 }
@@ -300,7 +300,7 @@ void Xfer::xferKindOf(KindOfType *thing)
     uint8_t ver = 1;
     xferVersion(&ver, 1);
 
-    AsciiString kind;
+    Utf8String kind;
     const char *kindc;
 
     switch (Get_Mode()) {
@@ -362,9 +362,9 @@ void Xfer::xferMatrix3D(Matrix3D *thing)
     xferReal(&(*thing)[2][3]);
 }
 
-void Xfer::xferMapName(AsciiString *thing)
+void Xfer::xferMapName(Utf8String *thing)
 {
-    AsciiString map;
+    Utf8String map;
 
     if (Get_Mode() == XFER_SAVE) {
         map = g_theGameState->Real_To_Portable_Map_Path(*thing);

--- a/src/game/common/system/xfer.cpp
+++ b/src/game/common/system/xfer.cpp
@@ -101,7 +101,7 @@ void Xfer::xferAsciiString(AsciiString *thing)
     xferImplementation(const_cast<char *>(thing->Str()), thing->Get_Length());
 }
 
-void Xfer::xferUnicodeString(UnicodeString *thing)
+void Xfer::xferUnicodeString(Utf16String *thing)
 {
     xferImplementation(const_cast<unichar_t *>(thing->Str()), thing->Get_Length() * 2);
 }

--- a/src/game/common/system/xfer.h
+++ b/src/game/common/system/xfer.h
@@ -74,7 +74,7 @@ public:
     virtual void xferReal(float *thing);
     virtual void xferMarkerLabel(AsciiString thing);
     virtual void xferAsciiString(AsciiString *thing);
-    virtual void xferUnicodeString(UnicodeString *thing);
+    virtual void xferUnicodeString(Utf16String *thing);
     virtual void xferCoord3D(Coord3D *thing);
     virtual void xferICoord3D(ICoord3D *thing);
     virtual void xferRegion3D(Region3D *thing);

--- a/src/game/common/system/xfer.h
+++ b/src/game/common/system/xfer.h
@@ -55,7 +55,7 @@ public:
     virtual void Clear_Options(unsigned options) { m_options &= ~options; }
     virtual unsigned Get_Options() { return m_options; }
 
-    virtual void Open(AsciiString filename);
+    virtual void Open(Utf8String filename);
     virtual void Close() = 0;
     virtual int Begin_Block() = 0;
     virtual void End_Block() = 0;
@@ -72,8 +72,8 @@ public:
     virtual void xferShort(int16_t *thing);
     virtual void xferUnsignedShort(uint16_t *thing);
     virtual void xferReal(float *thing);
-    virtual void xferMarkerLabel(AsciiString thing);
-    virtual void xferAsciiString(AsciiString *thing);
+    virtual void xferMarkerLabel(Utf8String thing);
+    virtual void xferAsciiString(Utf8String *thing);
     virtual void xferUnicodeString(Utf16String *thing);
     virtual void xferCoord3D(Coord3D *thing);
     virtual void xferICoord3D(ICoord3D *thing);
@@ -99,7 +99,7 @@ public:
     virtual void xferUpgradeMask(BitFlags<128> *thing);
     virtual void xferUser(void *thing, int size);
     virtual void xferMatrix3D(Matrix3D *thing);
-    virtual void xferMapName(AsciiString *thing);
+    virtual void xferMapName(Utf8String *thing);
     virtual void xferImplementation(void *thing, int size) = 0;
 
     void Xfer_Client_Random_Var(GameClientRandomVariable *thing);
@@ -108,7 +108,7 @@ public:
 protected:
     unsigned m_options;
     XferType m_type;
-    AsciiString m_filename;
+    Utf8String m_filename;
 };
 
 #ifndef THYME_STANDALONE

--- a/src/game/common/system/xfercrc.cpp
+++ b/src/game/common/system/xfercrc.cpp
@@ -21,7 +21,7 @@ void XferCRC::Add_CRC(uint32_t val)
     m_crc = htobe32(val) + (m_crc >> 31) + (m_crc << 1);
 }
 
-void XferCRC::Open(AsciiString filename)
+void XferCRC::Open(Utf8String filename)
 {
     Xfer::Open(filename);
     m_crc = 0;

--- a/src/game/common/system/xfercrc.h
+++ b/src/game/common/system/xfercrc.h
@@ -22,7 +22,7 @@ public:
     XferCRC() : m_crc(0) { m_type = XFER_CRC; }
     virtual ~XferCRC() {}
 
-    virtual void Open(AsciiString filename);
+    virtual void Open(Utf8String filename);
     virtual void Close() {}
     virtual int Begin_Block() { return 0; }
     virtual void End_Block() {}

--- a/src/game/common/terraintypes.cpp
+++ b/src/game/common/terraintypes.cpp
@@ -97,7 +97,7 @@ TerrainTypeCollection::~TerrainTypeCollection()
     }
 }
 
-TerrainType *TerrainTypeCollection::Find_Terrain(AsciiString name)
+TerrainType *TerrainTypeCollection::Find_Terrain(Utf8String name)
 {
     TerrainType *retval = m_terrainList;
 
@@ -113,7 +113,7 @@ TerrainType *TerrainTypeCollection::Find_Terrain(AsciiString name)
     return retval;
 }
 
-TerrainType *TerrainTypeCollection::New_Terrain(AsciiString name)
+TerrainType *TerrainTypeCollection::New_Terrain(Utf8String name)
 {
     TerrainType *retval = new TerrainType;
     TerrainType *def = Find_Terrain("DefaultTerrain");
@@ -131,7 +131,7 @@ TerrainType *TerrainTypeCollection::New_Terrain(AsciiString name)
 
 void TerrainTypeCollection::Parse_Terrain_Definition(INI *ini)
 {
-    AsciiString token = ini->Get_Next_Token();
+    Utf8String token = ini->Get_Next_Token();
     TerrainType *tt = g_theTerrainTypes->Find_Terrain(token);
 
     if (tt == nullptr) {

--- a/src/game/common/terraintypes.h
+++ b/src/game/common/terraintypes.h
@@ -78,8 +78,8 @@ public:
     virtual ~TerrainType() {}
 
 private:
-    AsciiString m_name;
-    AsciiString m_texture;
+    Utf8String m_name;
+    Utf8String m_texture;
     bool m_blendEdgeTexture;
     TerrainClass m_class;
     bool m_restrictConstruction;
@@ -97,8 +97,8 @@ public:
     virtual void Reset() override{};
     virtual void Update() override{};
 
-    TerrainType *Find_Terrain(AsciiString name);
-    TerrainType *New_Terrain(AsciiString name);
+    TerrainType *Find_Terrain(Utf8String name);
+    TerrainType *New_Terrain(Utf8String name);
 
     static void Parse_Terrain_Definition(INI *ini);
 

--- a/src/game/common/thing/moduleinfo.h
+++ b/src/game/common/thing/moduleinfo.h
@@ -24,8 +24,8 @@ class ModuleInfo
 {
     struct Nugget
     {
-        AsciiString unk_string1;
-        AsciiString unk_string2;
+        Utf8String unk_string1;
+        Utf8String unk_string2;
         ModuleData *data;
         int interface_mask;
         bool copied_from_default;

--- a/src/game/common/thing/thingtemplate.h
+++ b/src/game/common/thing/thingtemplate.h
@@ -84,7 +84,7 @@ public:
     bool Is_KindOf(KindOfType type) const { return m_kindOf.Get(type); }
 
 private:
-    UnicodeString m_displayName;
+    Utf16String m_displayName;
     AsciiString m_unkAsciiString1;
     AsciiString m_side;
     AsciiString m_commandSet;

--- a/src/game/common/thing/thingtemplate.h
+++ b/src/game/common/thing/thingtemplate.h
@@ -85,16 +85,16 @@ public:
 
 private:
     Utf16String m_displayName;
-    AsciiString m_unkAsciiString1;
-    AsciiString m_side;
-    AsciiString m_commandSet;
-    AsciiString m_selectPortrait;
-    AsciiString m_buttonImage;
-    AsciiString m_upgradeCameo[5];
-    AsciiString m_shadowTexture;
-    AsciiString m_unkAsciiString2;
-    AsciiString m_unkAsciiString3;
-    AsciiString m_unkAsciiString4;
+    Utf8String m_unkAsciiString1;
+    Utf8String m_side;
+    Utf8String m_commandSet;
+    Utf8String m_selectPortrait;
+    Utf8String m_buttonImage;
+    Utf8String m_upgradeCameo[5];
+    Utf8String m_shadowTexture;
+    Utf8String m_unkAsciiString2;
+    Utf8String m_unkAsciiString3;
+    Utf8String m_unkAsciiString4;
     GeometryInfo m_geometryInfo;
     //int m_kindOf[4];
     BitFlags<KINDOF_COUNT> m_kindOf;
@@ -106,13 +106,13 @@ private:
     int m_experienceValue[4];
     int m_experienceRequired[4];
     std::vector<ProductionPrerequisite> m_prerequisites;
-    std::vector<AsciiString> m_buildVariations;
+    std::vector<Utf8String> m_buildVariations;
     std::vector<WeaponTemplateSet> m_weaponTemplateSets;
     SparseMatchFinder<BitFlags<WEAPONSET_COUNT>, WeaponTemplateSet> m_weaponTemplateSetFinder;
     std::vector<ArmorTemplateSet> m_armorTemplateSets;
     SparseMatchFinder<BitFlags<ARMORSET_COUNT>, ArmorTemplateSet> m_armorTemplateSetFinder;
-    std::map<AsciiString, AudioEventRTS> m_perUnitSounds;
-    std::map<AsciiString, FXList *> m_perUnitEffects;
+    std::map<Utf8String, AudioEventRTS> m_perUnitSounds;
+    std::map<Utf8String, FXList *> m_perUnitEffects;
     int m_unkInt1;
     int m_unkInt2;
     int m_unkInt3;

--- a/src/game/common/userpreferences.cpp
+++ b/src/game/common/userpreferences.cpp
@@ -29,7 +29,7 @@ UserPreferences::UserPreferences()
 {
 }
 
-bool UserPreferences::Load(AsciiString filename)
+bool UserPreferences::Load(Utf8String filename)
 {
     m_filename = g_theWriteableGlobalData->m_userDataDirectory;
     m_filename += filename;
@@ -41,11 +41,11 @@ bool UserPreferences::Load(AsciiString filename)
 
         while ( fgets(buffer, sizeof(buffer), fptr) != 0 ) {
             // Get key/value pair per line.
-            AsciiString key;
-            AsciiString line = buffer;
+            Utf8String key;
+            Utf8String line = buffer;
             line.Trim();
             line.Next_Token(&key, "=");
-            AsciiString value = line.Str() + 1;
+            Utf8String value = line.Str() + 1;
 
             // Trim whitespace.
             key.Trim();
@@ -84,7 +84,7 @@ bool UserPreferences::Write()
     return false;
 }
 
-AsciiString UserPreferences::Get_AsciiString(AsciiString key, AsciiString def_arg)
+Utf8String UserPreferences::Get_AsciiString(Utf8String key, Utf8String def_arg)
 {
     auto it = find(key);
 
@@ -95,9 +95,9 @@ AsciiString UserPreferences::Get_AsciiString(AsciiString key, AsciiString def_ar
     return it->second;
 }
 
-int UserPreferences::Get_Int(AsciiString key, int def_arg)
+int UserPreferences::Get_Int(Utf8String key, int def_arg)
 {
-    AsciiString value = Get_AsciiString(key);
+    Utf8String value = Get_AsciiString(key);
 
     if ( value.Is_Empty() ) {
         return def_arg;
@@ -106,9 +106,9 @@ int UserPreferences::Get_Int(AsciiString key, int def_arg)
     return atoi(value.Str());
 }
 
-float UserPreferences::Get_Real(AsciiString key, float def_arg)
+float UserPreferences::Get_Real(Utf8String key, float def_arg)
 {
-    AsciiString value = Get_AsciiString(key);
+    Utf8String value = Get_AsciiString(key);
 
     if ( value.Is_Empty() ) {
         return def_arg;
@@ -117,9 +117,9 @@ float UserPreferences::Get_Real(AsciiString key, float def_arg)
     return (float)atof(value.Str());
 }
 
-bool UserPreferences::Get_Bool(AsciiString key, bool def_arg)
+bool UserPreferences::Get_Bool(Utf8String key, bool def_arg)
 {
-    AsciiString value = Get_AsciiString(key);
+    Utf8String value = Get_AsciiString(key);
 
     if ( value.Is_Empty() ) {
         return def_arg;
@@ -141,28 +141,28 @@ bool UserPreferences::Get_Bool(AsciiString key, bool def_arg)
     return true;
 }
 
-void UserPreferences::Set_AsciiString(AsciiString key, AsciiString value)
+void UserPreferences::Set_AsciiString(Utf8String key, Utf8String value)
 {
     (*this)[key] = value;
 }
 
-void UserPreferences::Set_Int(AsciiString key, int value)
+void UserPreferences::Set_Int(Utf8String key, int value)
 {
-    AsciiString val;
+    Utf8String val;
     val.Format("%d", value);
     (*this)[key] = val;
 }
 
-void UserPreferences::Set_Real(AsciiString key, float value)
+void UserPreferences::Set_Real(Utf8String key, float value)
 {
-    AsciiString val;
+    Utf8String val;
     val.Format("%g", value);
     (*this)[key] = val;
 }
 
-void UserPreferences::Set_Bool(AsciiString key, bool value)
+void UserPreferences::Set_Bool(Utf8String key, bool value)
 {
-    AsciiString val;
+    Utf8String val;
     val.Format("%d", value);
     (*this)[key] = val;
 }

--- a/src/game/common/userpreferences.h
+++ b/src/game/common/userpreferences.h
@@ -26,24 +26,24 @@
 #include "asciistring.h"
 #include <map>
 
-class UserPreferences : public std::map<AsciiString, AsciiString>
+class UserPreferences : public std::map<Utf8String, Utf8String>
 {
 public:
     UserPreferences();
     virtual ~UserPreferences() {}
 
-    virtual bool Load(AsciiString filename);
+    virtual bool Load(Utf8String filename);
     virtual bool Write();
 
-    AsciiString Get_AsciiString(AsciiString key, AsciiString def_arg = AsciiString::s_emptyString);
-    int Get_Int(AsciiString key, int def_arg);
-    float Get_Real(AsciiString key, float def_arg);
-    bool Get_Bool(AsciiString key, bool def_arg);
-    void Set_AsciiString(AsciiString key, AsciiString value);
-    void Set_Int(AsciiString key, int value);
-    void Set_Real(AsciiString key, float value);
-    void Set_Bool(AsciiString key, bool value);
+    Utf8String Get_AsciiString(Utf8String key, Utf8String def_arg = Utf8String::s_emptyString);
+    int Get_Int(Utf8String key, int def_arg);
+    float Get_Real(Utf8String key, float def_arg);
+    bool Get_Bool(Utf8String key, bool def_arg);
+    void Set_AsciiString(Utf8String key, Utf8String value);
+    void Set_Int(Utf8String key, int value);
+    void Set_Real(Utf8String key, float value);
+    void Set_Bool(Utf8String key, bool value);
 
 private:
-    AsciiString m_filename;
+    Utf8String m_filename;
 };

--- a/src/game/common/version.cpp
+++ b/src/game/common/version.cpp
@@ -36,8 +36,8 @@ Version::Version() :
 {
 }
 
-void Version::Set_Version(int32_t maj, int32_t min, int32_t build, int32_t local_build, AsciiString location,
-    AsciiString user, AsciiString time, AsciiString date)
+void Version::Set_Version(int32_t maj, int32_t min, int32_t build, int32_t local_build, Utf8String location,
+    Utf8String user, Utf8String time, Utf8String date)
 {
     m_major = maj;
     m_minor = min;
@@ -49,9 +49,9 @@ void Version::Set_Version(int32_t maj, int32_t min, int32_t build, int32_t local
     m_buildDate = date;
 }
 
-AsciiString Version::Get_Ascii_Version()
+Utf8String Version::Get_Ascii_Version()
 {
-    AsciiString version;
+    Utf8String version;
 
     if (m_localBuildNum != 0) {
         version.Format("%d.%d.%d.%d", m_major, m_minor, m_buildNum, m_localBuildNum);
@@ -62,9 +62,9 @@ AsciiString Version::Get_Ascii_Version()
     return version;
 }
 
-AsciiString Version::Get_Ascii_Build_Time()
+Utf8String Version::Get_Ascii_Build_Time()
 {
-    AsciiString version;
+    Utf8String version;
 
     version.Format("%s %s", m_buildDate.Str(), m_buildTime.Str());
 

--- a/src/game/common/version.cpp
+++ b/src/game/common/version.cpp
@@ -71,18 +71,18 @@ AsciiString Version::Get_Ascii_Build_Time()
     return version;
 }
 
-UnicodeString Version::Get_Unicode_Version()
+Utf16String Version::Get_Unicode_Version()
 {
-    UnicodeString ret;
+    Utf16String ret;
 
     ret.Format(g_theGameText->Fetch("Version:Format2").Str(), m_major, m_minor);
 
     return ret;
 }
 
-UnicodeString Version::Get_Full_Unicode_Version()
+Utf16String Version::Get_Full_Unicode_Version()
 {
-    UnicodeString ret;
+    Utf16String ret;
 
     if (m_localBuildNum != 0) {
         ret.Format(g_theGameText->Fetch("Version:Format4").Str(), m_major, m_minor, m_buildNum, m_localBuildNum);
@@ -93,10 +93,10 @@ UnicodeString Version::Get_Full_Unicode_Version()
     return ret;
 }
 
-UnicodeString Version::Get_Unicode_Branch()
+Utf16String Version::Get_Unicode_Branch()
 {
-    UnicodeString ret;
-    UnicodeString branch;
+    Utf16String ret;
+    Utf16String branch;
 
     branch.Translate(m_branch);
     ret.Format(g_theGameText->Fetch("Version:BuildLocation").Str(), branch.Str());
@@ -104,10 +104,10 @@ UnicodeString Version::Get_Unicode_Branch()
     return ret;
 }
 
-UnicodeString Version::Get_Unicode_Commit_Hash()
+Utf16String Version::Get_Unicode_Commit_Hash()
 {
-    UnicodeString ret;
-    UnicodeString hash;
+    Utf16String ret;
+    Utf16String hash;
 
     hash.Translate(m_commitHash);
     ret.Format(g_theGameText->Fetch("Version:BuildUser").Str(), hash.Str());
@@ -115,11 +115,11 @@ UnicodeString Version::Get_Unicode_Commit_Hash()
     return ret;
 }
 
-UnicodeString Version::Get_Unicode_Build_Time()
+Utf16String Version::Get_Unicode_Build_Time()
 {
-    UnicodeString ret;
-    UnicodeString date;
-    UnicodeString time;
+    Utf16String ret;
+    Utf16String date;
+    Utf16String time;
 
     date.Translate(m_buildDate);
     time.Translate(m_buildTime);

--- a/src/game/common/version.h
+++ b/src/game/common/version.h
@@ -15,6 +15,7 @@
  */
 #pragma once
 
+#include "always.h"
 #include "asciistring.h"
 #include "unicodestring.h"
 

--- a/src/game/common/version.h
+++ b/src/game/common/version.h
@@ -35,11 +35,11 @@ public:
     AsciiString Get_Ascii_Branch() { return m_branch; }
     AsciiString Get_Ascii_Commit_Hash() { return m_commitHash; }
     AsciiString Get_Ascii_Build_Time();
-    UnicodeString Get_Unicode_Version();
-    UnicodeString Get_Full_Unicode_Version();
-    UnicodeString Get_Unicode_Branch();
-    UnicodeString Get_Unicode_Commit_Hash();
-    UnicodeString Get_Unicode_Build_Time();
+    Utf16String Get_Unicode_Version();
+    Utf16String Get_Full_Unicode_Version();
+    Utf16String Get_Unicode_Branch();
+    Utf16String Get_Unicode_Commit_Hash();
+    Utf16String Get_Unicode_Build_Time();
 
     void Set_Use_Full_Version(bool cmd_line) { m_useFullVersion = cmd_line; }
     bool Using_Full_Version() { return m_useFullVersion; }

--- a/src/game/common/version.h
+++ b/src/game/common/version.h
@@ -24,17 +24,17 @@ class Version
 public:
     Version();
 
-    void Set_Version(int32_t maj, int32_t min, int32_t build, int32_t local_build, AsciiString location, AsciiString user,
-        AsciiString time, AsciiString date);
+    void Set_Version(int32_t maj, int32_t min, int32_t build, int32_t local_build, Utf8String location, Utf8String user,
+        Utf8String time, Utf8String date);
 
     int32_t Get_Version_Number() { return m_minor | (m_major << 16); }
     int32_t Get_Build_Number() { return m_buildNum; }
     int32_t Get_Local_Build_Number() { return m_localBuildNum; }
 
-    AsciiString Get_Ascii_Version();
-    AsciiString Get_Ascii_Branch() { return m_branch; }
-    AsciiString Get_Ascii_Commit_Hash() { return m_commitHash; }
-    AsciiString Get_Ascii_Build_Time();
+    Utf8String Get_Ascii_Version();
+    Utf8String Get_Ascii_Branch() { return m_branch; }
+    Utf8String Get_Ascii_Commit_Hash() { return m_commitHash; }
+    Utf8String Get_Ascii_Build_Time();
     Utf16String Get_Unicode_Version();
     Utf16String Get_Full_Unicode_Version();
     Utf16String Get_Unicode_Branch();
@@ -49,10 +49,10 @@ private:
     int32_t m_minor;
     int32_t m_buildNum;
     int32_t m_localBuildNum;
-    AsciiString m_branch; // Was Location in orignal
-    AsciiString m_commitHash; // Was User in original
-    AsciiString m_buildTime;
-    AsciiString m_buildDate;
+    Utf8String m_branch; // Was Location in orignal
+    Utf8String m_commitHash; // Was User in original
+    Utf8String m_buildTime;
+    Utf8String m_buildDate;
     bool m_useFullVersion;
 };
 

--- a/src/game/logic/scriptengine/script.cpp
+++ b/src/game/logic/scriptengine/script.cpp
@@ -118,7 +118,7 @@ Script *Script::Duplicate()
  *
  * 0x0051CFC0
  */
-Script *Script::Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3)
+Script *Script::Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3)
 {
     Script *new_script = new Script;
 

--- a/src/game/logic/scriptengine/script.h
+++ b/src/game/logic/scriptengine/script.h
@@ -34,7 +34,7 @@ public:
     virtual void Load_Post_Process() override {}
 
     Script *Duplicate();
-    Script *Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3);
+    Script *Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3);
     Script *Get_Next() { return m_nextScript; }
     OrCondition *Get_Condition() { return m_condition; }
     ScriptAction *Get_Action() { return m_action; }
@@ -59,10 +59,10 @@ public:
     static Script *s_emptyScript;
 
 private:
-    AsciiString m_scriptName;
-    AsciiString m_comment;
-    AsciiString m_conditionComment;
-    AsciiString m_actionComment;
+    Utf8String m_scriptName;
+    Utf8String m_comment;
+    Utf8String m_conditionComment;
+    Utf8String m_actionComment;
     int32_t m_evaluationInterval;
     bool m_isActive;
     bool m_isOneShot;
@@ -76,7 +76,7 @@ private:
     Script *m_nextScript;
     int m_unkInt2;
     bool m_hasWarnings;
-    AsciiString m_conditionTeamName;
+    Utf8String m_conditionTeamName;
     int m_unkInt3;
     int m_unkInt4;
     int m_unkInt5;

--- a/src/game/logic/scriptengine/scriptaction.cpp
+++ b/src/game/logic/scriptengine/scriptaction.cpp
@@ -83,7 +83,7 @@ ScriptAction *ScriptAction::Duplicate()
  *
  * 0x00520240
  */
-ScriptAction *ScriptAction::Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3)
+ScriptAction *ScriptAction::Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3)
 {
     ScriptAction *new_action = new ScriptAction(m_actionType);
 
@@ -114,13 +114,13 @@ ScriptAction *ScriptAction::Duplicate_And_Qualify(const AsciiString &str1, const
  *
  * 0x005206B0
  */
-AsciiString ScriptAction::Get_UI_Text()
+Utf8String ScriptAction::Get_UI_Text()
 {
     // TODO Requires ScriptEngine vtable
 #ifndef THYME_STANDALONE
-    return Call_Method<AsciiString, ScriptAction>(0x005206B0, this);
+    return Call_Method<Utf8String, ScriptAction>(0x005206B0, this);
 #else
-    return AsciiString();
+    return Utf8String();
 #endif
 }
 

--- a/src/game/logic/scriptengine/scriptaction.h
+++ b/src/game/logic/scriptengine/scriptaction.h
@@ -39,8 +39,8 @@ public:
     virtual ~ScriptAction();
 
     ScriptAction *Duplicate();
-    ScriptAction *Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3);
-    AsciiString Get_UI_Text();
+    ScriptAction *Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3);
+    Utf8String Get_UI_Text();
 
     static bool Parse_Action_Chunk(DataChunkInput &input, DataChunkInfo *info, void *data);
     static bool Parse_False_Action_Chunk(DataChunkInput &input, DataChunkInfo *info, void *data);

--- a/src/game/logic/scriptengine/scriptcondition.cpp
+++ b/src/game/logic/scriptengine/scriptcondition.cpp
@@ -95,7 +95,7 @@ Condition *Condition::Duplicate()
  *
  * 0x0051E0B0
  */
-Condition *Condition::Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3)
+Condition *Condition::Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3)
 {
     // Parameters are allocated in Set_Condition_Type which the ctor calls.
     Condition *new_cond = new Condition(m_conditionType);
@@ -214,7 +214,7 @@ OrCondition *OrCondition::Duplicate()
  *
  * 0x0051D8A0
  */
-OrCondition *OrCondition::Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3)
+OrCondition *OrCondition::Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3)
 {
     OrCondition *new_or = new OrCondition;
 

--- a/src/game/logic/scriptengine/scriptcondition.h
+++ b/src/game/logic/scriptengine/scriptcondition.h
@@ -40,7 +40,7 @@ public:
     virtual ~Condition();
 
     Condition *Duplicate();
-    Condition *Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3);
+    Condition *Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3);
     void Set_Condition_Type(ConditionType type);
 
     static bool Parse_Data_Chunk(DataChunkInput &input, DataChunkInfo *info, void *data);
@@ -68,7 +68,7 @@ public:
     virtual ~OrCondition();
 
     OrCondition *Duplicate();
-    OrCondition *Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3);
+    OrCondition *Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3);
     
     static bool Parse_OrCondition_Chunk(DataChunkInput &input, DataChunkInfo *info, void *data);
 

--- a/src/game/logic/scriptengine/scriptgroup.cpp
+++ b/src/game/logic/scriptengine/scriptgroup.cpp
@@ -118,7 +118,7 @@ ScriptGroup *ScriptGroup::Duplicate()
  *
  * 0x0051C670
  */
-ScriptGroup *ScriptGroup::Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3)
+ScriptGroup *ScriptGroup::Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3)
 {
     ScriptGroup *new_group = new ScriptGroup;
 

--- a/src/game/logic/scriptengine/scriptgroup.h
+++ b/src/game/logic/scriptengine/scriptgroup.h
@@ -36,7 +36,7 @@ public:
     virtual void Load_Post_Process() override {}
 
     ScriptGroup *Duplicate();
-    ScriptGroup *Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3);
+    ScriptGroup *Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3);
     void Add_Script(Script *script, int index);
     ScriptGroup *Get_Next() { return m_nextGroup; }
     Script *Get_Scripts() { return m_firstScript; }
@@ -51,7 +51,7 @@ public:
 
 private:
     Script *m_firstScript;
-    AsciiString m_groupName;
+    Utf8String m_groupName;
     bool m_isGroupActive;
     bool m_isGroupSubroutine;
     ScriptGroup *m_nextGroup;

--- a/src/game/logic/scriptengine/scriptlist.cpp
+++ b/src/game/logic/scriptengine/scriptlist.cpp
@@ -131,7 +131,7 @@ ScriptList *ScriptList::Duplicate()
  *
  * 0x0051BD80
  */
-ScriptList *ScriptList::Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3)
+ScriptList *ScriptList::Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3)
 {
     ScriptList *new_list = new ScriptList;
 

--- a/src/game/logic/scriptengine/scriptlist.h
+++ b/src/game/logic/scriptengine/scriptlist.h
@@ -44,7 +44,7 @@ public:
     virtual void Load_Post_Process() override {}
 
     ScriptList *Duplicate();
-    ScriptList *Duplicate_And_Qualify(const AsciiString &str1, const AsciiString &str2, const AsciiString &str3);
+    ScriptList *Duplicate_And_Qualify(const Utf8String &str1, const Utf8String &str2, const Utf8String &str3);
     void Add_Group(ScriptGroup *group, int index);
     void Add_Script(Script *script, int index);
     Script *Get_Scripts() { return m_firstScript; }

--- a/src/game/logic/scriptengine/scriptparam.cpp
+++ b/src/game/logic/scriptengine/scriptparam.cpp
@@ -34,7 +34,7 @@ Parameter::Parameter(ParameterType type) :
  *
  * 0x0051E990, also inlined example at around 0x00520376
  */
-void Parameter::Qualify(const AsciiString &suffix, const AsciiString &side_test, const AsciiString &side_replacemet)
+void Parameter::Qualify(const Utf8String &suffix, const Utf8String &side_test, const Utf8String &side_replacemet)
 {
     //DEBUG_LOG("Qualifying parameter string '%s' with suffix '%s' against '%s' to replace with '%s'.\n", m_string.Str(), suffix.Str(), side_test.Str(), side_replacemet.Str());
     switch (m_type) {
@@ -66,7 +66,7 @@ void Parameter::Qualify(const AsciiString &suffix, const AsciiString &side_test,
  *
  * 0x0051EB90
  */
-AsciiString Parameter::Get_UI_Text()
+Utf8String Parameter::Get_UI_Text()
 {
     // Dunno where this is supposed to be from, only appears used here.
     static BorderColor _border_colors[] = {
@@ -80,8 +80,8 @@ AsciiString Parameter::Get_UI_Text()
         {"Pink", 0xFFFF8670}
     };
 
-    AsciiString ui_string = m_string.Is_Empty() ? "???" : m_string;
-    AsciiString ui_text;
+    Utf8String ui_string = m_string.Is_Empty() ? "???" : m_string;
+    Utf8String ui_text;
 
     switch (m_type) {
         case INT:

--- a/src/game/logic/scriptengine/scriptparam.h
+++ b/src/game/logic/scriptengine/scriptparam.h
@@ -133,9 +133,9 @@ public:
 
     Parameter &operator=(const Parameter &that);
 
-    void Qualify(const AsciiString &suffix, const AsciiString &side_test, const AsciiString &side_replacemet);
+    void Qualify(const Utf8String &suffix, const Utf8String &side_test, const Utf8String &side_replacemet);
 
-    AsciiString Get_UI_Text();
+    Utf8String Get_UI_Text();
     void Get_Coord3D(Coord3D *coord);
     void Set_Coord3D(Coord3D *coord);
 
@@ -149,7 +149,7 @@ private:
     bool m_initialized;
     int m_int;
     float m_real;
-    AsciiString m_string;
+    Utf8String m_string;
     Coord3D m_coord;
     BitFlags<OBJECT_STATUS_COUNT> m_objStatus;
 };

--- a/src/game/logic/system/rankinfo.h
+++ b/src/game/logic/system/rankinfo.h
@@ -57,7 +57,7 @@ public:
 
     RankInfo *Get_Override() { return m_next != nullptr ? reinterpret_cast<RankInfo *>(m_next->Get_Final_Override()) : this; }
 private:
-    UnicodeString m_rankName;
+    Utf16String m_rankName;
     int m_skillPointsNeeded;
     unsigned m_sciencePurchasePointsGranted;
     std::vector<ScienceType> m_sciencesGranted;

--- a/src/game/maputil.cpp
+++ b/src/game/maputil.cpp
@@ -35,7 +35,7 @@ void WaypointMap::Update()
 {
     if ( g_waypoints != nullptr ) {
         clear();
-        AsciiString key_name = g_theNameKeyGenerator->Key_To_Name(g_theInitialCameraPositionKey);
+        Utf8String key_name = g_theNameKeyGenerator->Key_To_Name(g_theInitialCameraPositionKey);
         auto it = g_waypoints->find(key_name);
 
         if ( it != g_waypoints->end() ) {
@@ -62,9 +62,9 @@ void WaypointMap::Update()
     }
 }
 
-AsciiString MapCache::Get_User_Map_Dir()
+Utf8String MapCache::Get_User_Map_Dir()
 {
-    AsciiString dir = g_theWriteableGlobalData->m_userDataDirectory;
+    Utf8String dir = g_theWriteableGlobalData->m_userDataDirectory;
     dir += Get_Map_Dir();
 
     return dir;

--- a/src/game/maputil.h
+++ b/src/game/maputil.h
@@ -19,7 +19,7 @@
 #include "list"
 #include <map>
 
-class WaypointMap : public std::map<AsciiString, Coord3D>
+class WaypointMap : public std::map<Utf8String, Coord3D>
 {
 public:
     void Update();
@@ -35,8 +35,8 @@ struct WinTimeStamp
 
 struct MapMetaData
 {
-    AsciiString m_displayName;
-    AsciiString m_lookupTag;
+    Utf8String m_displayName;
+    Utf8String m_lookupTag;
     Region3D m_extent;
     int m_numPlayers;
     bool m_isMultiplayer;
@@ -49,17 +49,17 @@ struct MapMetaData
     std::list<Coord3D> m_techPositions;
 };
 
-class MapCache : std::map<AsciiString, MapMetaData>
+class MapCache : std::map<Utf8String, MapMetaData>
 {
 public:
-    AsciiString Get_Map_Dir() { return s_mapDirName; }
-    AsciiString Get_Map_Extension() { return s_mapExtension; }
-    AsciiString Get_Cache_Name() { return s_mapCacheName; }
-    AsciiString Get_User_Map_Dir();
+    Utf8String Get_Map_Dir() { return s_mapDirName; }
+    Utf8String Get_Map_Extension() { return s_mapExtension; }
+    Utf8String Get_Cache_Name() { return s_mapCacheName; }
+    Utf8String Get_User_Map_Dir();
 
     void Write_Cache_INI(bool custom_cache);
     void Update_Cache();
-    bool Clear_Unseen_Maps(AsciiString prefix);
+    bool Clear_Unseen_Maps(Utf8String prefix);
     void Load_Standard_Maps();
     bool Load_User_Maps();
 
@@ -68,7 +68,7 @@ private:
     static const char *const s_mapExtension;
     static const char *const s_mapCacheName;
 
-    std::map<AsciiString, int> m_seen;
+    std::map<Utf8String, int> m_seen;
 };
 
 #ifndef THYME_STANDALONE

--- a/src/game/network/filetransfer.cpp
+++ b/src/game/network/filetransfer.cpp
@@ -20,7 +20,7 @@
 
 using std::ptrdiff_t;
 
-AsciiString Get_Base_Path_From_Path(AsciiString path)
+Utf8String Get_Base_Path_From_Path(Utf8String path)
 {
     const char *path_str = path.Str();
 
@@ -31,16 +31,16 @@ AsciiString Get_Base_Path_From_Path(AsciiString path)
 
     if (last_sep != nullptr) {
         ptrdiff_t size = last_sep - path_str;
-        AsciiString ret;
+        Utf8String ret;
         memcpy(ret.Get_Buffer_For_Read(size + 1), path_str, size);
 
         return ret;
     }
 
-    return AsciiString::s_emptyString;
+    return Utf8String::s_emptyString;
 }
 
-AsciiString Get_File_From_Path(AsciiString path)
+Utf8String Get_File_From_Path(Utf8String path)
 {
     const char *path_str = path.Str();
 
@@ -50,13 +50,13 @@ AsciiString Get_File_From_Path(AsciiString path)
     DEBUG_LOG("Getting file from '%s'.\n", path_str);
 
     if (last_sep != nullptr) {
-        return AsciiString(last_sep + 1);
+        return Utf8String(last_sep + 1);
     }
 
     return path;
 }
 
-AsciiString Get_Base_File_From_File(AsciiString path)
+Utf8String Get_Base_File_From_File(Utf8String path)
 {
     const char *path_str = path.Str();
 
@@ -68,18 +68,18 @@ AsciiString Get_Base_File_From_File(AsciiString path)
     // If we have a file extension, return the part before it.
     if (last_sep != nullptr) {
         ptrdiff_t size = last_sep - path_str;
-        AsciiString ret;
+        Utf8String ret;
         memcpy(ret.Get_Buffer_For_Read(size + 1), path_str, size);
 
         return ret;
     }
 
-    return AsciiString::s_emptyString;
+    return Utf8String::s_emptyString;
 }
 
-AsciiString Get_Preview_From_Map(AsciiString path)
+Utf8String Get_Preview_From_Map(Utf8String path)
 {
-    AsciiString preview;
+    Utf8String preview;
 
     preview.Format(
         "%s/%s.tga", Get_Base_Path_From_Path(path).Str(), Get_Base_File_From_File(Get_File_From_Path(path)).Str());
@@ -87,45 +87,45 @@ AsciiString Get_Preview_From_Map(AsciiString path)
     return preview;
 }
 
-AsciiString Get_INI_From_Map(AsciiString path)
+Utf8String Get_INI_From_Map(Utf8String path)
 {
-    AsciiString ini;
+    Utf8String ini;
 
     ini.Format("%s/map.ini", Get_Base_Path_From_Path(path).Str());
 
     return ini;
 }
 
-AsciiString Get_Str_File_From_Map(AsciiString path)
+Utf8String Get_Str_File_From_Map(Utf8String path)
 {
-    AsciiString str;
+    Utf8String str;
 
     str.Format("%s/map.str", Get_Base_Path_From_Path(path).Str());
 
     return str;
 }
 
-AsciiString Get_Solo_INI_From_Map(AsciiString path)
+Utf8String Get_Solo_INI_From_Map(Utf8String path)
 {
-    AsciiString ini;
+    Utf8String ini;
 
     ini.Format("%s/solo.ini", Get_Base_Path_From_Path(path).Str());
 
     return ini;
 }
 
-AsciiString Get_Asset_Usage_From_Map(AsciiString path)
+Utf8String Get_Asset_Usage_From_Map(Utf8String path)
 {
-    AsciiString use;
+    Utf8String use;
 
     use.Format("%s/assetusage.txt", Get_Base_Path_From_Path(path).Str());
 
     return use;
 }
 
-AsciiString Get_Readme_From_Map(AsciiString path)
+Utf8String Get_Readme_From_Map(Utf8String path)
 {
-    AsciiString readme;
+    Utf8String readme;
 
     readme.Format("%s/readme.txt", Get_Base_Path_From_Path(path).Str());
 
@@ -138,7 +138,7 @@ bool Do_Any_File_Transfers(GameInfo *gameinfo)
     return false;
 }
 
-bool Do_File_Transfer(AsciiString filename, MapTransferLoadScreen *screen, int unkbool)
+bool Do_File_Transfer(Utf8String filename, MapTransferLoadScreen *screen, int unkbool)
 {
     // TODO needs MapTransferLoadScreen
     return false;

--- a/src/game/network/filetransfer.h
+++ b/src/game/network/filetransfer.h
@@ -21,17 +21,17 @@
 class GameInfo;
 class MapTransferLoadScreen;
 
-AsciiString Get_Base_Path_From_Path(AsciiString path);
-AsciiString Get_File_From_Path(AsciiString path);
-AsciiString Get_Base_File_From_File(AsciiString path);
-AsciiString Get_Preview_From_Map(AsciiString path);
-AsciiString Get_INI_From_Map(AsciiString path);
-AsciiString Get_Str_File_From_Map(AsciiString path);
-AsciiString Get_Solo_INI_From_Map(AsciiString path);
-AsciiString Get_Asset_Usage_From_Map(AsciiString path);
-AsciiString Get_Readme_From_Map(AsciiString path);
+Utf8String Get_Base_Path_From_Path(Utf8String path);
+Utf8String Get_File_From_Path(Utf8String path);
+Utf8String Get_Base_File_From_File(Utf8String path);
+Utf8String Get_Preview_From_Map(Utf8String path);
+Utf8String Get_INI_From_Map(Utf8String path);
+Utf8String Get_Str_File_From_Map(Utf8String path);
+Utf8String Get_Solo_INI_From_Map(Utf8String path);
+Utf8String Get_Asset_Usage_From_Map(Utf8String path);
+Utf8String Get_Readme_From_Map(Utf8String path);
 bool Do_Any_File_Transfers(GameInfo *gameinfo);
-bool Do_File_Transfer(AsciiString filename, MapTransferLoadScreen *screen, int unkbool);
+bool Do_File_Transfer(Utf8String filename, MapTransferLoadScreen *screen, int unkbool);
 
 #ifndef THYME_STANDALONE
 #include "hooker.h"

--- a/src/game/weather.h
+++ b/src/game/weather.h
@@ -47,7 +47,7 @@ public:
     static void Parse_Weather_Definition(INI *ini);
 
 private:
-    AsciiString m_snowTexture;
+    Utf8String m_snowTexture;
     float m_snowFreqScaleX;
     float m_snowFreqScaleY;
     float m_snowAmplitude;

--- a/src/hooker/dllmain.cpp
+++ b/src/hooker/dllmain.cpp
@@ -142,10 +142,10 @@ void Setup_Hooks()
     FileSystem::Hook_Me();
     ArchiveFileSystem::Hook_Me();
 
-    // Replace AsciiString
-    Hook_Method(0x0040D640, static_cast<void (AsciiString::*)(char const *)>(&AsciiString::Set));
-    Hook_Method(0x00415290, &AsciiString::Ensure_Unique_Buffer_Of_Size);
-    Hook_Method(0x0040FB40, static_cast<void (AsciiString::*)(char const *)>(&AsciiString::Concat));
+    // Replace Utf8String
+    Hook_Method(0x0040D640, static_cast<void (Utf8String::*)(char const *)>(&Utf8String::Set));
+    Hook_Method(0x00415290, &Utf8String::Ensure_Unique_Buffer_Of_Size);
+    Hook_Method(0x0040FB40, static_cast<void (Utf8String::*)(char const *)>(&Utf8String::Concat));
 
     Win32GameEngine::Hook_Me();
     INI::Hook_Me();

--- a/src/platform/win32bigfile.cpp
+++ b/src/platform/win32bigfile.cpp
@@ -17,7 +17,7 @@
 #include "ramfile.h"
 #include "streamingarchivefile.h"
 
-bool Win32BIGFile::Get_File_Info(AsciiString const &name, FileInfo *info)
+bool Win32BIGFile::Get_File_Info(Utf8String const &name, FileInfo *info)
 {
     ArchivedFileInfo *arch_info = Get_Archived_File_Info(name);
 

--- a/src/platform/win32bigfile.h
+++ b/src/platform/win32bigfile.h
@@ -22,15 +22,15 @@ public:
     Win32BIGFile() {}
     virtual ~Win32BIGFile() {}
 
-    virtual bool Get_File_Info(AsciiString const &name, FileInfo *info) override;
+    virtual bool Get_File_Info(Utf8String const &name, FileInfo *info) override;
     virtual File *Open_File(const char *filename, int mode) override;
     virtual void Close_All_Files() override {};
-    virtual AsciiString Get_Name() override { return FileName; }
-    virtual AsciiString Get_Path() override { return FilePath; }
+    virtual Utf8String Get_Name() override { return FileName; }
+    virtual Utf8String Get_Path() override { return FilePath; }
     virtual void Set_Search_Priority(int priority) override {}
     virtual void Close() override {}
 
 private:
-    AsciiString FileName;
-    AsciiString FilePath;
+    Utf8String FileName;
+    Utf8String FilePath;
 };

--- a/src/platform/win32bigfilesystem.cpp
+++ b/src/platform/win32bigfilesystem.cpp
@@ -30,7 +30,7 @@ void Win32BIGFileSystem::Init()
     if (g_theLocalFileSystem != nullptr) {
         Load_Archives_From_Dir("", "*.big", false);
 
-        AsciiString gen_path;
+        Utf8String gen_path;
 
         Get_String_From_Generals_Registry("", "InstallPath", gen_path);
 
@@ -51,7 +51,7 @@ ArchiveFile *Win32BIGFileSystem::Open_Archive_File(const char *filename)
     File *file = g_theLocalFileSystem->Open_File(filename, File::READ | File::BINARY);
     Win32BIGFile *big = new Win32BIGFile;
 
-    AsciiString fullname = filename;
+    Utf8String fullname = filename;
     fullname.To_Lower();
 
     if (file == nullptr) {
@@ -142,7 +142,7 @@ ArchiveFile *Win32BIGFileSystem::Open_Archive_File(const char *filename)
 
         // DEBUG_LOG("Path is '%s'.\n", namebuf);
 
-        AsciiString file_path = namebuf;
+        Utf8String file_path = namebuf;
         file_path += info->file_name;
         big->Add_File(namebuf, info);
     }
@@ -174,9 +174,9 @@ void Win32BIGFileSystem::Close_Archive_File(const char *filename)
     }
 }
 
-void Win32BIGFileSystem::Load_Archives_From_Dir(AsciiString dir, AsciiString filter, bool read_subdirs)
+void Win32BIGFileSystem::Load_Archives_From_Dir(Utf8String dir, Utf8String filter, bool read_subdirs)
 {
-    std::set<AsciiString, rts::less_than_nocase<AsciiString>> file_list;
+    std::set<Utf8String, rts::less_than_nocase<Utf8String>> file_list;
 
     g_theLocalFileSystem->Get_File_List_From_Dir(dir, "", filter, file_list, read_subdirs);
 

--- a/src/platform/win32bigfilesystem.h
+++ b/src/platform/win32bigfilesystem.h
@@ -36,5 +36,5 @@ public:
     virtual void Close_Archive_File(const char *filename) override;
     virtual void Close_All_Archives() override {}
     virtual void Close_All_Files() override {}
-    virtual void Load_Archives_From_Dir(AsciiString dir, AsciiString filter, bool read_subdirs) override;
+    virtual void Load_Archives_From_Dir(Utf8String dir, Utf8String filter, bool read_subdirs) override;
 };

--- a/src/platform/win32localfile.cpp
+++ b/src/platform/win32localfile.cpp
@@ -174,7 +174,7 @@ bool Win32LocalFile::Scan_Int(int &integer)
 {
     DEBUG_LOG("Scanning Int from Win32LocalFile %s.\n", m_filename.Str());
     char tmp;
-    AsciiString number;
+    Utf8String number;
 
     integer = 0;
 
@@ -215,7 +215,7 @@ bool Win32LocalFile::Scan_Real(float &real)
 {
     DEBUG_LOG("Scanning Real from Win32LocalFile %s.\n", m_filename.Str());
     char tmp;
-    AsciiString number;
+    Utf8String number;
 
     real = 0.0f;
 
@@ -258,7 +258,7 @@ bool Win32LocalFile::Scan_Real(float &real)
     return true;
 }
 
-bool Win32LocalFile::Scan_String(AsciiString &string)
+bool Win32LocalFile::Scan_String(Utf8String &string)
 {
     DEBUG_LOG("Scanning String from Win32LocalFile %s.\n", m_filename.Str());
     char tmp;

--- a/src/platform/win32localfile.h
+++ b/src/platform/win32localfile.h
@@ -41,7 +41,7 @@ public:
     virtual void Next_Line(char *dst, int bytes) override;
     virtual bool Scan_Int(int &integer) override;
     virtual bool Scan_Real(float &real) override;
-    virtual bool Scan_String(AsciiString &string) override;
+    virtual bool Scan_String(Utf8String &string) override;
 
 private:
     int FileHandle;

--- a/src/platform/win32localfilesystem.cpp
+++ b/src/platform/win32localfilesystem.cpp
@@ -39,9 +39,9 @@ File *Win32LocalFileSystem::Open_File(const char *filename, int mode)
     // If we need to write a file, ensure the needed directory exists.
     if ((mode & File::WRITE) != 0) {
         DEBUG_LOG("Preparing file '%s' for write access.\n", filename);
-        AsciiString name = filename;
-        AsciiString token;
-        AsciiString path;
+        Utf8String name = filename;
+        Utf8String token;
+        Utf8String path;
 
         name.Next_Token(&token, "\\/");
         path = token;
@@ -71,10 +71,10 @@ bool Win32LocalFileSystem::Does_File_Exist(const char *filename)
     return access(filename, 0) == 0;
 }
 
-void Win32LocalFileSystem::Get_File_List_From_Dir(AsciiString const &subdir, AsciiString const &dirpath,
-    AsciiString const &filter, std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdirs)
+void Win32LocalFileSystem::Get_File_List_From_Dir(Utf8String const &subdir, Utf8String const &dirpath,
+    Utf8String const &filter, std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdirs)
 {
-    AsciiString search_path = dirpath;
+    Utf8String search_path = dirpath;
     search_path += subdir;
     search_path += filter;
 
@@ -86,10 +86,10 @@ void Win32LocalFileSystem::Get_File_List_From_Dir(AsciiString const &subdir, Asc
         // Loop over all files in the directory, ignoring other directories
         do {
             if (!(data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY)) {
-                AsciiString name = UTF16To8(data.cFileName);
+                Utf8String name = UTF16To8(data.cFileName);
 
                 if (name != "." && name != "..") {
-                    AsciiString filepath = dirpath;
+                    Utf8String filepath = dirpath;
                     filepath += subdir;
                     filepath += name;
                     // filelist.insert(filepath.Posix_Path()); // TODO 0x006C8400 relies on '\' as path sep.
@@ -103,7 +103,7 @@ void Win32LocalFileSystem::Get_File_List_From_Dir(AsciiString const &subdir, Asc
 
     // Recurse into subdirectories if required.
     if (search_subdirs) {
-        AsciiString sub_path = dirpath;
+        Utf8String sub_path = dirpath;
         sub_path += subdir;
         sub_path += "*.";
 
@@ -113,10 +113,10 @@ void Win32LocalFileSystem::Get_File_List_From_Dir(AsciiString const &subdir, Asc
             // Loop over all files in the directory finding only directories.
             do {
                 if (data.dwFileAttributes & FILE_ATTRIBUTE_DIRECTORY) {
-                    AsciiString name = UTF16To8(data.cFileName);
+                    Utf8String name = UTF16To8(data.cFileName);
 
                     if (name != "." && name != "..") {
-                        AsciiString filepath;
+                        Utf8String filepath;
                         filepath += subdir;
                         filepath += name;
                         filepath += '\\';
@@ -134,7 +134,7 @@ void Win32LocalFileSystem::Get_File_List_From_Dir(AsciiString const &subdir, Asc
 #endif
 }
 
-bool Win32LocalFileSystem::Get_File_Info(AsciiString const &filename, FileInfo *info)
+bool Win32LocalFileSystem::Get_File_Info(Utf8String const &filename, FileInfo *info)
 {
     // TODO Make this cross platform.
 #ifdef PLATFORM_WINDOWS
@@ -173,7 +173,7 @@ bool Win32LocalFileSystem::Get_File_Info(AsciiString const &filename, FileInfo *
 #endif
 }
 
-bool Win32LocalFileSystem::Create_Directory(AsciiString dir_path)
+bool Win32LocalFileSystem::Create_Directory(Utf8String dir_path)
 {
     if (dir_path.Is_Empty() || dir_path.Get_Length() > PATH_MAX) {
         return false;

--- a/src/platform/win32localfilesystem.h
+++ b/src/platform/win32localfilesystem.h
@@ -31,8 +31,8 @@ public:
     // LocalFileSystem interface implementations.
     virtual File *Open_File(const char *filename, int mode) override;
     virtual bool Does_File_Exist(const char *filename) override;
-    virtual void Get_File_List_From_Dir(AsciiString const &subdir, AsciiString const &dirpath, AsciiString const &filter,
-        std::set<AsciiString, rts::less_than_nocase<AsciiString>> &filelist, bool search_subdirs) override;
-    virtual bool Get_File_Info(AsciiString const &filename, FileInfo *info) override;
-    virtual bool Create_Directory(AsciiString dir_path) override;
+    virtual void Get_File_List_From_Dir(Utf8String const &subdir, Utf8String const &dirpath, Utf8String const &filter,
+        std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist, bool search_subdirs) override;
+    virtual bool Get_File_Info(Utf8String const &filename, FileInfo *info) override;
+    virtual bool Create_Directory(Utf8String dir_path) override;
 };


### PR DESCRIPTION
Requires ICU on none windows platforms to support UTF-16 unicode strings correctly and to provide correct conversion functions between UTF-8 and UTF-16 strings on those platforms. Windows build can also optionally be built against it by setting ICU_ROOT in cmake to the path to the ICU installation (will need a custom build for 32bit).

Also implements translation functions using correct conversions functions where previously a naive copy was done that appeared to assume the multi byte strings were in Windows-1252 code page and corresponded to the first 255 unicode characters in UTF-16. This should also allow .str files to be encoded in UTF-8 and support other languages besides European languages.