### PR TITLE
Fixes RectClass::Set(float, float, float, float)

### DIFF
--- a/src/w3d/math/rect.h
+++ b/src/w3d/math/rect.h
@@ -68,12 +68,12 @@ public:
         return (rval.left != left) || (rval.right != right) || (rval.top != top) || (rval.bottom != bottom);
     }
 
-    void Set(float left, float top, float right, float bottom)
+    void Set(float _left, float _top, float _right, float _bottom)
     {
-        left = left;
-        top = top;
-        right = right;
-        bottom = bottom;
+        left = _left;
+        top = _top;
+        right = _right;
+        bottom = _bottom;
     }
 
     void Set(const Vector2 &top_left, const Vector2 &bottom_right)


### PR DESCRIPTION
Due to using the same names for the member variables and the function parameters the member variables were hidden and the function turned into a big NOP.