### PR TITLE
Add missing include to allow building in latest MSVC

### DIFF
--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -18,6 +18,7 @@
 #include "memdynalloc.h"
 #include <cstdarg>
 #include <cstring>
+#include <new>
 
 // Using STLPort seems to screw up some of the C++11 header inclusions.
 #ifndef GAME_DLL

--- a/src/w3d/renderer/textureloadtask.h
+++ b/src/w3d/renderer/textureloadtask.h
@@ -21,6 +21,7 @@
 #include "vector3.h"
 #include "w3dformat.h"
 #include "w3dtypes.h"
+#include <new>
 
 class TextureLoadTaskListClass;
 


### PR DESCRIPTION
Something must have changed in the latest versions of MSVC. eitherway this will fix the ci's and stop it failing to build.