### PR TITLE
Corrections to some renderer code.

### DIFF
--- a/src/game/client/image.cpp
+++ b/src/game/client/image.cpp
@@ -12,8 +12,6 @@
  *            A full copy of the GNU General Public License can be found in
  *            LICENSE
  */
-#pragma once
-
 #include "always.h"
 #include "image.h"
 

--- a/src/hooker/setupglobals_zh.cpp
+++ b/src/hooker/setupglobals_zh.cpp
@@ -369,6 +369,7 @@ bool &W3D::s_texturingEnabled = Make_Global<bool>(PICK_ADDRESS(0x00A16998, 0x00C
 bool &W3D::s_thumbnailEnabled = Make_Global<bool>(PICK_ADDRESS(0x00A1698C, 0x00CC58AC));
 int &W3D::s_textureFilter = Make_Global<int>(PICK_ADDRESS(0x00A47FEC, 0x00DEE84C));
 float &W3D::s_defaultNativeScreenSize = Make_Global<float>(PICK_ADDRESS(0x00A16984, 0x00CC58A4));
+bool &W3D::s_isSortingEnabled = Make_Global<bool>(PICK_ADDRESS(0x00A1697C, 0x00CC589C));
 HWND &W3D::s_hwnd = Make_Global<HWND>(PICK_ADDRESS(0x00A47FE0, 0x00DEE840));
 
 // dx8renderer.cpp

--- a/src/w3d/math/colmath.h
+++ b/src/w3d/math/colmath.h
@@ -12,6 +12,7 @@
  *            A full copy of the GNU General Public License can be found in
  *            LICENSE
  */
+#pragma once
 #include "always.h"
 #include "castres.h"
 

--- a/src/w3d/math/colmathaaplane.cpp
+++ b/src/w3d/math/colmathaaplane.cpp
@@ -12,8 +12,6 @@
  *            A full copy of the GNU General Public License can be found in
  *            LICENSE
  */
-#pragma once
-
 #include "always.h"
 #include "aabox.h"
 #include "aaplane.h"

--- a/src/w3d/math/colmathfrustum.cpp
+++ b/src/w3d/math/colmathfrustum.cpp
@@ -12,8 +12,6 @@
  *            A full copy of the GNU General Public License can be found in
  *            LICENSE
  */
-#pragma once
-
 #include "always.h"
 #include "aabox.h"
 #include "colmath.h"

--- a/src/w3d/math/colmathplane.cpp
+++ b/src/w3d/math/colmathplane.cpp
@@ -12,8 +12,6 @@
  *            A full copy of the GNU General Public License can be found in
  *            LICENSE
  */
-#pragma once
-
 #include "always.h"
 #include "aabox.h"
 #include "colmath.h"

--- a/src/w3d/renderer/dx8caps.cpp
+++ b/src/w3d/renderer/dx8caps.cpp
@@ -303,7 +303,7 @@ void DX8Caps::Compute_Caps(WW3DFormat format, const w3dadapterid_t &identifier)
 
     m_supportLargePointSize = m_caps.MaxPointSize > 1.0f;
     m_supportZBias = Has_Feature(m_caps.RasterCaps, D3DPRASTERCAPS_ZBIAS);
-    m_supportNPatches = Has_Feature(m_caps.DevCaps, D3DDEVCAPS_NPATCHES);
+    m_supportNPatches = false;
     m_supportGamma = Has_Feature(m_caps.Caps2, D3DCAPS2_FULLSCREENGAMMA);
     m_supportDot3Blend = Has_Feature(m_caps.TextureOpCaps, D3DTEXOPCAPS_DOTPRODUCT3);
     m_supportsModulateAlphaAddColor = Has_Feature(m_caps.TextureOpCaps, D3DTEXOPCAPS_MODULATEALPHA_ADDCOLOR);

--- a/src/w3d/renderer/dx8caps.h
+++ b/src/w3d/renderer/dx8caps.h
@@ -60,7 +60,6 @@ public:
     bool Supports_Texture_Format(WW3DFormat format) const { return m_supportTextureFormat[format]; }
     bool Supports_Render_To_Texture_Format(WW3DFormat format) const { return m_supportRenderToTextureFormat[format]; }
     bool Use_TnL() const { return m_useTnL; }
-    bool Supports_NPatches() const { return m_supportNPatches; }
     uint32_t Max_Textures_Per_Pass() const { return m_maxTexturesPerPass; }
     w3dcaps_t Get_DX8_Caps() const { return m_caps; }
     bool Support_Gamma() const { return m_supportGamma; }

--- a/src/w3d/renderer/dx8indexbuffer.cpp
+++ b/src/w3d/renderer/dx8indexbuffer.cpp
@@ -169,11 +169,10 @@ DX8IndexBufferClass::DX8IndexBufferClass(unsigned short index_count_, UsageType 
 {
 #ifdef BUILD_WITH_D3D8
     captainslog_assert(m_indexCount);
-    int d3dusage = ((usage & USAGE_NPATCHES) >= 1 ? D3DUSAGE_NPATCHES : 0)
-        | ((usage & USAGE_DYNAMIC) < 1 ? D3DUSAGE_WRITEONLY : D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY)
+    int d3dusage = ((usage & USAGE_DYNAMIC) < 1 ? D3DUSAGE_WRITEONLY : D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY)
         | ((usage & USAGE_SOFTWAREPROCESSING) >= 1 ? D3DUSAGE_SOFTWAREPROCESSING : 0);
 
-    if (!DX8Wrapper::Get_Caps()->Use_TnL()) {
+    if (!DX8Wrapper::Get_Current_Caps()->Use_TnL()) {
         d3dusage |= D3DUSAGE_SOFTWAREPROCESSING;
     }
 
@@ -284,12 +283,6 @@ void DynamicIBAccessClass::Allocate_DX8_Dynamic_Buffer()
 
     if (!g_dynamicDX8IndexBuffer) {
         DX8IndexBufferClass::UsageType usage = DX8IndexBufferClass::USAGE_DYNAMIC;
-
-        if (DX8Wrapper::Get_Caps()->Supports_NPatches()) {
-            usage =
-                (DX8IndexBufferClass::UsageType)(DX8IndexBufferClass::USAGE_DYNAMIC | DX8IndexBufferClass::USAGE_NPATCHES);
-        }
-
         g_dynamicDX8IndexBuffer = new DX8IndexBufferClass(g_dynamicDX8IndexBufferSize, usage);
         g_dynamicDX8IndexBufferOffset = 0;
     }

--- a/src/w3d/renderer/dx8indexbuffer.h
+++ b/src/w3d/renderer/dx8indexbuffer.h
@@ -98,8 +98,7 @@ public:
     {
         USAGE_DEFAULT,
         USAGE_DYNAMIC,
-        USAGE_SOFTWAREPROCESSING,
-        USAGE_NPATCHES,
+        USAGE_SOFTWAREPROCESSING
     };
     DX8IndexBufferClass(unsigned short index_count_, UsageType usage);
     ~DX8IndexBufferClass();

--- a/src/w3d/renderer/dx8vertexbuffer.cpp
+++ b/src/w3d/renderer/dx8vertexbuffer.cpp
@@ -209,11 +209,10 @@ void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
 {
 #ifdef BUILD_WITH_D3D8
     captainslog_assert(!m_vertexBuffer);
-    int d3dusage = ((usage & USAGE_NPATCHES) >= 1 ? D3DUSAGE_NPATCHES : 0)
-        | ((usage & USAGE_DYNAMIC) < 1 ? D3DUSAGE_WRITEONLY : D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY)
+    int d3dusage = ((usage & USAGE_DYNAMIC) < 1 ? D3DUSAGE_WRITEONLY : D3DUSAGE_DYNAMIC | D3DUSAGE_WRITEONLY)
         | ((usage & USAGE_SOFTWAREPROCESSING) >= 1 ? D3DUSAGE_SOFTWAREPROCESSING : 0);
 
-    if (!DX8Wrapper::Get_Caps()->Use_TnL()) {
+    if (!DX8Wrapper::Get_Current_Caps()->Use_TnL()) {
         d3dusage |= D3DUSAGE_SOFTWAREPROCESSING;
     }
 
@@ -307,10 +306,6 @@ void DynamicVBAccessClass::Allocate_DX8_Dynamic_Buffer()
 
     if (!g_dynamicDX8VertexBuffer) {
         DX8VertexBufferClass::UsageType usage = DX8VertexBufferClass::USAGE_DYNAMIC;
-        if (DX8Wrapper::Get_Caps()->Supports_NPatches()) {
-            usage = (DX8VertexBufferClass::UsageType)(
-                DX8VertexBufferClass::USAGE_DYNAMIC | DX8VertexBufferClass::USAGE_NPATCHES);
-        }
         g_dynamicDX8VertexBuffer = new DX8VertexBufferClass(DX8_FVF_XYZNDUV2, g_dynamicDX8VertexBufferSize, usage, 0);
         g_dynamicDX8VertexBufferOffset = 0;
     }

--- a/src/w3d/renderer/dx8vertexbuffer.h
+++ b/src/w3d/renderer/dx8vertexbuffer.h
@@ -139,7 +139,6 @@ public:
         USAGE_DEFAULT = 0,
         USAGE_DYNAMIC = 1,
         USAGE_SOFTWAREPROCESSING = 2,
-        USAGE_NPATCHES = 4,
     };
     DX8VertexBufferClass(unsigned int fvf, unsigned short vertex_count_, UsageType usage, unsigned int flags);
     DX8VertexBufferClass(

--- a/src/w3d/renderer/dx8wrapper.cpp
+++ b/src/w3d/renderer/dx8wrapper.cpp
@@ -246,7 +246,7 @@ inline unsigned long F2DW(float f)
 void DX8Wrapper::Set_Default_Global_Render_States()
 {
 #ifdef BUILD_WITH_D3D8
-    const D3DCAPS8 &caps = Get_Caps()->Get_DX8_Caps();
+    const D3DCAPS8 &caps = Get_Current_Caps()->Get_DX8_Caps();
 
     Set_DX8_Render_State(D3DRS_RANGEFOGENABLE, (caps.RasterCaps & D3DPRASTERCAPS_FOGRANGE) ? TRUE : FALSE);
     Set_DX8_Render_State(D3DRS_FOGTABLEMODE, D3DFOG_NONE);
@@ -325,7 +325,7 @@ void DX8Wrapper::Do_Onetime_Device_Dependent_Shutdowns()
 
     Ref_Ptr_Release(s_renderState.material);
 
-    for (unsigned int i = 0; i < Get_Caps()->Max_Textures_Per_Pass(); i++) {
+    for (unsigned int i = 0; i < Get_Current_Caps()->Max_Textures_Per_Pass(); i++) {
         Ref_Ptr_Release(s_renderState.Textures[i]);
     }
 

--- a/src/w3d/renderer/matpass.cpp
+++ b/src/w3d/renderer/matpass.cpp
@@ -40,7 +40,7 @@ void MaterialPassClass::Install_Materials()
 {
     DX8Wrapper::Set_Material(Peek_Material());
     DX8Wrapper::Set_Shader(Peek_Shader());
-    for (uint32_t i = 0; i < DX8Wrapper::Get_Caps()->Max_Textures_Per_Pass(); ++i) {
+    for (uint32_t i = 0; i < DX8Wrapper::Get_Current_Caps()->Max_Textures_Per_Pass(); ++i) {
         DX8Wrapper::Set_Texture(i, Peek_Texture(i));
     }
 }

--- a/src/w3d/renderer/rendobj.h
+++ b/src/w3d/renderer/rendobj.h
@@ -104,6 +104,18 @@ public:
         ANIM_MODE_ONCE,
     };
 
+    enum
+    {
+        USER_DATA_MATERIAL_OVERRIDE = 0x1234567,
+    };
+
+    struct Material_Override
+    {
+        int m_structID;
+        Vector2 m_customUVOffset;
+        Material_Override() : m_structID(USER_DATA_MATERIAL_OVERRIDE), m_customUVOffset(0, 0) {}
+    };
+
     RenderObjClass();
     RenderObjClass(const RenderObjClass &src);
     RenderObjClass &operator=(const RenderObjClass &that);
@@ -210,6 +222,7 @@ public:
     virtual void Scale(float scale) {}
     virtual void Scale(float scalex, float scaley, float scalez) {}
     virtual void Set_ObjectScale(float scale) { m_objectScale = scale; }
+    float Get_ObjectScale() { return m_objectScale; }
     virtual int Get_Sort_Level() const { return 0; }
     virtual void Set_Sort_Level(int level) {}
     virtual int Is_Really_Visible() { return ((m_bits & IS_REALLY_VISIBLE) == IS_REALLY_VISIBLE); }

--- a/src/w3d/renderer/sortingrenderer.cpp
+++ b/src/w3d/renderer/sortingrenderer.cpp
@@ -21,18 +21,20 @@ void SortingRendererClass::Insert_Triangles(
     unsigned short start_index, unsigned short polygon_count, unsigned short min_vertex_index, unsigned short vertex_count)
 {
 #ifdef GAME_DLL
-    Call_Function<void>(PICK_ADDRESS(0x0080CC40, 0x00569CD0));
+    Call_Function<void, unsigned short, unsigned short, unsigned short, unsigned short>(
+        PICK_ADDRESS(0x0080CC40, 0x00569CD0), start_index, polygon_count, min_vertex_index, vertex_count);
 #endif
 }
 
-void SortingRendererClass::Insert_Triangles(class SphereClass &bounding_sphere,
+void SortingRendererClass::Insert_Triangles(const SphereClass &bounding_sphere,
     unsigned short start_index,
     unsigned short polygon_count,
     unsigned short min_vertex_index,
     unsigned short vertex_count)
 {
 #ifdef GAME_DLL
-    Call_Function<void>(PICK_ADDRESS(0x0080C610, 0x00569570));
+    Call_Function<void, const SphereClass &, unsigned short, unsigned short, unsigned short, unsigned short>(
+        PICK_ADDRESS(0x0080C610, 0x00569570), bounding_sphere, start_index, polygon_count, min_vertex_index, vertex_count);
 #endif
 }
 
@@ -53,6 +55,6 @@ void SortingRendererClass::Deinit()
 void SortingRendererClass::SetMinVertexBufferSize(unsigned int val)
 {
 #ifdef GAME_DLL
-    Call_Function<void>(PICK_ADDRESS(0x0080C570, 0x00569410));
+    Call_Function<void, unsigned int>(PICK_ADDRESS(0x0080C570, 0x00569410), val);
 #endif
 }

--- a/src/w3d/renderer/sortingrenderer.h
+++ b/src/w3d/renderer/sortingrenderer.h
@@ -16,6 +16,8 @@
 #include "always.h"
 #include "w3dtypes.h"
 struct SortingNodeStruct;
+class SphereClass;
+
 class SortingRendererClass
 {
 public:
@@ -25,7 +27,7 @@ public:
         unsigned short polygon_count,
         unsigned short min_vertex_index,
         unsigned short vertex_count);
-    static void Insert_Triangles(class SphereClass &bounding_sphere,
+    static void Insert_Triangles(const SphereClass &bounding_sphere,
         unsigned short start_index,
         unsigned short polygon_count,
         unsigned short min_vertex_index,

--- a/src/w3d/renderer/texture.cpp
+++ b/src/w3d/renderer/texture.cpp
@@ -81,11 +81,11 @@ void TextureFilterClass::Init_Filters(TextureFilterMode mode)
     g_magTextureFilters[0][FILTER_TYPE_BEST] = D3DTEXF_POINT;
     g_mipMapFilters[0][FILTER_TYPE_BEST] = D3DTEXF_POINT;
 
-    if (DX8Wrapper::Get_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MAGFLINEAR) {
+    if (DX8Wrapper::Get_Current_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MAGFLINEAR) {
         g_magTextureFilters[0][FILTER_TYPE_BEST] = D3DTEXF_LINEAR;
     }
 
-    if (DX8Wrapper::Get_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MINFLINEAR) {
+    if (DX8Wrapper::Get_Current_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MINFLINEAR) {
         g_minTextureFilters[0][FILTER_TYPE_BEST] = D3DTEXF_LINEAR;
     }
 
@@ -94,15 +94,15 @@ void TextureFilterClass::Init_Filters(TextureFilterMode mode)
         case FILTER_MODE_ANISOTROPIC4X:
         case FILTER_MODE_ANISOTROPIC8X:
         case FILTER_MODE_ANISOTROPIC16X:
-            if (DX8Wrapper::Get_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MAGFANISOTROPIC) {
+            if (DX8Wrapper::Get_Current_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MAGFANISOTROPIC) {
                 g_magTextureFilters[0][FILTER_TYPE_BEST] = D3DTEXF_ANISOTROPIC;
             }
 
-            if (DX8Wrapper::Get_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MINFANISOTROPIC) {
+            if (DX8Wrapper::Get_Current_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MINFANISOTROPIC) {
                 g_minTextureFilters[0][FILTER_TYPE_BEST] = D3DTEXF_ANISOTROPIC;
             }
         case FILTER_MODE_TRILINEAR: // fall-through
-            if (DX8Wrapper::Get_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MIPFLINEAR) {
+            if (DX8Wrapper::Get_Current_Caps()->Get_Filter_Caps() & D3DPTFILTERCAPS_MIPFLINEAR) {
                 g_mipMapFilters[0][FILTER_TYPE_BEST] = D3DTEXF_LINEAR;
             }
         default:

--- a/src/w3d/renderer/textureloader.cpp
+++ b/src/w3d/renderer/textureloader.cpp
@@ -147,16 +147,16 @@ void TextureLoader::Validate_Texture_Size(unsigned &width, unsigned &height, uns
     for (v = 1; v < volume; v *= 2);
     // clang-format on
 
-    if (DX8Wrapper::Get_Caps()->Get_Max_Tex_Width() < w) {
-        w = DX8Wrapper::Get_Caps()->Get_Max_Tex_Width();
+    if (DX8Wrapper::Get_Current_Caps()->Get_Max_Tex_Width() < w) {
+        w = DX8Wrapper::Get_Current_Caps()->Get_Max_Tex_Width();
     }
 
-    if (h > DX8Wrapper::Get_Caps()->Get_Max_Tex_Height()) {
-        h = DX8Wrapper::Get_Caps()->Get_Max_Tex_Height();
+    if (h > DX8Wrapper::Get_Current_Caps()->Get_Max_Tex_Height()) {
+        h = DX8Wrapper::Get_Current_Caps()->Get_Max_Tex_Height();
     }
 
-    if (v > DX8Wrapper::Get_Caps()->Get_Max_Vol_Extent()) {
-        v = DX8Wrapper::Get_Caps()->Get_Max_Vol_Extent();
+    if (v > DX8Wrapper::Get_Current_Caps()->Get_Max_Vol_Extent()) {
+        v = DX8Wrapper::Get_Current_Caps()->Get_Max_Vol_Extent();
     }
 
     if (w > h) {
@@ -397,7 +397,7 @@ bool TextureLoader::Is_Format_Compressed(WW3DFormat format, bool allow_compresse
         return true;
     }
 
-    if (format == WW3D_FORMAT_UNKNOWN && DX8Wrapper::Supports_DXTC() && allow_compressed) {
+    if (format == WW3D_FORMAT_UNKNOWN && DX8Wrapper::Get_Current_Caps()->Supports_DXTC() && allow_compressed) {
         return true;
     }
 

--- a/src/w3d/renderer/vertmaterial.cpp
+++ b/src/w3d/renderer/vertmaterial.cpp
@@ -34,7 +34,7 @@ void VertexMaterialClass::Shutdown()
 void VertexMaterialClass::Apply() const
 {
 #ifdef GAME_DLL
-    Call_Function<void>(PICK_ADDRESS(0x008193A0, 0x004E63A0));
+    Call_Method<void, const VertexMaterialClass>(PICK_ADDRESS(0x008193A0, 0x004E63A0), this);
 #endif
 }
 
@@ -42,5 +42,50 @@ void VertexMaterialClass::Apply_Null()
 {
 #ifdef GAME_DLL
     Call_Function<void>(PICK_ADDRESS(0x00819460, 0x004E64B0));
+#endif
+}
+
+float VertexMaterialClass::Get_Opacity() const
+{
+#ifdef BUILD_WITH_D3D8
+    return m_material->Diffuse.a;
+#else
+    return 0;
+#endif
+}
+
+void VertexMaterialClass::Get_Diffuse(Vector3 *set_color) const
+{
+#ifdef BUILD_WITH_D3D8
+    set_color->X = m_material->Diffuse.r;
+    set_color->Y = m_material->Diffuse.g;
+    set_color->Z = m_material->Diffuse.b;
+#endif
+}
+
+unsigned long VertexMaterialClass::Compute_CRC() const
+{
+#ifdef GAME_DLL
+    return Call_Method<unsigned long, const VertexMaterialClass>(PICK_ADDRESS(0x00817750, 0x004E4400), this);
+#else
+    return 0;
+#endif
+}
+
+void VertexMaterialClass::Set_Diffuse(float r, float g, float b)
+{
+#ifdef BUILD_WITH_D3D8
+    m_CRCDirty = true;
+    m_material->Diffuse.r = r;
+    m_material->Diffuse.g = g;
+    m_material->Diffuse.b = b;
+#endif
+}
+
+void VertexMaterialClass::Set_Opacity(float o)
+{
+#ifdef BUILD_WITH_D3D8
+    m_CRCDirty = true;
+    m_material->Diffuse.a = o;
 #endif
 }

--- a/src/w3d/renderer/vertmaterial.h
+++ b/src/w3d/renderer/vertmaterial.h
@@ -15,21 +15,57 @@
 #pragma once
 #include "always.h"
 #include "refcount.h"
+#include "vector3.h"
 #include "w3dmpo.h"
 #include "w3dtypes.h"
 #include "wwstring.h"
+#ifdef BUILD_WITH_D3D8
+struct DynD3DMATERIAL8 : public W3DMPO, public D3DMATERIAL8
+{
+    IMPLEMENT_W3D_POOL(DynD3DMATERIAL8);
+};
+#endif
+class DX8Wrapper;
 class TextureMapperClass;
 class VertexMaterialClass : public W3DMPO, public RefCountClass
 {
+    friend DX8Wrapper;
+
 public:
+    enum ColorSourceType
+    {
+        MATERIAL = 0,
+        COLOR1,
+        COLOR2,
+    };
+
     virtual ~VertexMaterialClass();
-    void Apply() const;
     static void Init();
     static void Shutdown();
-    static void Apply_Null();
 
-private:
+    unsigned long Get_CRC() const
+    {
+        if (m_CRCDirty) {
+            m_CRC = Compute_CRC();
+            m_CRCDirty = false;
+        }
+
+        return m_CRC;
+    }
+
+    float Get_Opacity() const;
+    void Set_Opacity(float o);
+
+    void Get_Diffuse(Vector3 *set_color) const;
+    void Set_Diffuse(float r, float g, float b);
+    TextureMapperClass *Peek_Mapper(int stage = 0) { return m_mapper[stage]; }
+
+protected:
+#ifdef BUILD_WITH_D3D8
+    DynD3DMATERIAL8 *m_material;
+#else
     w3dmat_t *m_material;
+#endif
     unsigned int m_flags;
     unsigned int m_ambientColorSource;
     unsigned int m_emissiveColorSource;
@@ -38,7 +74,12 @@ private:
     TextureMapperClass *m_mapper[8];
     unsigned int m_UVSource[8];
     unsigned int m_uniqueID;
-    unsigned long m_CRC;
-    bool m_CRCDirty;
+    mutable unsigned long m_CRC;
+    mutable bool m_CRCDirty;
     bool m_useLighting;
+
+private:
+    void Apply() const;
+    static void Apply_Null();
+    unsigned long Compute_CRC(void) const;
 };

--- a/src/w3d/renderer/w3d.cpp
+++ b/src/w3d/renderer/w3d.cpp
@@ -26,6 +26,7 @@ bool W3D::s_texturingEnabled = true;
 bool W3D::s_thumbnailEnabled = true;
 int W3D::s_textureFilter;
 float W3D::s_defaultNativeScreenSize = 1;
+bool W3D::s_isSortingEnabled = true;
 #ifdef PLATFORM_WINDOWS
 HWND W3D::s_hwnd;
 #endif
@@ -43,7 +44,7 @@ void W3D::Get_Render_Target_Resolution(int &set_w, int &set_h, int &set_bits, bo
 
 int W3D::Get_Texture_Bit_Depth()
 {
-    return DX8Wrapper::Get_Texture_Bit_Depth();
+    return DX8Wrapper::s_textureBitDepth;
 }
 
 void W3D::Invalidate_Mesh_Cache()

--- a/src/w3d/renderer/w3d.h
+++ b/src/w3d/renderer/w3d.h
@@ -33,6 +33,7 @@ public:
     static bool Is_Thumbnail_Enabled() { return s_thumbnailEnabled; }
     static int Get_Texture_Filter() { return s_textureFilter; }
     static float Get_Default_Native_Screen_Size() { return s_defaultNativeScreenSize; }
+    static bool Is_Sorting_Enabled() { return s_isSortingEnabled; }
 
     // Calls to the graphics wrapper.
     static void Get_Device_Resolution(int &width, int &height, int &bit_depth, bool &windowed);
@@ -57,6 +58,7 @@ private:
     static bool &s_thumbnailEnabled;
     static int &s_textureFilter;
     static float &s_defaultNativeScreenSize;
+    static bool &s_isSortingEnabled;
 #ifdef PLATFORM_WINDOWS
     static HWND &s_hwnd;
 #endif
@@ -70,6 +72,7 @@ private:
     static bool s_thumbnailEnabled;
     static int s_textureFilter;
     static float s_defaultNativeScreenSize;
+    static bool s_isSortingEnabled;
 #ifdef PLATFORM_WINDOWS
     static HWND s_hwnd;
 #endif

--- a/src/w3d/renderer/w3dformat.cpp
+++ b/src/w3d/renderer/w3dformat.cpp
@@ -297,7 +297,7 @@ WW3DFormat Get_Valid_Texture_Format(WW3DFormat format, bool allow_compression)
 {
     WW3DFormat check_format = format;
 
-    if (!DX8Wrapper::Get_Caps()->Supports_DXTC() || !allow_compression) {
+    if (!DX8Wrapper::Get_Current_Caps()->Supports_DXTC() || !allow_compression) {
         if (format == WW3D_FORMAT_DXT1) {
             check_format = WW3D_FORMAT_X8R8G8B8;
         }
@@ -312,13 +312,13 @@ WW3DFormat Get_Valid_Texture_Format(WW3DFormat format, bool allow_compression)
     } else {
         if (format != WW3D_FORMAT_DXT1) {
             if (format > WW3D_FORMAT_DXT1 && format <= WW3D_FORMAT_DXT5
-                && !DX8Wrapper::Get_Caps()->Supports_Texture_Format(format)) {
+                && !DX8Wrapper::Get_Current_Caps()->Supports_Texture_Format(format)) {
                 check_format = WW3D_FORMAT_A8R8G8B8;
             } else if (check_format == WW3D_FORMAT_R8G8B8) {
                 check_format = WW3D_FORMAT_X8R8G8B8;
             }
-        } else if (!DX8Wrapper::Get_Caps()->Supports_Texture_Format(WW3D_FORMAT_DXT1)
-            && DX8Wrapper::Get_Caps()->Supports_Texture_Format(WW3D_FORMAT_DXT2)) {
+        } else if (!DX8Wrapper::Get_Current_Caps()->Supports_Texture_Format(WW3D_FORMAT_DXT1)
+            && DX8Wrapper::Get_Current_Caps()->Supports_Texture_Format(WW3D_FORMAT_DXT2)) {
             check_format = WW3D_FORMAT_DXT2;
         }
     }
@@ -343,13 +343,13 @@ WW3DFormat Get_Valid_Texture_Format(WW3DFormat format, bool allow_compression)
         }
     }
 
-    if (!DX8Wrapper::Get_Caps()->Supports_Texture_Format(check_format)) {
+    if (!DX8Wrapper::Get_Current_Caps()->Supports_Texture_Format(check_format)) {
         check_format = WW3D_FORMAT_A8R8G8B8;
-        if (!DX8Wrapper::Get_Caps()->Supports_Texture_Format(check_format)) {
+        if (!DX8Wrapper::Get_Current_Caps()->Supports_Texture_Format(check_format)) {
             check_format = WW3D_FORMAT_A4R4G4B4;
-            if (!DX8Wrapper::Get_Caps()->Supports_Texture_Format(check_format)) {
+            if (!DX8Wrapper::Get_Current_Caps()->Supports_Texture_Format(check_format)) {
                 check_format = WW3D_FORMAT_X8R8G8B8;
-                if (!DX8Wrapper::Get_Caps()->Supports_Texture_Format(check_format)) {
+                if (!DX8Wrapper::Get_Current_Caps()->Supports_Texture_Format(check_format)) {
                     check_format = WW3D_FORMAT_R5G6B5;
                 } else {
                     captainslog_dbgassert(false, "Get_Valid_Texture_Format - No valid texture format found");


### PR DESCRIPTION
Rename DX8Wrapper::Get_Caps to DX8Wrapper::Get_Current_Caps (which is the correct name)
Add s_isSortingEnabled and Is_Sorting_Enabled to W3D
Fix some functions in SortingRendererClass
Add Material_Override and Get_ObjectScale to RenderObjClass
Add DX8Wrapper::Set_Index_Buffer_Index_Offset and
DX8Wrapper::Set_World_Identity to DX8Wrapper.
Remove DX8Wrapper::Supports_DXTC (there is no evidence it exists and the
code is using a mix of DX8Wrapper::Supports_DXTC and
DX8Wrapper::Get_Current_Caps->Supports_DXTC)
Force NPatches to off and remove some related code.
Add missing #pragma once to colmath.h
Mark some things in DX8Wrapper public/private/protected as per available
information and add friend definitions based on what Renegade has for
friend defintions
Some fixes to the definition of VertexMaterialClass and add a couple
function definitions.
Add a couple definitions (no implementations) to mapper.h