### PR TITLE
Few changes to better match known symbols.

### DIFF
--- a/src/game/common/audio/soundmanager.h
+++ b/src/game/common/audio/soundmanager.h
@@ -23,6 +23,7 @@ class SoundManager : public SubsystemInterface
 {
 public:
     virtual void Init() override {}
+    virtual void PostProcessLoad() override {}
     virtual void Reset() override;
     virtual void Update() override {}
     virtual void Lose_Focus() {}

--- a/src/w3d/renderer/texturebase.cpp
+++ b/src/w3d/renderer/texturebase.cpp
@@ -96,7 +96,7 @@ void TextureBaseClass::Invalidate()
 /**
  * Set a HSV adjustment.
  */
-void TextureBaseClass::Set_Recolor(const Vector3 &shift)
+void TextureBaseClass::Set_HSV_Shift(const Vector3 &shift)
 {
     Invalidate();
     m_hsvShift = shift;

--- a/src/w3d/renderer/texturebase.h
+++ b/src/w3d/renderer/texturebase.h
@@ -78,7 +78,7 @@ public:
     }
     void Set_Platform_Base_Texture(w3dbasetexture_t tex);
     void Set_Texture_Name(const char *name) { m_name = name; }
-    void Set_Recolor(const Vector3 &shift);
+    void Set_HSV_Shift(const Vector3 &shift);
     unsigned Get_Reduction() const;
     void Load_Locked_Surface();
     bool Is_Missing_Texture() const;
@@ -88,7 +88,7 @@ public:
     TextureLoadTaskClass *Get_Thumbnail_Load_Task() { return m_thumbnailTextureLoadTask; }
     const StringClass &Get_Full_Path() const { return m_fullPath; }
     const StringClass &Get_Name() const { return m_name; }
-    const Vector3 &Get_Recolor() const { return m_hsvShift; }
+    const Vector3 &Get_HSV_Shift() const { return m_hsvShift; }
     bool Is_Initialized() const { return m_initialized; }
     void Set_Dirty(bool dirty) { m_dirty = dirty; }
 

--- a/src/w3d/renderer/textureloader.cpp
+++ b/src/w3d/renderer/textureloader.cpp
@@ -516,7 +516,7 @@ void TextureLoader::Begin_Load_And_Queue(TextureLoadTaskClass *task)
 void TextureLoader::Load_Thumbnail(TextureBaseClass *texture)
 {
     const StringClass *name = texture->Get_Full_Path().Is_Empty() ? &texture->Get_Name() : &texture->Get_Full_Path();
-    w3dtexture_t tex = Load_Thumbnail(*name, texture->Get_Recolor());
+    w3dtexture_t tex = Load_Thumbnail(*name, texture->Get_HSV_Shift());
     texture->Apply_New_Surface(tex, false, false);
 #ifdef BUILD_WITH_D3D8
     tex->Release();


### PR DESCRIPTION
Renames a TextureBaseClass functions to match symbols.
Adds empty implementation of a virtual in SoundManager as per original.