### PR TITLE
W3dassetmgr

### DIFF
--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -238,3 +238,8 @@ inline Utf8String &Utf8String::operator+=(Utf8String const &s)
 
     return *this;
 }
+
+// Windows to POSIX names
+// strcmpi = strcasecmp
+// strnicmp = strncasecmp
+// sprintf_s = snprintf

--- a/src/hooker/setupglobals_zh.cpp
+++ b/src/hooker/setupglobals_zh.cpp
@@ -477,7 +477,7 @@ CriticalSectionClass &g_mouseCriticalSection = Make_Global<CriticalSectionClass>
 
 // w3ddisplay.cpp
 #include "w3ddisplay.h"
-W3DAssetManager *&W3DDisplay::s_assetManager = Make_Global<W3DAssetManager *>(0x00A32518);
+GameAssetManager *&W3DDisplay::s_assetManager = Make_Global<GameAssetManager *>(0x00A32518);
 SceneClass *&W3DDisplay::s_3DScene = Make_Global<SceneClass *>(0x00A3250C); // TODO: Actual type is RTS2DScene
 SceneClass *&W3DDisplay::s_2DScene = Make_Global<SceneClass *>(0x00A32510); // TODO: Actual type is RTS2DScene
 SceneClass *&W3DDisplay::s_3DInterfaceScene =
@@ -517,3 +517,7 @@ AI *&g_theAI = Make_Global<AI *>(PICK_ADDRESS(0x00A2BBF4, 0));
 // terrainlogic.cpp
 #include "terrainlogic.h"
 TerrainLogic *&g_theTerrainLogic = Make_Global<TerrainLogic *>(PICK_ADDRESS(0x00A2B680, 0));
+
+// assetmgr.cpp
+#include "assetmgr.h"
+NullPrototypeClass &s_nullPrototype = Make_Global<NullPrototypeClass>(0x00A4C1B8);

--- a/src/hooker/setuphooks_zh.cpp
+++ b/src/hooker/setuphooks_zh.cpp
@@ -15,6 +15,7 @@
 #include "archivefile.h"
 #include "archivefilesystem.h"
 #include "asciistring.h"
+#include "assetmgr.h"
 #include "audioeventrts.h"
 #include "audiomanager.h"
 #include "binkvideoplayer.h"
@@ -1407,4 +1408,38 @@ void Setup_Hooks()
     Hook_Any(0x008401D0, HTreeClass::Release_Bone);
     Hook_Any(0x00840200, HTreeClass::Is_Bone_Captured);
     Hook_Any(0x00840220, HTreeClass::Control_Bone);
+
+    // assetmgr.h
+    Hook_Any(0x008147C0, W3DAssetManager::Free_Assets);
+    Hook_Any(0x00814850, W3DAssetManager::Release_Unused_Assets);
+    // Hook_Any(0x00814870, W3DAssetManager::Free_Assets_With_Exclusion_List);
+    Hook_Any(0x00814A60, W3DAssetManager::Create_Asset_List);
+    Hook_Any(0x00814FC0, W3DAssetManager::Create_Render_Obj);
+    Hook_Any(0x008152C0, W3DAssetManager::Render_Obj_Exists);
+    Hook_Any(0x00815340, W3DAssetManager::Create_Render_Obj_Iterator);
+    // Can't hook due to reuse of address Hook_Any(0x00815370, W3DAssetManager::Release_Render_Obj_Iterator);
+    Hook_Any(0x00815390, W3DAssetManager::Create_HAnim_Iterator);
+    Hook_Any(0x008154F0, W3DAssetManager::Get_HAnim);
+    Hook_Any(0x00765FF0, W3DAssetManager::Add_Anim);
+    Hook_Any(0x00815920, W3DAssetManager::Get_Texture);
+    Hook_Any(0x00815C90, W3DAssetManager::Release_All_Textures);
+    Hook_Any(0x00815D90, W3DAssetManager::Release_Unused_Textures);
+    Hook_Any(0x00816090, W3DAssetManager::Release_Texture);
+    Hook_Any(0x008145A0, W3DAssetManager::Load_Procedural_Textures);
+    Hook_Any(0x00766010, W3DAssetManager::Peek_Metal_Map_Manager);
+    Hook_Any(0x008161A0, W3DAssetManager::Get_Font3DInstance);
+    Hook_Any(0x00816370, W3DAssetManager::Get_FontChars);
+    Hook_Any(0x00815440, W3DAssetManager::Create_HTree_Iterator);
+    Hook_Any(0x00815720, W3DAssetManager::Get_HTree);
+    Hook_Any(0x00816550, W3DAssetManager::Register_Prototype_Loader);
+    Hook_Any(0x00815460, W3DAssetManager::Create_Font3DData_Iterator);
+    Hook_Any(0x008162B0, W3DAssetManager::Add_Font3DData);
+    Hook_Any(0x008162D0, W3DAssetManager::Remove_Font3DData);
+    Hook_Any(0x00816210, W3DAssetManager::Get_Font3DData);
+    Hook_Any(0x00816300, W3DAssetManager::Release_All_Font3DDatas);
+    Hook_Any(0x00816330, W3DAssetManager::Release_Unused_Font3DDatas);
+    Hook_Any(0x008164C0, W3DAssetManager::Release_All_FontChars);
+
+    Hook_Method(0x00763D70, &GameAssetManager::Hook_Ctor);
+
 }

--- a/src/platform/w3dengine/client/w3ddisplay.cpp
+++ b/src/platform/w3dengine/client/w3ddisplay.cpp
@@ -31,7 +31,7 @@
 #include "w3d.h"
 
 #ifndef GAME_DLL
-W3DAssetManager *W3DDisplay::s_assetManager; // TODO: Actual type is GameAssetManager
+GameAssetManager *W3DDisplay::s_assetManager;
 SceneClass *W3DDisplay::s_3DScene; // TODO: Actual type is RTS2DScene
 SceneClass *W3DDisplay::s_2DScene; // TODO: Actual type is RTS2DScene
 SceneClass *W3DDisplay::s_3DInterfaceScene; // TODO: Actual type is RTS3DInterfaceScene
@@ -99,7 +99,7 @@ W3DDisplay::~W3DDisplay()
 // 0x0073CA80
 void W3DDisplay::Init()
 {
-    // TODO: Requires RTS3DInterfaceScene, RTS2DScene, RTS3DScene, W3DAssetManager, ...
+    // TODO: Requires RTS3DInterfaceScene, RTS2DScene, RTS3DScene, GameAssetManager, ...
 #ifdef GAME_DLL
     Call_Method<void, W3DDisplay>(0x0073CA80, this);
 #endif

--- a/src/platform/w3dengine/client/w3ddisplay.h
+++ b/src/platform/w3dengine/client/w3ddisplay.h
@@ -20,7 +20,7 @@
 #include "render2d.h"
 #include "scene.h"
 
-class W3DAssetManager;
+class GameAssetManager;
 
 class W3DDisplay final : public Display
 {
@@ -72,7 +72,7 @@ public:
     virtual float Get_Average_FPS() override { return m_averageFps; }
     virtual int Get_Last_Frame_Draw_Calls() override;
 
-    static W3DAssetManager *Get_AssetManager() { return s_assetManager; }
+    static GameAssetManager *Get_AssetManager() { return s_assetManager; }
     static SceneClass *Get_3DInterfaceScene() { return s_3DInterfaceScene; }
 
 private:
@@ -90,12 +90,12 @@ private:
     uint32_t m_nativeDebugDisplay;
 
 #ifdef GAME_DLL
-    static W3DAssetManager *&s_assetManager; // TODO: Actual type is GameAssetManager
+    static GameAssetManager *&s_assetManager;
     static SceneClass *&s_3DScene; // TODO: Actual type is RTS2DScene
     static SceneClass *&s_2DScene; // TODO: Actual type is RTS2DScene
     static SceneClass *&s_3DInterfaceScene; // TODO: Actual type is RTS3DInterfaceScene
 #else
-    static W3DAssetManager *s_assetManager; // TODO: Actual type is GameAssetManager
+    static GameAssetManager *s_assetManager;
     static SceneClass *s_3DScene; // TODO: Actual type is RTS2DScene
     static SceneClass *s_2DScene; // TODO: Actual type is RTS2DScene
     static SceneClass *s_3DInterfaceScene; // TODO: Actual type is RTS3DInterfaceScene

--- a/src/platform/w3dengine/client/w3dmouse.cpp
+++ b/src/platform/w3dengine/client/w3dmouse.cpp
@@ -352,7 +352,7 @@ void W3DMouse::Release_D3D_Cursor_Texture(MouseCursor cursor)
 // 0x007AD0E0
 void W3DMouse::Load_D3D_Cursor_Texture(MouseCursor cursor)
 {
-    // TODO: Requires WW3DAssetManager
+    // TODO: Requires W3DAssetManager
 #ifdef GAME_DLL
     Call_Method<void, W3DMouse>(0x007AD0E0, this);
 #endif

--- a/src/w3d/renderer/assetmgr.cpp
+++ b/src/w3d/renderer/assetmgr.cpp
@@ -13,6 +13,794 @@
  *            LICENSE
  */
 #include "assetmgr.h"
+#include "chunkio.h"
+#include "crc.h"
+#include "ffactory.h"
+#include "fileclass.h"
+#include "mesh.h"
+#include "proto.h"
+#include "render2dsentence.h"
+#include "string.h"
+#include "w3d_file.h"
+#include <cmath>
+#include <stdio.h>
+
 #ifndef GAME_DLL
 W3DAssetManager * ::W3DAssetManager::s_theInstance;
+NullPrototypeClass s_nullPrototype;
 #endif
+
+// 0x00814090
+W3DAssetManager::W3DAssetManager()
+{
+#ifdef GAME_DLL
+    Call_Method<void, W3DAssetManager>(0x00814090, this);
+#endif
+}
+
+// 0x008143C0
+W3DAssetManager::~W3DAssetManager()
+{
+    Free_Assets();
+    s_theInstance = nullptr;
+    delete[] m_prototypeHashTable;
+}
+
+// 0x00814C30
+bool W3DAssetManager::Load_3D_Assets(const char *filename)
+{
+    auto file = g_theFileFactory->Get_File(filename);
+    if (file == nullptr) {
+        return false;
+    }
+
+    if (file->Is_Available() == false) {
+        g_theFileFactory->Return_File(file);
+        return false;
+    }
+
+    Load_3D_Assets(*file);
+    g_theFileFactory->Return_File(file);
+    return true;
+}
+
+// 0x00814E10
+bool W3DAssetManager::Load_3D_Assets(FileClass &asset_file)
+{
+    if (asset_file.Open() == false) {
+        return false;
+    }
+
+    for (ChunkLoadClass chunk(&asset_file); chunk.Open_Chunk(); chunk.Close_Chunk()) {
+        auto chunk_id = chunk.Cur_Chunk_ID();
+        switch (chunk_id) {
+            case W3D_CHUNK_COMPRESSED_ANIMATION:
+            case W3D_CHUNK_ANIMATION:
+            case W3D_CHUNK_MORPH_ANIMATION:
+                m_hAnimManager.Load_Anim(chunk);
+                break;
+            case W3D_CHUNK_HIERARCHY:
+                m_hTreeManager.Load_Tree(chunk);
+                break;
+            default: {
+                for (auto i = 0; i < m_prototypeLoaders.Count(); ++i) {
+                    auto *loader = m_prototypeLoaders[i];
+
+                    if (loader == nullptr) {
+                        continue;
+                    }
+
+                    if (loader->Chunk_Type() != chunk_id) {
+                        continue;
+                    }
+
+                    auto *prototype = loader->Load_W3D(chunk);
+                    if (prototype == nullptr) {
+                        continue;
+                    }
+
+                    const auto *name = prototype->Get_Name();
+                    if (Render_Obj_Exists(name)) {
+                        prototype->Delete_Self();
+                    } else {
+                        Prototype_Hash_Table_Add(prototype);
+                        m_prototypes.Add(prototype);
+                    }
+                }
+                break;
+            }
+        }
+    }
+
+    asset_file.Close();
+    return true;
+}
+
+// 0x008147C0
+void W3DAssetManager::Free_Assets()
+{
+    for (auto i = m_prototypes.Count() - 1; i >= 0; --i) {
+        auto *prototype = m_prototypes[i];
+        m_prototypes.Delete(i);
+        if (prototype != nullptr) {
+            prototype->Delete_Self();
+        }
+    }
+    memset(m_prototypeHashTable, 0, s_prototypeHashTableSize * sizeof(uintptr_t));
+    m_hAnimManager.Free_All_Anims();
+    m_hTreeManager.Free_All_Trees();
+    Release_All_Textures();
+    Release_All_FontChars();
+}
+
+// 0x00814870
+void W3DAssetManager::Free_Assets_With_Exclusion_List(DynamicVectorClass<StringClass> const &list)
+{
+#ifdef GAME_DLL
+    Call_Method<void, W3DAssetManager, DynamicVectorClass<StringClass> const &>(0x00814870, this, list);
+#endif
+}
+
+// 0x00814A60
+void W3DAssetManager::Create_Asset_List(DynamicVectorClass<StringClass> &list)
+{
+    captainslog_dbgassert(false, "Create_Asset_List is not used");
+    // Not used
+    for (auto i = 0; i < m_prototypes.Count(); ++i) {
+        auto *proto = m_prototypes[i];
+        if (proto == nullptr) {
+            continue;
+        }
+
+        const auto *name = proto->Get_Name();
+        if (strchr(name, '#') != nullptr) {
+            continue;
+        }
+        const auto *period = strchr(name, '.');
+        if (period == nullptr) {
+            continue;
+        }
+        list.Add(name);
+    }
+    m_hAnimManager.Create_Asset_List(list);
+}
+
+// 0x00814FC0
+RenderObjClass *W3DAssetManager::Create_Render_Obj(const char *name)
+{
+    auto *proto = Find_Prototype(name);
+
+    if (m_loadOnDemand && proto == nullptr) {
+        char asset_filename[256]{};
+        auto *period = strchr(name, '.');
+        if (period == nullptr) {
+            snprintf(asset_filename, 256, "%s.w3d", name);
+        } else {
+            snprintf(asset_filename, 256, "%s.w3d", period + 1);
+        }
+
+        if (Load_3D_Assets(asset_filename) == false) {
+            StringClass new_filename = StringClass{ "..\\", true } + asset_filename;
+            Load_3D_Assets(new_filename);
+        }
+
+        proto = Find_Prototype(name);
+    }
+    if (proto == nullptr) {
+        return nullptr;
+    }
+    return proto->Create();
+}
+
+// 0x008152C0
+bool W3DAssetManager::Render_Obj_Exists(const char *name)
+{
+    if (strcasecmp(name, "NULL") == 0) {
+        return true;
+    }
+
+    auto proto = Prototype_Hash_Table_Find(name);
+    return proto != nullptr;
+}
+
+// 0x00815340
+RenderObjIterator *W3DAssetManager::Create_Render_Obj_Iterator()
+{
+    captainslog_dbgassert(false, "RenderObjIterator class is not used");
+    return nullptr;
+}
+
+// 0x00815370
+void W3DAssetManager::Release_Render_Obj_Iterator(RenderObjIterator *it)
+{
+    captainslog_dbgassert(false, "RenderObjIterator class is not used");
+}
+
+// 0x00815390
+AssetIterator *W3DAssetManager::Create_HAnim_Iterator(void)
+{
+    captainslog_dbgassert(false, "HAnim Iterator class is not used");
+    return nullptr;
+}
+
+// 0x008154F0
+HAnimClass *W3DAssetManager::Get_HAnim(const char *name)
+{
+    auto *anim = m_hAnimManager.Get_Anim(name);
+    if (m_loadOnDemand == false || anim != nullptr) {
+        return anim;
+    }
+
+    if (m_hAnimManager.Is_Missing(name)) {
+        return anim;
+    }
+
+    const char *asset = strchr(name, '.');
+    if (asset == nullptr) {
+        return nullptr;
+    }
+    // Skip over the seperator
+    asset++;
+
+    char asset_filename[256]{};
+    snprintf(asset_filename, 256, "%s.w3d", asset);
+
+    if (Load_3D_Assets(asset_filename) == false) {
+        StringClass new_filename = StringClass{ "..\\", true } + asset_filename;
+        Load_3D_Assets(new_filename);
+    }
+    anim = m_hAnimManager.Get_Anim(name);
+    if (anim == nullptr) {
+        m_hAnimManager.Register_Missing(name);
+    }
+
+    return anim;
+}
+
+// 0x00765FF0
+bool W3DAssetManager::Add_Anim(HAnimClass *new_anim)
+{
+    // TODO: Not used?
+    return m_hAnimManager.Add_Anim(new_anim);
+}
+
+// 0x00815920
+TextureClass *W3DAssetManager::Get_Texture(const char *filename,
+    MipCountType mip_level_count,
+    WW3DFormat texture_format,
+    bool allow_compression,
+    TexAssetType asset_type,
+    bool allow_reduction)
+{
+    if (texture_format == WW3DFormat::WW3D_FORMAT_U8V8) {
+        mip_level_count = MipCountType::MIP_LEVELS_1;
+    }
+
+    if (filename == nullptr || strlen(filename) == 0) {
+        return nullptr;
+    }
+
+    StringClass name = { filename };
+    name.To_Lower();
+    auto *texture = m_textureHash.Get(name);
+    if (texture != nullptr) {
+        (*texture)->Add_Ref();
+        return *texture;
+    }
+
+    TextureClass *new_texture = nullptr;
+    switch (asset_type) {
+        case TexAssetType::ASSET_STANDARD:
+            new_texture =
+                new TextureClass{ name, nullptr, mip_level_count, texture_format, allow_compression, allow_reduction };
+            break;
+        case TexAssetType::ASSET_CUBE:
+            captainslog_dbgassert(false, "CubeTextureClass is not used");
+            break;
+        case TexAssetType::ASSET_VOLUME:
+            captainslog_dbgassert(false, "VolumeTextureClass is not used");
+            break;
+        default:
+            break;
+    }
+    if (new_texture == nullptr) {
+        return nullptr;
+    }
+    m_textureHash.Insert(new_texture->Get_Name(), new_texture);
+
+    new_texture->Add_Ref();
+    return new_texture;
+}
+
+// 0x00815C90
+void W3DAssetManager::Release_All_Textures()
+{
+    for (HashTemplateIterator<StringClass, TextureClass *> texture(m_textureHash); texture; texture.Reset()) {
+        texture.getValue()->Release_Ref();
+        texture.Remove();
+    }
+    m_textureHash.Remove_All();
+}
+
+// 0x00815D90
+void W3DAssetManager::Release_Unused_Textures()
+{
+    constexpr auto unused_textures_size = 256;
+    TextureClass *unused_textures[unused_textures_size]{};
+    auto unused_textures_count = 0;
+    for (HashTemplateIterator<StringClass, TextureClass *> texture(m_textureHash); texture; ++texture) {
+        if (texture.getValue()->Num_Refs() != 1) {
+            continue;
+        }
+        unused_textures[unused_textures_count++] = texture.getValue();
+
+        if (unused_textures_count < unused_textures_size) {
+            continue;
+        }
+
+        for (auto i = 0; i < unused_textures_count; ++i) {
+            auto *unused_texture = unused_textures[i];
+            m_textureHash.Remove(unused_texture->Get_Name());
+            unused_texture->Release_Ref();
+            unused_textures[i] = nullptr;
+        }
+        unused_textures_count = 0;
+        texture.Reset();
+    }
+
+    if (unused_textures_count != 0) {
+        for (auto i = 0; i < unused_textures_count; ++i) {
+            auto *unused_texture = unused_textures[i];
+            m_textureHash.Remove(unused_texture->Get_Name());
+            unused_texture->Release_Ref();
+            unused_textures[i] = nullptr;
+        }
+    }
+}
+
+// 0x00816090
+void W3DAssetManager::Release_Texture(TextureClass *tex)
+{
+    m_textureHash.Remove(tex->Get_Name());
+    tex->Release_Ref();
+}
+
+// 0x008145A0
+void W3DAssetManager::Load_Procedural_Textures()
+{
+    captainslog_dbgassert(false, "MetalMapManagerClass not used");
+}
+
+// 0x00766010
+MetalMapManagerClass *W3DAssetManager::Peek_Metal_Map_Manager()
+{
+    captainslog_dbgassert(false, "MetalMapManagerClass not used");
+    return nullptr;
+}
+
+// 0x008161A0
+Font3DInstanceClass *W3DAssetManager::Get_Font3DInstance(const char *name)
+{
+    captainslog_dbgassert(false, "Font3D classes are not used");
+    return nullptr;
+}
+
+// 0x00816370
+FontCharsClass *W3DAssetManager::Get_FontChars(const char *name, int point_size, bool is_bold)
+{
+    for (auto i = 0; i < m_fontCharsList.Count(); ++i) {
+        auto *font = m_fontCharsList[i];
+        if (font->Is_Font(name, point_size, is_bold)) {
+            font->Add_Ref();
+            return font;
+        }
+    }
+
+    // Font not found so will create a new font
+    auto *font = new FontCharsClass;
+    font->Initialize_GDI_Font(name, point_size, is_bold);
+    font->Add_Ref();
+    m_fontCharsList.Add(font);
+    return font;
+}
+
+// 0x00815440
+AssetIterator *W3DAssetManager::Create_HTree_Iterator()
+{
+    captainslog_dbgassert(false, "HTree Iterator class is not used");
+    return nullptr;
+}
+
+// 0x00815720
+HTreeClass *W3DAssetManager::Get_HTree(const char *name)
+{
+    auto *hTree = m_hTreeManager.Get_Tree(name);
+    if (m_loadOnDemand == false || hTree != nullptr) {
+        return hTree;
+    }
+
+    char asset_filename[256]{};
+    snprintf(asset_filename, 256, "%s.w3d", name);
+
+    if (Load_3D_Assets(asset_filename) == false) {
+        StringClass new_filename = StringClass{ "..\\", true } + asset_filename;
+        Load_3D_Assets(new_filename);
+    }
+    hTree = m_hTreeManager.Get_Tree(name);
+    return hTree;
+}
+
+// 0x00815460
+AssetIterator *W3DAssetManager::Create_Font3DData_Iterator()
+{
+    captainslog_dbgassert(false, "Font3D classes are not used");
+    return nullptr;
+}
+
+// 0x008162B0
+void W3DAssetManager::Add_Font3DData(Font3DDataClass *font)
+{
+    captainslog_dbgassert(false, "Font3D classes are not used");
+}
+
+// 0x008162D0
+void W3DAssetManager::Remove_Font3DData(Font3DDataClass *font)
+{
+    captainslog_dbgassert(false, "Font3D classes are not used");
+}
+
+// 0x00816210
+Font3DDataClass *W3DAssetManager::Get_Font3DData(const char *name)
+{
+    captainslog_dbgassert(false, "Font3D classes are not used");
+    return nullptr;
+}
+
+// 0x00816300
+void W3DAssetManager::Release_All_Font3DDatas()
+{
+    captainslog_dbgassert(false, "Font3D classes are not used");
+}
+
+// 0x00816330
+void W3DAssetManager::Release_Unused_Font3DDatas()
+{
+    captainslog_dbgassert(false, "Font3D classes are not used");
+}
+
+// 0x008164C0
+void W3DAssetManager::Release_All_FontChars()
+{
+    for (auto i = 0; i < m_fontCharsList.Count(); ++i) {
+        m_fontCharsList[i]->Release_Ref();
+    }
+    m_fontCharsList.Delete_All();
+}
+
+// 0x00816610
+PrototypeClass *W3DAssetManager::Find_Prototype(const char *name)
+{
+    PrototypeClass *proto = &s_nullPrototype;
+    if (strcasecmp(name, "NULL") != 0) {
+        proto = Prototype_Hash_Table_Find(name);
+    }
+    return proto;
+}
+
+void W3DAssetManager::Prototype_Hash_Table_Add(PrototypeClass *entry)
+{
+    unsigned int hash = Prototype_Hash_Table_Hash(entry->Get_Name());
+    entry->Set_Next_Hash(m_prototypeHashTable[hash]);
+    m_prototypeHashTable[hash] = entry;
+}
+
+PrototypeClass *W3DAssetManager::Prototype_Hash_Table_Find(char const *key)
+{
+    for (PrototypeClass *i = m_prototypeHashTable[Prototype_Hash_Table_Hash(key)]; i; i = i->Get_Next_Hash()) {
+        if (!strcasecmp(i->Get_Name(), key)) {
+            return i;
+        }
+    }
+    return nullptr;
+}
+
+int32_t W3DAssetManager::Prototype_Hash_Table_Hash(char const *key)
+{
+    return (s_prototypeHashTableSize - 1) & CRC::Stringi(key, 0);
+}
+
+GameAssetManager::~GameAssetManager() {}
+
+// 0x00765CD0
+bool GameAssetManager::Load_3D_Assets(const char *filename)
+{
+    // file_base will be the filename up until the first '.' i.e. TANK.GUN would be TANK
+    char file_base[512];
+    strncpy(file_base, filename, sizeof(file_base));
+    file_base[sizeof(file_base) - 1] = '\0';
+    auto *period = strrchr(file_base, '.');
+    if (period != nullptr) {
+        *period = '\0';
+    }
+
+    if (Find_Prototype(file_base) != nullptr) {
+        return true;
+    }
+
+    return W3DAssetManager::Load_3D_Assets(filename);
+}
+
+// 0x00763E10
+RenderObjClass *GameAssetManager::Create_Render_Obj(const char *name)
+{
+    return W3DAssetManager::Create_Render_Obj(name);
+}
+
+// 0x00765D60
+HAnimClass *GameAssetManager::Get_HAnim(const char *name)
+{
+    return W3DAssetManager::Get_HAnim(name);
+}
+
+// 0x00763DC0
+TextureClass *GameAssetManager::Get_Texture(const char *filename,
+    MipCountType mip_level_count,
+    WW3DFormat texture_format,
+    bool allow_compression,
+    TexAssetType asset_type,
+    bool allow_reduction)
+{
+    if (filename != nullptr) {
+        if (*filename != '\0') {
+            if (strncasecmp(filename, "ZHC", 3) == 0) {
+                allow_reduction = false;
+            }
+        }
+    }
+    return W3DAssetManager::Get_Texture(
+        filename, mip_level_count, texture_format, allow_compression, asset_type, allow_reduction);
+}
+
+// 0x00765180
+RenderObjClass *GameAssetManager::Create_Render_Obj(
+    const char *name, float scale, uint32_t colour, const char *old_texture, const char *new_texture)
+{
+    bool has_scaling = fabs(scale - 1.0) >= 0.001f;
+    bool has_colour = (colour & 0xFFFFFF) != 0;
+    bool has_texture = old_texture != nullptr && new_texture != nullptr;
+
+    if (has_scaling || has_colour || has_texture) {
+        char new_name[256]{};
+        strcpy(new_name, name);
+        strlwr(new_name);
+        const char *tex = "";
+        if (new_texture != nullptr) {
+            tex = new_texture;
+        }
+
+        char buffer[512]{};
+        snprintf(buffer, 512, "#%d!%g!%s#%s", colour, scale, tex, new_name);
+        m_loadOnDemand = false;
+        auto *robj = W3DAssetManager::Create_Render_Obj(buffer);
+        if (robj != nullptr) {
+            robj->Set_House_Color(colour);
+            m_loadOnDemand = true;
+            return robj;
+        }
+
+        auto *proto = Find_Prototype(name);
+        m_loadOnDemand = true;
+        if (proto == nullptr) {
+            char asset_filename[256]{};
+            auto *period = strchr(name, '.');
+            if (period == nullptr) {
+                snprintf(asset_filename, 256, "%s.w3d", name);
+            } else {
+                snprintf(asset_filename, 256, "%s.w3d", period + 1);
+            }
+            if (Load_3D_Assets(asset_filename) == false) {
+                StringClass new_filename = StringClass{ "..\\", true } + asset_filename;
+                Load_3D_Assets(new_filename);
+            }
+            proto = Find_Prototype(name);
+        }
+
+        if (proto == nullptr) {
+            return nullptr;
+        }
+
+        robj = proto->Create();
+        if (robj == nullptr) {
+            return nullptr;
+        }
+
+        if (has_scaling) {
+            robj->Set_ObjectScale(scale);
+        }
+
+        switch (robj->Class_ID()) {
+            case RenderObjClass::CLASSID_MESH:
+                Make_Mesh_Unique(robj, has_scaling, has_colour);
+                break;
+            case RenderObjClass::CLASSID_HLOD:
+                Make_Unique(robj, has_scaling, has_colour);
+                break;
+            default:
+                break;
+        }
+        if (has_texture) {
+            auto *old_tex = Get_Texture(old_texture);
+            auto *new_tex = Get_Texture(new_texture);
+            switch (robj->Class_ID()) {
+                case RenderObjClass::CLASSID_MESH:
+                    Replace_Mesh_Texture(robj, old_tex, new_tex);
+                    break;
+                case RenderObjClass::CLASSID_HLOD:
+                    Replace_HLOD_Texture(robj, old_tex, new_tex);
+                    break;
+                default:
+                    break;
+            }
+            if (old_tex != nullptr) {
+                old_tex->Release_Ref();
+            }
+            if (new_tex != nullptr) {
+                new_tex->Release_Ref();
+            }
+        }
+        if (has_colour) {
+            switch (robj->Class_ID()) {
+                case RenderObjClass::CLASSID_MESH:
+                    Recolor_Mesh(robj, colour);
+                    break;
+                case RenderObjClass::CLASSID_HLOD: {
+                    bool recolored = false;
+                    for (auto i = 0; i < robj->Get_Num_Sub_Objects(); ++i) {
+                        auto *sobj = robj->Get_Sub_Object(i);
+                        recolored |= Recolor_HLOD(sobj, colour);
+                        if (sobj != nullptr) {
+                            sobj->Release_Ref();
+                        }
+                    }
+                    break;
+                }
+                default:
+                    break;
+            }
+        }
+
+        auto *w3d_proto = new W3DPrototypeClass(robj, buffer);
+        robj->Release_Ref();
+        Prototype_Hash_Table_Add(w3d_proto);
+        robj = w3d_proto->Create();
+        robj->Set_House_Color(colour);
+        return robj;
+    } else {
+        return W3DAssetManager::Create_Render_Obj(name);
+    }
+}
+
+// 0x00765DF0
+void GameAssetManager::Make_Mesh_Unique(RenderObjClass *robj, bool geometry, bool colors)
+{
+    // Uses MeshClass requires MaterialInfoClass
+#ifdef GAME_DLL
+    Call_Method<void, W3DAssetManager, RenderObjClass *, bool, bool>(0x00765DF0, this, robj, geometry, colors);
+#endif
+}
+
+// 0x00765D70
+void GameAssetManager::Make_Unique(RenderObjClass *robj, bool geometry, bool colors)
+{
+    for (auto i = 0; i < robj->Get_Num_Sub_Objects(); ++i) {
+        auto *sub_robj = robj->Get_Sub_Object(i);
+
+        switch (sub_robj->Class_ID()) {
+            case RenderObjClass::CLASSID_MESH:
+                Make_Mesh_Unique(sub_robj, geometry, colors);
+                break;
+            case RenderObjClass::CLASSID_HLOD:
+                Make_Unique(sub_robj, geometry, colors);
+                break;
+
+            default:
+                break;
+        }
+
+        if (sub_robj != nullptr) {
+            sub_robj->Release_Ref();
+        }
+    }
+}
+
+// 0x00765A40
+bool GameAssetManager::Recolor_Mesh(RenderObjClass *robj, uint32_t colour)
+{
+    // Uses MeshClass requires MaterialInfoClass
+#ifdef GAME_DLL
+    return Call_Method<bool, W3DAssetManager, RenderObjClass *, uint32_t>(0x00765A40, this, robj, colour);
+#else
+    return false;
+#endif
+}
+
+// 0x007659B0 maybe rename to Recolor_Asset
+bool GameAssetManager::Recolor_HLOD(RenderObjClass *robj, uint32_t colour)
+{
+    switch (robj->Class_ID()) {
+        case RenderObjClass::CLASSID_MESH:
+            return Recolor_Mesh(robj, colour);
+        case RenderObjClass::CLASSID_HLOD: {
+            bool recolored = false;
+            for (auto i = 0; i < robj->Get_Num_Sub_Objects(); ++i) {
+                auto *sub_robj = robj->Get_Sub_Object(i);
+                recolored |= Recolor_HLOD(sub_robj, colour);
+                if (sub_robj != nullptr) {
+                    sub_robj->Release_Ref();
+                }
+            }
+            return recolored;
+        }
+        default:
+            return false;
+    }
+}
+
+// 0x00763EC0
+bool GameAssetManager::Replace_HLOD_Texture(RenderObjClass *robj, TextureClass *old_texture, TextureClass *new_texture)
+{
+    bool replaced = false;
+    for (auto i = 0; i < robj->Get_Num_Sub_Objects(); ++i) {
+        auto *sub_robj = robj->Get_Sub_Object(i);
+
+        switch (sub_robj->Class_ID()) {
+            case RenderObjClass::CLASSID_MESH:
+                replaced |= Replace_Mesh_Texture(sub_robj, old_texture, new_texture);
+                break;
+            case RenderObjClass::CLASSID_HLOD:
+                replaced |= Replace_HLOD_Texture(sub_robj, old_texture, new_texture);
+                break;
+
+            default:
+                break;
+        }
+
+        if (sub_robj != nullptr) {
+            sub_robj->Release_Ref();
+        }
+    }
+    return replaced;
+}
+
+// 0x00763F70
+bool GameAssetManager::Replace_Mesh_Texture(RenderObjClass *robj, TextureClass *old_texture, TextureClass *new_texture)
+{
+    // Uses MeshClass requires MaterialInfoClass
+#ifdef GAME_DLL
+    return Call_Method<bool, W3DAssetManager, RenderObjClass *, TextureClass *, TextureClass *>(
+        0x00763F70, this, robj, old_texture, new_texture);
+#else
+    return false;
+#endif
+}
+
+W3DPrototypeClass::W3DPrototypeClass(RenderObjClass *proto, const char *name) : m_proto(proto), m_name(name)
+{
+    m_proto->Add_Ref();
+}
+
+int32_t W3DPrototypeClass::Get_Class_ID()
+{
+    return m_proto->Class_ID();
+}
+
+RenderObjClass *W3DPrototypeClass::Create()
+{
+    return m_proto->Clone();
+}
+
+W3DPrototypeClass::~W3DPrototypeClass()
+{
+    m_proto->Release_Ref();
+    m_proto = nullptr;
+}

--- a/src/w3d/renderer/assetmgr.h
+++ b/src/w3d/renderer/assetmgr.h
@@ -12,33 +12,57 @@
  *            A full copy of the GNU General Public License can be found in
  *            LICENSE
  */
+#pragma once
 #include "always.h"
+#include "asciistring.h"
 #include "hanimmgr.h"
 #include "htreemgr.h"
+#include "nullrobj.h"
 #include "simplevec.h"
-#include "slist.h"
 #include "texture.h"
 #include "vector.h"
 
 class RenderObjClass;
 class RenderObjIterator;
-class AssetIterator;
+
+class AssetIterator
+{
+protected:
+    uint32_t m_index;
+
+public:
+    virtual ~AssetIterator(){};
+    virtual void First() { m_index = 0; }
+    virtual void Next() { ++m_index; }
+    virtual bool Is_Done() const = 0;
+    virtual const char *Current_Item_Name() const = 0;
+};
+
 class MetalMapManagerClass;
-class Font3DDataClass;
 class Font3DInstanceClass;
+class Font3DDataClass;
 class FontCharsClass;
 class PrototypeLoaderClass;
 class PrototypeClass;
 class TextureFileCache;
 
+#ifdef GAME_DLL
+extern NullPrototypeClass &s_nullPrototype;
+#else
+extern NullPrototypeClass s_nullPrototype;
+#endif
+
+// W3DAssetManager is the renamed WW3DAssetManager
 class W3DAssetManager
 {
 public:
+    W3DAssetManager();
     virtual ~W3DAssetManager();
     virtual bool Load_3D_Assets(const char *filename);
     virtual bool Load_3D_Assets(FileClass &asset_file);
     virtual void Free_Assets();
-    virtual void Release_Unused_Assets();
+    // 0x00814850
+    virtual void Release_Unused_Assets() { Release_Unused_Textures(); }
     virtual void Free_Assets_With_Exclusion_List(DynamicVectorClass<StringClass> const &list);
     virtual void Create_Asset_List(DynamicVectorClass<StringClass> &list);
     virtual RenderObjClass *Create_Render_Obj(const char *name);
@@ -63,7 +87,8 @@ public:
     virtual FontCharsClass *Get_FontChars(const char *name, int point_size, bool is_bold = false);
     virtual AssetIterator *Create_HTree_Iterator();
     virtual HTreeClass *Get_HTree(const char *name);
-    virtual void Register_Prototype_Loader(PrototypeLoaderClass *loader);
+    // 0x00816550
+    virtual void Register_Prototype_Loader(PrototypeLoaderClass *loader) { m_prototypeLoaders.Add(loader); }
     static W3DAssetManager *Get_Instance(void) { return s_theInstance; }
 
 protected:
@@ -75,21 +100,77 @@ protected:
     virtual void Release_Unused_Font3DDatas();
     virtual void Release_All_FontChars();
 
+    PrototypeClass *Find_Prototype(const char *name);
+
+    static constexpr auto s_prototypeHashTableSize = 0x1000;
+    void Prototype_Hash_Table_Add(PrototypeClass *entry);
+    PrototypeClass *Prototype_Hash_Table_Find(char const *key);
+    int32_t Prototype_Hash_Table_Hash(char const *key);
+
+protected:
     DynamicVectorClass<PrototypeLoaderClass *> m_prototypeLoaders;
     DynamicVectorClass<PrototypeClass *> m_prototypes;
     PrototypeClass **m_prototypeHashTable;
     HTreeManagerClass m_hTreeManager;
     HAnimManagerClass m_hAnimManager;
     TextureFileCache *m_textureCache;
-    SList<Font3DDataClass> m_font3DDatas;
+    uint32_t m_font3DDatasPad[3]; // This was not used and is now just padding.
     SimpleDynVecClass<FontCharsClass *> m_fontCharsList;
     bool m_loadOnDemand;
     bool m_activateFogOnLoad;
-    MetalMapManagerClass *m_metalManager;
+    uint32_t m_metalManagerPad; // Not used
     HashTemplateClass<StringClass, TextureClass *> m_textureHash;
 #ifdef GAME_DLL
     static W3DAssetManager *&s_theInstance;
 #else
     static W3DAssetManager *s_theInstance;
 #endif
+};
+
+// GameAssetManager is the renamed W3DAssetManager
+class GameAssetManager final : public W3DAssetManager
+{
+public:
+    GameAssetManager(){};
+    virtual ~GameAssetManager();
+    virtual bool Load_3D_Assets(const char *filename);
+    virtual RenderObjClass *Create_Render_Obj(const char *name);
+    virtual HAnimClass *Get_HAnim(const char *name);
+    virtual TextureClass *Get_Texture(const char *filename,
+        MipCountType mip_level_count = MIP_LEVELS_ALL,
+        WW3DFormat texture_format = WW3D_FORMAT_UNKNOWN,
+        bool allow_compression = true,
+        TexAssetType asset_type = ASSET_STANDARD,
+        bool allow_reduction = true);
+    virtual RenderObjClass *Create_Render_Obj(
+        const char *name, float scale, uint32_t colour, const char *old_texture, const char *new_texture);
+
+    // 0x00763D70
+    GameAssetManager *Hook_Ctor() { return new (this) GameAssetManager; }
+
+private:
+    void Make_Mesh_Unique(RenderObjClass *robj, bool geometry, bool colors);
+    void Make_Unique(RenderObjClass *robj, bool geometry, bool colors);
+    bool Recolor_Mesh(RenderObjClass *robj, uint32_t colour);
+    bool Recolor_HLOD(RenderObjClass *robj, uint32_t colour);
+    bool Replace_HLOD_Texture(RenderObjClass *robj, TextureClass *old_texture, TextureClass *new_texture);
+    bool Replace_Mesh_Texture(RenderObjClass *robj, TextureClass *old_texture, TextureClass *new_texture);
+    uint32_t m_grannyAnimManager; // Not used, only here to match original size
+};
+
+class W3DPrototypeClass final : public W3DMPO, public PrototypeClass
+{
+    IMPLEMENT_W3D_POOL(W3DPrototypeClass);
+
+public:
+    W3DPrototypeClass(RenderObjClass *proto, const char *name);
+    virtual const char *Get_Name() override { return m_name; }
+    virtual int32_t Get_Class_ID() override;
+    virtual RenderObjClass *Create() override;
+    virtual void Delete_Self() override { delete this; };
+    virtual ~W3DPrototypeClass() override;
+
+private:
+    RenderObjClass *m_proto;
+    Utf8String m_name;
 };

--- a/src/w3d/renderer/assetmgr.h
+++ b/src/w3d/renderer/assetmgr.h
@@ -45,6 +45,7 @@ class FontCharsClass;
 class PrototypeLoaderClass;
 class PrototypeClass;
 class TextureFileCache;
+class VertexMaterialClass;
 
 #ifdef GAME_DLL
 extern NullPrototypeClass &s_nullPrototype;
@@ -62,7 +63,11 @@ public:
     virtual bool Load_3D_Assets(FileClass &asset_file);
     virtual void Free_Assets();
     // 0x00814850
-    virtual void Release_Unused_Assets() { Release_Unused_Textures(); }
+    virtual void Release_Unused_Assets()
+    {
+        Release_Unused_Textures();
+        // Release_Unused_Font3DDatas(); Font3DData is not used
+    }
     virtual void Free_Assets_With_Exclusion_List(DynamicVectorClass<StringClass> const &list);
     virtual void Create_Asset_List(DynamicVectorClass<StringClass> &list);
     virtual RenderObjClass *Create_Render_Obj(const char *name);
@@ -91,6 +96,9 @@ public:
     virtual void Register_Prototype_Loader(PrototypeLoaderClass *loader) { m_prototypeLoaders.Add(loader); }
     static W3DAssetManager *Get_Instance(void) { return s_theInstance; }
 
+    bool Get_W3D_Load_On_Demand() const { return m_loadOnDemand; }
+    void Set_W3D_Load_On_Demand(bool state) { m_loadOnDemand = state; }
+
 protected:
     virtual AssetIterator *Create_Font3DData_Iterator();
     virtual void Add_Font3DData(Font3DDataClass *font);
@@ -106,6 +114,10 @@ protected:
     void Prototype_Hash_Table_Add(PrototypeClass *entry);
     PrototypeClass *Prototype_Hash_Table_Find(char const *key);
     int32_t Prototype_Hash_Table_Hash(char const *key);
+
+    void Add_Prototype(PrototypeClass *proto);
+    PrototypeLoaderClass *Find_Prototype_Loader(int chunk_id);
+    bool Load_Prototype(ChunkLoadClass &cload);
 
 protected:
     DynamicVectorClass<PrototypeLoaderClass *> m_prototypeLoaders;
@@ -150,11 +162,15 @@ public:
 
 private:
     void Make_Mesh_Unique(RenderObjClass *robj, bool geometry, bool colors);
+    void Make_HLOD_Unique(RenderObjClass *robj, bool geometry, bool colors);
     void Make_Unique(RenderObjClass *robj, bool geometry, bool colors);
+    void Recolor_Vertex_Material(VertexMaterialClass *vmat, uint32_t colour);
     bool Recolor_Mesh(RenderObjClass *robj, uint32_t colour);
     bool Recolor_HLOD(RenderObjClass *robj, uint32_t colour);
+    bool Recolour_Asset(RenderObjClass *robj, uint32_t colour);
     bool Replace_HLOD_Texture(RenderObjClass *robj, TextureClass *old_texture, TextureClass *new_texture);
     bool Replace_Mesh_Texture(RenderObjClass *robj, TextureClass *old_texture, TextureClass *new_texture);
+    bool Replace_Asset_Texture(RenderObjClass *robj, TextureClass *old_texture, TextureClass *new_texture);
     uint32_t m_grannyAnimManager; // Not used, only here to match original size
 };
 

--- a/src/w3d/renderer/colorspace.h
+++ b/src/w3d/renderer/colorspace.h
@@ -42,6 +42,13 @@ inline void Color_To_RGBA(Vector4 &rgba, uint32_t color)
     rgba.W = ((color & 0xFF000000) >> 24) / 255.0f;
 }
 
+inline void Color_To_RGB(Vector3 &rgb, uint32_t color)
+{
+    rgb.X = ((color & 0xFF0000) >> 16) / 255.0f;
+    rgb.Y = ((color & 0xFF00) >> 8) / 255.0f;
+    rgb.Z = (color & 0xFF) / 255.0f;
+}
+
 inline void RGBA_To_Color(uint32_t &color, const Vector4 &rgba)
 {
     color = Make_Color(rgba.X * 255.0f, rgba.Y * 255.0f, rgba.Z * 255.0f, rgba.W * 255.0f);

--- a/src/w3d/renderer/hanimmgr.cpp
+++ b/src/w3d/renderer/hanimmgr.cpp
@@ -85,7 +85,9 @@ int HAnimManagerClass::Load_Compressed_Anim(ChunkLoadClass &cload)
 HAnimClass *HAnimManagerClass::Get_Anim(const char *name)
 {
     HAnimClass *anim = Peek_Anim(name);
-    anim->Add_Ref();
+    if (anim != nullptr) {
+        anim->Add_Ref();
+    }
     return anim;
 }
 

--- a/src/w3d/renderer/nullrobj.h
+++ b/src/w3d/renderer/nullrobj.h
@@ -22,13 +22,16 @@ class Null3DObjClass final : public RenderObjClass
 {
     char m_Name[32];
 
-    virtual int Class_ID() const override;
-    virtual RenderObjClass *Clone() const override;
-    virtual const char *Get_Name() const override;
-    virtual void Render(RenderInfoClass &rinfo) override;
-    virtual void Get_Obj_Space_Bounding_Sphere(SphereClass &sphere) const override;
-    virtual void Get_Obj_Space_Bounding_Box(AABoxClass &box) const override;
-    virtual ~Null3DObjClass();
+    virtual int Class_ID() const override { return CLASSID_NULL; }
+    virtual RenderObjClass *Clone() const override { return new Null3DObjClass; }
+    virtual const char *Get_Name() const override { return m_Name; }
+    virtual void Render(RenderInfoClass &rinfo) override {}
+    virtual void Get_Obj_Space_Bounding_Sphere(SphereClass &sphere) const override { sphere.Init(Vector3(0, 0, 0), 0.1f); }
+    virtual void Get_Obj_Space_Bounding_Box(AABoxClass &box) const override
+    {
+        box.Init(Vector3(0, 0, 0), Vector3(0.1f, 0.1f, 0.1f));
+    }
+    virtual ~Null3DObjClass() {}
 };
 
 class NullPrototypeClass final : public W3DMPO, public PrototypeClass

--- a/src/w3d/renderer/rendobj.h
+++ b/src/w3d/renderer/rendobj.h
@@ -328,6 +328,7 @@ public:
     bool Is_Transform_Identity() const;
     bool Is_Transform_Identity_No_Validity_Check() const;
     RenderObjClass *Get_Container() const { return m_container; }
+    void Set_House_Color(uint32_t color) { m_houseColor = color; }
 
     void Set_Sub_Object_Transforms_Dirty(bool onoff)
     {


### PR DESCRIPTION
A number of the virtual functions were found to not be in use and have therefore been turned into assert(false) functions.
Free_Assets_With_Exclusion_List has not been implemented at this time. It requires an additional class most likely and it is not clear if it performs any useful function. Constructor of W3DAssetManager has not been implemented at this time due to the requirement for multiple PrototypeLoader classes. Non virtual member functions of GameAssetManager require further work on MeshClass to implement.

I suggest I remove the changes to SList as it appears there is no point in implementing it due to no classes requireing it.

SList has now been removed. Seperate PR's have been created for HAnimManager and HTreeManager that will need to be merged in first.