### PR TITLE
Fixes Image::Parse_Image_Status and applies hook

### DIFF
--- a/src/game/client/image.cpp
+++ b/src/game/client/image.cpp
@@ -35,6 +35,7 @@ Image::~Image()
     return;
 }
 
+// 0x00519260
 void Image::Set_Status(uint32_t bit)
 {
     m_status |= bit;
@@ -45,6 +46,7 @@ void Image::Clear_Status(uint32_t bit)
     m_status &= ~bit;
 }
 
+// 0x00518F10
 void Image::Parse_Image_Coords(INI *ini, void *formal, void *store, const void *user_data)
 {
     Image *image = static_cast<Image *>(formal);
@@ -78,19 +80,15 @@ void Image::Parse_Image_Coords(INI *ini, void *formal, void *store, const void *
     image->m_imageSize.y = bottom - top;
 }
 
+// 0x00519030
 void Image::Parse_Image_Status(INI *ini, void *instance, void *store, const void *user_data)
 {
     const char *_imageStatusNames[3] = { "ROTATED_90_CLOCKWISE", "RAW_TEXTURE", nullptr };
-    enum _imageStatus // this does not seem to be used anywhere else. If WB proves otherwise, refactor.
-    {
-        IMAGE_STATUS_NONE,
-        IMAGE_STATUS_ROTATED_90_CLOCKWISE,
-        IMAGE_STATUS_RAW_TEXTURE
-    };
+
     Image *image = static_cast<Image *>(instance);
     ini->Parse_Bitstring32(ini, instance, store, _imageStatusNames);
     uint8_t *byte = static_cast<uint8_t *>(store);
-    if (*byte == IMAGE_STATUS_ROTATED_90_CLOCKWISE) {
+    if (*byte & IMAGE_STATUS_ROTATED_90_CLOCKWISE) {
         int oldx = image->m_imageSize.x;
         image->m_imageSize.x = image->m_imageSize.y;
         image->m_imageSize.y = oldx;

--- a/src/game/client/image.h
+++ b/src/game/client/image.h
@@ -33,16 +33,26 @@ public:
     // Methods
     void Clear_Status(uint32_t bit); // TODO not hooked or verified
     void Set_Status(uint32_t bit);
+    bool Is_Set_Status(uint32_t bit) const { return m_status & bit; }
+    TextureClass *Get_Raw_Texture_Data() { return m_rawTextureData; }
+    Utf8String Get_File_Name() { return m_filename; }
+    Region2D Get_UV_Region() const { return m_UVCoords; }
 
     // initFromINIMulti variants for Field Parsing Functions.
     static void Parse_Image_Coords(INI *ini, void *formal, void *store, const void *user_data);
-    static void Parse_Image_Status(INI *ini, void *formal, void *store, const void *user_data); // TODO not hooked or
-                                                                                                // verified
+    static void Parse_Image_Status(INI *ini, void *formal, void *store, const void *user_data);
 
 #ifdef GAME_DLL
     Image *Hook_Ctor() { return new (this) Image(); }
     void Hook_Dtor() { Image::~Image(); }
 #endif
+
+    enum ImageStatus // Note these are flags
+    {
+        IMAGE_STATUS_NONE = 0,
+        IMAGE_STATUS_ROTATED_90_CLOCKWISE = (1 << 0),
+        IMAGE_STATUS_RAW_TEXTURE = (1 << 1),
+    };
 
 private:
     Utf8String m_name;

--- a/src/hooker/setuphooks_zh.cpp
+++ b/src/hooker/setuphooks_zh.cpp
@@ -56,6 +56,7 @@
 #include "ini.h"
 #include "keyboard.h"
 #include "main.h"
+#include "matpass.h"
 #include "messagestream.h"
 #include "milesaudiofilecache.h"
 #include "milesaudiomanager.h"
@@ -98,7 +99,6 @@
 #include "w3dfilesystem.h"
 #include "w3dmouse.h"
 #include "w3dpoly.h"
-#include "matpass.h"
 #include "w3droadbuffer.h"
 #include "weapon.h"
 #include "win32gameengine.h"
@@ -971,7 +971,7 @@ void Setup_Hooks()
     // Hook_Method(0x00000000, &Image::Clear_Status);
     Hook_Method(0x00519260, &Image::Set_Status);
     Hook_Method(0x00518F10, &Image::Parse_Image_Coords);
-    // Hook_Method(0x00000000, &Image::Parse_Image_Status);
+    Hook_Method(0x00519030, &Image::Parse_Image_Status);
 
     // w3droadbuffer.h
     Hook_Method(0x00795F90, &W3DRoadBuffer::Hook_Dtor);
@@ -1062,7 +1062,7 @@ void Setup_Hooks()
     Hook_Method(0x00842FA0, &FontCharsClass::Get_Char_Data);
     Hook_Method(0x00843750, &FontCharsClass::Grow_Unicode_Array);
     Hook_Method(0x00843860, &FontCharsClass::Free_Character_Arrays);
-    
+
     // gameclient.h
     Hook_Method(0x00613D10, &GameClientMessageDispatcher::Hook_Translate_Game_Message);
 
@@ -1107,7 +1107,7 @@ void Setup_Hooks()
     Hook_Any(0x007AD2D0, W3DMouse::Free_D3D_Assets);
     Hook_Any(0x007AD060, W3DMouse::Release_D3D_Cursor_Texture);
     Hook_Function(0x00775540, &Create_Mouse); // This is actually a W3DGameClient virtual method but this not used
-    
+
     // matpass.h
     Hook_Any(0x00833320, MaterialPassClass::Install_Materials);
     Hook_Any(0x008333E0, MaterialPassClass::Set_Texture);


### PR DESCRIPTION
The function was checking for a flag using == but if there was more than one flag set this would be incorrect. As these flags are used in other locations I moved the enum into the header. Accessor functions also added as required by future PR.