### PR TITLE
Remove C++14 feature

### DIFF
--- a/src/w3d/math/gamemath.cpp
+++ b/src/w3d/math/gamemath.cpp
@@ -17,7 +17,7 @@
 #include "gamemath.h"
 
 template<typename T, int N>
-inline constexpr auto calculateFastTable(T(*func)(T),bool arc)
+inline constexpr Array<T, N> calculateFastTable(T(*func)(T),bool arc)
 {
 	Array<T, N> table;
 	for (int a = 0; a < N; ++a) 


### PR DESCRIPTION
auto-deduce types are a C++14 thing, but the code is compiled as C++11

This should be the last c++14 feature and the code is able to be compiled as c++11, as stated in cmakelists.txt.