### PR TITLE
Fixes #139, issues with texture colors/brightness.

### DIFF
--- a/src/w3d/renderer/colorspace.cpp
+++ b/src/w3d/renderer/colorspace.cpp
@@ -109,7 +109,7 @@ void HSV_To_RGBA(Vector4 &rgba, const Vector3 &hsv)
  */
 void Adjust_RGBA(Vector4 &rgba, const Vector3 &hsv_adj)
 {
-    Vector3 hsv;
+    Vector3 hsv(0.0f, 0.0f, 0.0f);
     RGBA_To_HSV(hsv, rgba);
 
     if (hsv.X > 0.0f) {

--- a/src/w3d/renderer/textureloader.cpp
+++ b/src/w3d/renderer/textureloader.cpp
@@ -62,7 +62,7 @@ w3dtexture_t Load_Compressed_Texture(
 
         for (unsigned i = 0; i < dds.Get_Mip_Level_Count(); ++i) {
             texture->GetSurfaceLevel(i, &surface);
-            dds.Copy_Level_To_Surface(i, surface, Vector3());
+            dds.Copy_Level_To_Surface(i, surface, Vector3(0.0f, 0.0f, 0.0f));
             surface->Release();
         };
 
@@ -242,7 +242,7 @@ w3dsurface_t TextureLoader::Load_Surface_Immediate(const StringClass &texture, W
             (uint8_t *)targa.Get_Palette(),
             targa.Get_Header().cmap_depth >> 3,
             false,
-            Vector3());
+            Vector3(0.0f, 0.0f, 0.0f));
         src_surface = dest_surface;
         src_format = WW3D_FORMAT_A8R8G8B8;
         src_bpp = Get_Bytes_Per_Pixel(WW3D_FORMAT_A8R8G8B8);
@@ -265,7 +265,7 @@ w3dsurface_t TextureLoader::Load_Surface_Immediate(const StringClass &texture, W
         (uint8_t *)targa.Get_Palette(),
         targa.Get_Header().cmap_depth >> 3,
         false,
-        Vector3());
+        Vector3(0.0f, 0.0f, 0.0f));
     surface->UnlockRect();
 #endif
     if (dest_surface) {

--- a/src/w3d/renderer/textureloadtask.cpp
+++ b/src/w3d/renderer/textureloadtask.cpp
@@ -46,7 +46,7 @@ TextureLoadTaskClass::TextureLoadTaskClass() :
     m_height(0),
     m_mipLevelCount(0),
     m_reduction(0),
-    m_hsvAdjust(),
+    m_hsvAdjust(0.0f, 0.0f, 0.0f),
     m_type(TASK_NONE),
     m_priority(PRIORITY_BACKGROUND),
     m_loadState(STATE_NONE)
@@ -441,7 +441,7 @@ bool TextureLoadTaskClass::Load_Uncompressed_Mipmap()
                 0,
                 0,
                 true,
-                Vector3());
+                Vector3(0.0f, 0.0f, 0.0f));
             width >>= 1;
             height >>= 1;
             srcwidth >>= 1;
@@ -469,7 +469,7 @@ bool TextureLoadTaskClass::Load_Uncompressed_Mipmap()
             0,
             0,
             true,
-            Vector3());
+            Vector3(0.0f, 0.0f, 0.0f));
         width >>= 1;
         height >>= 1;
         srcwidth >>= 1;

--- a/src/w3d/renderer/thumbnail.cpp
+++ b/src/w3d/renderer/thumbnail.cpp
@@ -80,7 +80,8 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass *manager, const StringClass
         m_bitmap = new uint8_t[2 * m_height * m_width];
         m_isAllocated = true;
 
-        dds.Copy_Level_To_Surface(0, WW3D_FORMAT_A4R4G4B4, m_width, m_height, m_bitmap, 2 * m_width, Vector3());
+        dds.Copy_Level_To_Surface(
+            0, WW3D_FORMAT_A4R4G4B4, m_width, m_height, m_bitmap, 2 * m_width, Vector3(0.0f, 0.0f, 0.0f));
     } else {
         TargaImage targa;
 
@@ -154,7 +155,7 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass *manager, const StringClass
                 (uint8_t *)targa.Get_Palette(),
                 (uint8_t)targa.Get_Header().cmap_depth / 8,
                 false,
-                Vector3());
+                Vector3(0.0f, 0.0f, 0.0f));
         }
     }
 


### PR DESCRIPTION
Ensures vector3 temporaries are zero initialised given the
authentic default ctor for Vector3 looks like it was uninitialised.