### PR TITLE
Remove C++14 feature

### DIFF
--- a/src/game/common/crc.cpp
+++ b/src/game/common/crc.cpp
@@ -15,7 +15,7 @@
 #include "crc.h"
 
 template<typename T, int N>
-inline constexpr auto calculateCRC()
+inline constexpr Array<T,N> calculateCRC()
 {
 	Array<T,N> lookup;
 	const unsigned long POLYNOMIAL = 0xEDB88320;


### PR DESCRIPTION
auto return types are a C++14 feature, but the project is C++11