### PR TITLE
Add templates for strlcpy, strlcat, u_strlcpy to help avoid misuse

### DIFF
--- a/deps/baseconfig/src/always.h
+++ b/deps/baseconfig/src/always.h
@@ -75,6 +75,21 @@
 #if !defined HAVE_STD_CLAMP && defined __cplusplus
 #include <functional>
 
+template<size_t Size> size_t strlcat_t(char (&dst)[Size], const char *src)
+{
+    return strlcat(dst, src, Size);
+}
+
+template<size_t Size> size_t strlcpy_t(char (&dst)[Size], const char *src)
+{
+    return strlcpy(dst, src, Size);
+}
+
+template<size_t Size> size_t u_strlcpy_t(unichar_t (&dst)[Size], const unichar_t *src)
+{
+    return u_strlcpy(dst, src, Size);
+}
+
 namespace std
 {
     template<class T, class Compare>

--- a/deps/baseconfig/src/always.h
+++ b/deps/baseconfig/src/always.h
@@ -75,17 +75,17 @@
 #if !defined HAVE_STD_CLAMP && defined __cplusplus
 #include <functional>
 
-template<size_t Size> size_t strlcat_t(char (&dst)[Size], const char *src)
+template<size_t Size> size_t strlcat_tpl(char (&dst)[Size], const char *src)
 {
     return strlcat(dst, src, Size);
 }
 
-template<size_t Size> size_t strlcpy_t(char (&dst)[Size], const char *src)
+template<size_t Size> size_t strlcpy_tpl(char (&dst)[Size], const char *src)
 {
     return strlcpy(dst, src, Size);
 }
 
-template<size_t Size> size_t u_strlcpy_t(unichar_t (&dst)[Size], const unichar_t *src)
+template<size_t Size> size_t u_strlcpy_tpl(unichar_t (&dst)[Size], const unichar_t *src)
 {
     return u_strlcpy(dst, src, Size);
 }

--- a/src/game/common/ini/ini.cpp
+++ b/src/game/common/ini/ini.cpp
@@ -402,7 +402,7 @@ Utf8String INI::Get_Next_Quoted_Ascii_String()
     if (token != nullptr) {
         if (*token == '"') {
             if (strlen(token) > 1) {
-                strlcpy(buffer, token + 1, sizeof(buffer));
+                strlcpy_t(buffer, token + 1);
 
                 if (buffer[strlen(buffer) - 1] == '"') {
                     buffer[strlen(buffer) - 1] = '\0';
@@ -414,8 +414,8 @@ Utf8String INI::Get_Next_Quoted_Ascii_String()
             const char *next_tok = Get_Next_Token(m_sepsQuote);
 
             if (strlen(next_tok) > 1 && next_tok[1] != '\t') {
-                strlcat(buffer, " ", sizeof(buffer));
-                strlcat(buffer, next_tok, sizeof(buffer));
+                strlcat_t(buffer, " ");
+                strlcat_t(buffer, next_tok);
             }
 
             if (buffer[strlen(buffer) - 1] == '"') {

--- a/src/game/common/ini/ini.cpp
+++ b/src/game/common/ini/ini.cpp
@@ -402,7 +402,7 @@ Utf8String INI::Get_Next_Quoted_Ascii_String()
     if (token != nullptr) {
         if (*token == '"') {
             if (strlen(token) > 1) {
-                strlcpy_t(buffer, token + 1);
+                strlcpy_tpl(buffer, token + 1);
 
                 if (buffer[strlen(buffer) - 1] == '"') {
                     buffer[strlen(buffer) - 1] = '\0';
@@ -414,8 +414,8 @@ Utf8String INI::Get_Next_Quoted_Ascii_String()
             const char *next_tok = Get_Next_Token(m_sepsQuote);
 
             if (strlen(next_tok) > 1 && next_tok[1] != '\t') {
-                strlcat_t(buffer, " ");
-                strlcat_t(buffer, next_tok);
+                strlcat_tpl(buffer, " ");
+                strlcat_tpl(buffer, next_tok);
             }
 
             if (buffer[strlen(buffer) - 1] == '"') {

--- a/src/game/common/ini/ini.h
+++ b/src/game/common/ini/ini.h
@@ -219,17 +219,17 @@ inline Utf8String INI::Get_Next_Ascii_String()
             _buffer[0] = '\0';
 
             if (strlen(token) > 1) {
-                strlcpy_t(_buffer, token + 1);
+                strlcpy_tpl(_buffer, token + 1);
             }
 
             const char *next_token = Get_Next_Token_Or_Null(m_sepsQuote);
 
             if (next_token != nullptr) { // If we have another token, parse that too.
                 if (strlen(next_token) > 1 && next_token[1] != '\t') {
-                    strlcat_t(_buffer, " ");
+                    strlcat_tpl(_buffer, " ");
                 }
 
-                strlcat_t(_buffer, next_token);
+                strlcat_tpl(_buffer, next_token);
             } else { // Handle trailing ".
                 size_t length = strlen(_buffer);
 

--- a/src/game/common/ini/ini.h
+++ b/src/game/common/ini/ini.h
@@ -219,17 +219,17 @@ inline Utf8String INI::Get_Next_Ascii_String()
             _buffer[0] = '\0';
 
             if (strlen(token) > 1) {
-                strlcpy(_buffer, token + 1, sizeof(_buffer));
+                strlcpy_t(_buffer, token + 1);
             }
 
             const char *next_token = Get_Next_Token_Or_Null(m_sepsQuote);
 
             if (next_token != nullptr) { // If we have another token, parse that too.
                 if (strlen(next_token) > 1 && next_token[1] != '\t') {
-                    strlcat(_buffer, " ", sizeof(_buffer));
+                    strlcat_t(_buffer, " ");
                 }
 
-                strlcat(_buffer, next_token, sizeof(_buffer));
+                strlcat_t(_buffer, next_token);
             } else { // Handle trailing ".
                 size_t length = strlen(_buffer);
 

--- a/src/game/common/system/stackdump.cpp
+++ b/src/game/common/system/stackdump.cpp
@@ -603,10 +603,10 @@ void __cdecl Dump_Exception_Info(unsigned int u, struct _EXCEPTION_POINTERS *e_i
 
     for (int i = 32; i != 0; --i) {
         if (IsBadReadPtr(eip_pointer, 1)) {
-            strlcat_t(scratch, "?? ");
+            strlcat_tpl(scratch, "?? ");
         } else {
             sprintf(bytestr, "%02X ", *eip_pointer);
-            strlcat_t(scratch, bytestr);
+            strlcat_tpl(scratch, bytestr);
         }
 
         ++eip_pointer;
@@ -669,15 +669,15 @@ void __cdecl Dump_Exception_Info(unsigned int u, struct _EXCEPTION_POINTERS *e_i
             if (SymGetSymFromAddrPtr(GetCurrentProcess(), *esp_pointer, &disp, &sym) != 0) {
                 char sym_scratch[256];
                 snprintf(sym_scratch, sizeof(sym_scratch), " - %s + %" PRIPTRSIZE PRIXPTR "", sym.Name, disp);
-                strlcat_t(scratch, sym_scratch);
+                strlcat_tpl(scratch, sym_scratch);
             } else {
-                strlcat_t(scratch, " *");
+                strlcat_tpl(scratch, " *");
             }
         } else {
-            strlcat_t(scratch, " *");
+            strlcat_tpl(scratch, " *");
         }
 
-        strlcat_t(scratch, "\n");
+        strlcat_tpl(scratch, "\n");
         g_exceptionFileBuffer += scratch;
         ++esp_pointer;
     }

--- a/src/game/common/system/stackdump.cpp
+++ b/src/game/common/system/stackdump.cpp
@@ -603,10 +603,10 @@ void __cdecl Dump_Exception_Info(unsigned int u, struct _EXCEPTION_POINTERS *e_i
 
     for (int i = 32; i != 0; --i) {
         if (IsBadReadPtr(eip_pointer, 1)) {
-            strlcat(scratch, "?? ", sizeof(scratch));
+            strlcat_t(scratch, "?? ");
         } else {
             sprintf(bytestr, "%02X ", *eip_pointer);
-            strlcat(scratch, bytestr, sizeof(scratch));
+            strlcat_t(scratch, bytestr);
         }
 
         ++eip_pointer;
@@ -669,15 +669,15 @@ void __cdecl Dump_Exception_Info(unsigned int u, struct _EXCEPTION_POINTERS *e_i
             if (SymGetSymFromAddrPtr(GetCurrentProcess(), *esp_pointer, &disp, &sym) != 0) {
                 char sym_scratch[256];
                 snprintf(sym_scratch, sizeof(sym_scratch), " - %s + %" PRIPTRSIZE PRIXPTR "", sym.Name, disp);
-                strlcat(scratch, sym_scratch, sizeof(scratch));
+                strlcat_t(scratch, sym_scratch);
             } else {
-                strlcat(scratch, " *", sizeof(scratch));
+                strlcat_t(scratch, " *");
             }
         } else {
-            strlcat(scratch, " *", sizeof(scratch));
+            strlcat_t(scratch, " *");
         }
 
-        strlcat(scratch, "\n", sizeof(scratch));
+        strlcat_t(scratch, "\n");
         g_exceptionFileBuffer += scratch;
         ++esp_pointer;
     }

--- a/src/game/crashwrapper.cpp
+++ b/src/game/crashwrapper.cpp
@@ -26,7 +26,7 @@ CrashPrefWrapper::~CrashPrefWrapper()
 const char *CrashPrefWrapper::Get_Upload_URL()
 {
     static char path[512];
-    strlcpy_t(path, m_prefs->Get_Upload_URL().Str());
+    strlcpy_tpl(path, m_prefs->Get_Upload_URL().Str());
     return path;
 }
 

--- a/src/game/crashwrapper.cpp
+++ b/src/game/crashwrapper.cpp
@@ -26,7 +26,7 @@ CrashPrefWrapper::~CrashPrefWrapper()
 const char *CrashPrefWrapper::Get_Upload_URL()
 {
     static char path[512];
-    strlcpy(path, m_prefs->Get_Upload_URL().Str(), sizeof(path));
+    strlcpy_t(path, m_prefs->Get_Upload_URL().Str());
     return path;
 }
 

--- a/src/game/logic/scriptengine/scriptparam.cpp
+++ b/src/game/logic/scriptengine/scriptparam.cpp
@@ -403,9 +403,9 @@ Parameter *Parameter::Read_Parameter(DataChunkInput &input)
         if (param->m_string.Starts_With("Fundamentalist")) {
             char new_name[256];
             char old_name[256];
-            strlcpy_t(old_name, param->m_string.Str());
-            strlcpy_t(new_name, "GLA");
-            strlcat_t(new_name, &old_name[strlen("Fundamentalist")]);
+            strlcpy_tpl(old_name, param->m_string.Str());
+            strlcpy_tpl(new_name, "GLA");
+            strlcat_tpl(new_name, &old_name[strlen("Fundamentalist")]);
             param->m_string = new_name;
             captainslog_trace("Fixed up script reference from '%s' to '%s'.", old_name, new_name);
         }

--- a/src/game/logic/scriptengine/scriptparam.cpp
+++ b/src/game/logic/scriptengine/scriptparam.cpp
@@ -403,9 +403,9 @@ Parameter *Parameter::Read_Parameter(DataChunkInput &input)
         if (param->m_string.Starts_With("Fundamentalist")) {
             char new_name[256];
             char old_name[256];
-            strlcpy(old_name, param->m_string.Str(), sizeof(old_name));
-            strlcpy(new_name, "GLA", sizeof(new_name));
-            strlcat(new_name, &old_name[strlen("Fundamentalist")], sizeof(new_name));
+            strlcpy_t(old_name, param->m_string.Str());
+            strlcpy_t(new_name, "GLA");
+            strlcat_t(new_name, &old_name[strlen("Fundamentalist")]);
             param->m_string = new_name;
             captainslog_trace("Fixed up script reference from '%s' to '%s'.", old_name, new_name);
         }

--- a/src/game/network/lanapi.cpp
+++ b/src/game/network/lanapi.cpp
@@ -98,7 +98,7 @@ void LANAPI::Init()
 
     if (!GetUserNameA(user_name, &un_size)) {
         if (getenv("USERNAME") != nullptr) {
-            strlcpy_t(user_name, getenv("USERNAME"));
+            strlcpy_tpl(user_name, getenv("USERNAME"));
         } else {
             strcpy(user_name, "unknown");
         }
@@ -108,7 +108,7 @@ void LANAPI::Init()
 
     if (getlogin_r(user_name, sizeof(user_name)) != 0) {
         if (getenv("USER") != nullptr) {
-            strlcpy_t(user_name, getenv("USER"));
+            strlcpy_tpl(user_name, getenv("USER"));
         } else {
             strcpy(user_name, "unknown");
         }
@@ -126,7 +126,7 @@ void LANAPI::Init()
 
     if (!GetComputerNameA(host_name, &hn_size)) {
         if (getenv("COMPUTERNAME") != nullptr) {
-            strlcpy_t(host_name, getenv("COMPUTERNAME"));
+            strlcpy_tpl(host_name, getenv("COMPUTERNAME"));
         } else {
             strcpy(host_name, "unknown");
         }
@@ -136,7 +136,7 @@ void LANAPI::Init()
 
     if (gethostname(host_name, sizeof(host_name)) != 0) {
         if (getenv("HOSTNAME") != nullptr) {
-            strlcpy_t(host_name, getenv("HOSTNAME"));
+            strlcpy_tpl(host_name, getenv("HOSTNAME"));
         } else {
             strcpy(host_name, "unknown");
         }
@@ -229,7 +229,7 @@ void LANAPI::Request_Game_Join_Direct(uint32_t addr)
         msg.message_type = LANMessage::MSG_REQUEST_GAME_INFO;
         Fill_In_Message(&msg);
         msg.direct_join.addr = Get_Local_IP();
-        u_strlcpy_t(msg.direct_join.name, m_name.Str());
+        u_strlcpy_tpl(msg.direct_join.name, m_name.Str());
         Send_Message(&msg, addr);
         m_pendingAction = ACT_LEAVE;
         m_expiration = m_actionTimeout + rts::Get_Time();
@@ -525,9 +525,9 @@ bool LANAPI::Am_I_Host()
  */
 void LANAPI::Fill_In_Message(LANMessage *msg)
 {
-    u_strlcpy_t(msg->name, m_name.Str());
-    strlcpy_t(msg->user_name, m_userName);
-    strlcpy_t(msg->host_name, m_hostName);
+    u_strlcpy_tpl(msg->name, m_name.Str());
+    strlcpy_tpl(msg->user_name, m_userName);
+    strlcpy_tpl(msg->host_name, m_hostName);
 }
 
 LANPlayer *LANAPI::Lookup_Player(uint32_t ip)

--- a/src/game/network/lanapi.cpp
+++ b/src/game/network/lanapi.cpp
@@ -98,7 +98,7 @@ void LANAPI::Init()
 
     if (!GetUserNameA(user_name, &un_size)) {
         if (getenv("USERNAME") != nullptr) {
-            strlcpy(user_name, getenv("USERNAME"), sizeof(user_name));
+            strlcpy_t(user_name, getenv("USERNAME"));
         } else {
             strcpy(user_name, "unknown");
         }
@@ -108,7 +108,7 @@ void LANAPI::Init()
 
     if (getlogin_r(user_name, sizeof(user_name)) != 0) {
         if (getenv("USER") != nullptr) {
-            strlcpy(user_name, getenv("USER"), sizeof(user_name));
+            strlcpy_t(user_name, getenv("USER"));
         } else {
             strcpy(user_name, "unknown");
         }
@@ -126,7 +126,7 @@ void LANAPI::Init()
 
     if (!GetComputerNameA(host_name, &hn_size)) {
         if (getenv("COMPUTERNAME") != nullptr) {
-            strlcpy(host_name, getenv("COMPUTERNAME"), sizeof(host_name));
+            strlcpy_t(host_name, getenv("COMPUTERNAME"));
         } else {
             strcpy(host_name, "unknown");
         }
@@ -136,7 +136,7 @@ void LANAPI::Init()
 
     if (gethostname(host_name, sizeof(host_name)) != 0) {
         if (getenv("HOSTNAME") != nullptr) {
-            strlcpy(host_name, getenv("HOSTNAME"), sizeof(host_name));
+            strlcpy_t(host_name, getenv("HOSTNAME"));
         } else {
             strcpy(host_name, "unknown");
         }
@@ -216,7 +216,7 @@ void LANAPI::Request_Game_Join(LANGameInfo *game, uint32_t addr)
 }
 
 /**
- * Request a diret join game.
+ * Request a direct join game.
  *
  * 0x0072A090
  */
@@ -229,7 +229,7 @@ void LANAPI::Request_Game_Join_Direct(uint32_t addr)
         msg.message_type = LANMessage::MSG_REQUEST_GAME_INFO;
         Fill_In_Message(&msg);
         msg.direct_join.addr = Get_Local_IP();
-        u_strlcpy(msg.direct_join.name, m_name.Str(), m_name.Get_Length() + 1);
+        u_strlcpy_t(msg.direct_join.name, m_name.Str());
         Send_Message(&msg, addr);
         m_pendingAction = ACT_LEAVE;
         m_expiration = m_actionTimeout + rts::Get_Time();
@@ -525,9 +525,9 @@ bool LANAPI::Am_I_Host()
  */
 void LANAPI::Fill_In_Message(LANMessage *msg)
 {
-    u_strlcpy(msg->name, m_name.Str(), sizeof(msg->name));
-    strlcpy(msg->user_name, m_userName, sizeof(msg->user_name));
-    strlcpy(msg->host_name, m_hostName, sizeof(msg->host_name));
+    u_strlcpy_t(msg->name, m_name.Str());
+    strlcpy_t(msg->user_name, m_userName);
+    strlcpy_t(msg->host_name, m_hostName);
 }
 
 LANPlayer *LANAPI::Lookup_Player(uint32_t ip)

--- a/src/game/network/lanapi.cpp
+++ b/src/game/network/lanapi.cpp
@@ -229,6 +229,8 @@ void LANAPI::Request_Game_Join_Direct(uint32_t addr)
         msg.message_type = LANMessage::MSG_REQUEST_GAME_INFO;
         Fill_In_Message(&msg);
         msg.direct_join.addr = Get_Local_IP();
+        // BUGFIX: Originally the target buffer size came from the source string length, which could cause buffer overflow if
+        // the source string is longer than the target buffer.
         u_strlcpy_tpl(msg.direct_join.name, m_name.Str());
         Send_Message(&msg, addr);
         m_pendingAction = ACT_LEAVE;

--- a/src/platform/w3dfilesystem.cpp
+++ b/src/platform/w3dfilesystem.cpp
@@ -73,8 +73,8 @@ const char *GameFileClass::Set_Name(const char *filename)
     char buff[PATH_MAX];
     char ext[32];
 
-    strlcpy_t(m_filename, filename);
-    strlcpy_t(buff, filename);
+    strlcpy_tpl(m_filename, filename);
+    strlcpy_tpl(buff, filename);
 
     int count = 1;
     for (size_t i = strlen(buff) - 1; i > 0; --i) {
@@ -83,7 +83,7 @@ const char *GameFileClass::Set_Name(const char *filename)
         }
 
         if (buff[i] == '.') {
-            strlcpy_t(ext, &buff[i]);
+            strlcpy_tpl(ext, &buff[i]);
             buff[i] = '\0';
 
             break;
@@ -107,7 +107,7 @@ const char *GameFileClass::Set_Name(const char *filename)
     if (strcasecmp(ext, ".w3d") == 0) {
         file_type = GAME_FILE_W3D;
         snprintf(m_filePath, sizeof(m_filePath), "Data/%s/Art/W3D/", Get_Registry_Language().Str());
-        strlcat_t(m_filePath, filename);
+        strlcat_tpl(m_filePath, filename);
     } else {
         if (strcasecmp(ext, ".tga") == 0) {
             file_type = GAME_FILE_TGA;
@@ -120,7 +120,7 @@ const char *GameFileClass::Set_Name(const char *filename)
         if (file_type != GAME_FILE_UNK) {
             snprintf(m_filePath, sizeof(m_filePath), "Data/%s/Art/Textures/", Get_Registry_Language().Str());
 
-            strlcat_t(m_filePath, filename);
+            strlcat_tpl(m_filePath, filename);
         }
     }
 
@@ -129,16 +129,16 @@ const char *GameFileClass::Set_Name(const char *filename)
     if (!m_fileExists) {
         switch (file_type) {
             case GAME_FILE_W3D:
-                strlcpy_t(m_filePath, "Art/W3D/");
-                strlcat_t(m_filePath, filename);
+                strlcpy_tpl(m_filePath, "Art/W3D/");
+                strlcat_tpl(m_filePath, filename);
                 break;
             case GAME_FILE_TGA:
             case GAME_FILE_DDS: // Fallthrough
-                strlcpy_t(m_filePath, "Art/Textures/");
-                strlcat_t(m_filePath, filename);
+                strlcpy_tpl(m_filePath, "Art/Textures/");
+                strlcat_tpl(m_filePath, filename);
                 break;
             default:
-                strlcpy_t(m_filePath, filename);
+                strlcpy_tpl(m_filePath, filename);
                 break;
         }
 
@@ -150,8 +150,8 @@ const char *GameFileClass::Set_Name(const char *filename)
             case GAME_FILE_W3D:
             case GAME_FILE_TGA:
             case GAME_FILE_DDS: // Fallthrough
-                strlcpy_t(m_filePath, "../TestArt/");
-                strlcat_t(m_filePath, filename);
+                strlcpy_tpl(m_filePath, "../TestArt/");
+                strlcat_tpl(m_filePath, filename);
                 break;
             default:
                 break;
@@ -164,12 +164,12 @@ const char *GameFileClass::Set_Name(const char *filename)
         switch (file_type) {
             case GAME_FILE_W3D:
                 snprintf(m_filePath, sizeof(m_filePath), "%sW3D/", g_theWriteableGlobalData->m_userDataDirectory.Str());
-                strlcat_t(m_filePath, filename);
+                strlcat_tpl(m_filePath, filename);
                 break;
             case GAME_FILE_TGA:
             case GAME_FILE_DDS: // Fallthrough
                 snprintf(m_filePath, sizeof(m_filePath), "%sTextures/", g_theWriteableGlobalData->m_userDataDirectory.Str());
-                strlcat_t(m_filePath, filename);
+                strlcat_tpl(m_filePath, filename);
                 break;
             default:
                 break;
@@ -185,7 +185,7 @@ const char *GameFileClass::Set_Name(const char *filename)
                 // case GAME_FILE_DDS: //Fallthrough
                 snprintf(
                     m_filePath, sizeof(m_filePath), "%sMapPreviews/", g_theWriteableGlobalData->m_userDataDirectory.Str());
-                strlcat_t(m_filePath, filename);
+                strlcat_tpl(m_filePath, filename);
                 break;
             default:
                 break;

--- a/src/platform/w3dfilesystem.cpp
+++ b/src/platform/w3dfilesystem.cpp
@@ -73,8 +73,8 @@ const char *GameFileClass::Set_Name(const char *filename)
     char buff[PATH_MAX];
     char ext[32];
 
-    strlcpy(m_filename, filename, sizeof(m_filename));
-    strlcpy(buff, filename, sizeof(buff));
+    strlcpy_t(m_filename, filename);
+    strlcpy_t(buff, filename);
 
     int count = 1;
     for (size_t i = strlen(buff) - 1; i > 0; --i) {
@@ -83,7 +83,7 @@ const char *GameFileClass::Set_Name(const char *filename)
         }
 
         if (buff[i] == '.') {
-            strlcpy(ext, &buff[i], sizeof(ext));
+            strlcpy_t(ext, &buff[i]);
             buff[i] = '\0';
 
             break;
@@ -107,7 +107,7 @@ const char *GameFileClass::Set_Name(const char *filename)
     if (strcasecmp(ext, ".w3d") == 0) {
         file_type = GAME_FILE_W3D;
         snprintf(m_filePath, sizeof(m_filePath), "Data/%s/Art/W3D/", Get_Registry_Language().Str());
-        strlcat(m_filePath, filename, sizeof(m_filePath));
+        strlcat_t(m_filePath, filename);
     } else {
         if (strcasecmp(ext, ".tga") == 0) {
             file_type = GAME_FILE_TGA;
@@ -120,7 +120,7 @@ const char *GameFileClass::Set_Name(const char *filename)
         if (file_type != GAME_FILE_UNK) {
             snprintf(m_filePath, sizeof(m_filePath), "Data/%s/Art/Textures/", Get_Registry_Language().Str());
 
-            strlcat(m_filePath, filename, sizeof(m_filePath));
+            strlcat_t(m_filePath, filename);
         }
     }
 
@@ -129,16 +129,16 @@ const char *GameFileClass::Set_Name(const char *filename)
     if (!m_fileExists) {
         switch (file_type) {
             case GAME_FILE_W3D:
-                strlcpy(m_filePath, "Art/W3D/", sizeof(m_filePath));
-                strlcat(m_filePath, filename, sizeof(m_filePath));
+                strlcpy_t(m_filePath, "Art/W3D/");
+                strlcat_t(m_filePath, filename);
                 break;
             case GAME_FILE_TGA:
             case GAME_FILE_DDS: // Fallthrough
-                strlcpy(m_filePath, "Art/Textures/", sizeof(m_filePath));
-                strlcat(m_filePath, filename, sizeof(m_filePath));
+                strlcpy_t(m_filePath, "Art/Textures/");
+                strlcat_t(m_filePath, filename);
                 break;
             default:
-                strlcpy(m_filePath, filename, sizeof(m_filePath));
+                strlcpy_t(m_filePath, filename);
                 break;
         }
 
@@ -150,8 +150,8 @@ const char *GameFileClass::Set_Name(const char *filename)
             case GAME_FILE_W3D:
             case GAME_FILE_TGA:
             case GAME_FILE_DDS: // Fallthrough
-                strlcpy(m_filePath, "../TestArt/", sizeof(m_filePath));
-                strlcat(m_filePath, filename, sizeof(m_filePath));
+                strlcpy_t(m_filePath, "../TestArt/");
+                strlcat_t(m_filePath, filename);
                 break;
             default:
                 break;
@@ -164,12 +164,12 @@ const char *GameFileClass::Set_Name(const char *filename)
         switch (file_type) {
             case GAME_FILE_W3D:
                 snprintf(m_filePath, sizeof(m_filePath), "%sW3D/", g_theWriteableGlobalData->m_userDataDirectory.Str());
-                strlcat(m_filePath, filename, sizeof(m_filePath));
+                strlcat_t(m_filePath, filename);
                 break;
             case GAME_FILE_TGA:
             case GAME_FILE_DDS: // Fallthrough
                 snprintf(m_filePath, sizeof(m_filePath), "%sTextures/", g_theWriteableGlobalData->m_userDataDirectory.Str());
-                strlcat(m_filePath, filename, sizeof(m_filePath));
+                strlcat_t(m_filePath, filename);
                 break;
             default:
                 break;
@@ -185,7 +185,7 @@ const char *GameFileClass::Set_Name(const char *filename)
                 // case GAME_FILE_DDS: //Fallthrough
                 snprintf(
                     m_filePath, sizeof(m_filePath), "%sMapPreviews/", g_theWriteableGlobalData->m_userDataDirectory.Str());
-                strlcat(m_filePath, filename, sizeof(m_filePath));
+                strlcat_t(m_filePath, filename);
                 break;
             default:
                 break;

--- a/src/w3d/lib/cpudetect.cpp
+++ b/src/w3d/lib/cpudetect.cpp
@@ -1414,7 +1414,7 @@ void CPUDetectClass::Init_Processor_Log()
 #define CPU_LOG(n, ...) \
     do { \
         snprintf(work, sizeof(work), n, ##__VA_ARGS__); \
-        strlcat_t(ProcessorLog, work); \
+        strlcat_tpl(ProcessorLog, work); \
     } while (false)
 
     char work[256];
@@ -1549,7 +1549,7 @@ void CPUDetectClass::Init_Compact_Log()
 #define COMPACT_LOG(n, ...) \
     do { \
         snprintf(work, sizeof(work), n, ##__VA_ARGS__); \
-        strlcat_t(CompactLog, work); \
+        strlcat_tpl(CompactLog, work); \
     } while (false)
 
     char work[256];

--- a/src/w3d/lib/cpudetect.cpp
+++ b/src/w3d/lib/cpudetect.cpp
@@ -1414,7 +1414,7 @@ void CPUDetectClass::Init_Processor_Log()
 #define CPU_LOG(n, ...) \
     do { \
         snprintf(work, sizeof(work), n, ##__VA_ARGS__); \
-        strlcat(ProcessorLog, work, sizeof(ProcessorLog)); \
+        strlcat_t(ProcessorLog, work); \
     } while (false)
 
     char work[256];
@@ -1549,7 +1549,7 @@ void CPUDetectClass::Init_Compact_Log()
 #define COMPACT_LOG(n, ...) \
     do { \
         snprintf(work, sizeof(work), n, ##__VA_ARGS__); \
-        strlcat(CompactLog, work, sizeof(CompactLog)); \
+        strlcat_t(CompactLog, work); \
     } while (false)
 
     char work[256];

--- a/src/w3d/lib/targa.cpp
+++ b/src/w3d/lib/targa.cpp
@@ -366,7 +366,7 @@ int TargaImage::Save(const char *name, int flags, bool add_extension)
     // Write the extension if required, if not just write the footer.
     if (add_extension) {
         m_extension.ext_size = sizeof(m_extension);
-        strlcpy(m_extension.software_id, "Thyme Game Engine", sizeof(m_extension.software_id));
+        strlcpy_t(m_extension.software_id, "Thyme Game Engine");
         m_extension.software_vers.number = 1;
         m_extension.software_vers.letter = '\0';
         footer.extension = File_Seek(0, FileSeekType::FS_SEEK_CURRENT);
@@ -380,7 +380,7 @@ int TargaImage::Save(const char *name, int flags, bool add_extension)
         footer.extension = 0;
     }
 
-    strlcpy(footer.signature, "TRUEVISION-XFILE", sizeof(footer.signature));
+    strlcpy_t(footer.signature, "TRUEVISION-XFILE");
     footer.dot_char = '.';
     footer.null_char = '\0';
 

--- a/src/w3d/lib/targa.cpp
+++ b/src/w3d/lib/targa.cpp
@@ -366,7 +366,7 @@ int TargaImage::Save(const char *name, int flags, bool add_extension)
     // Write the extension if required, if not just write the footer.
     if (add_extension) {
         m_extension.ext_size = sizeof(m_extension);
-        strlcpy_t(m_extension.software_id, "Thyme Game Engine");
+        strlcpy_tpl(m_extension.software_id, "Thyme Game Engine");
         m_extension.software_vers.number = 1;
         m_extension.software_vers.letter = '\0';
         footer.extension = File_Seek(0, FileSeekType::FS_SEEK_CURRENT);
@@ -380,7 +380,7 @@ int TargaImage::Save(const char *name, int flags, bool add_extension)
         footer.extension = 0;
     }
 
-    strlcpy_t(footer.signature, "TRUEVISION-XFILE");
+    strlcpy_tpl(footer.signature, "TRUEVISION-XFILE");
     footer.dot_char = '.';
     footer.null_char = '\0';
 

--- a/src/w3d/lib/thread.cpp
+++ b/src/w3d/lib/thread.cpp
@@ -58,7 +58,7 @@ ThreadClass::ThreadClass(const char *thread_name, except_t exception_handler) :
 {
     if (thread_name != nullptr) {
         // Safer copy, prevents buffer overrun
-        strlcpy_t(m_threadName, thread_name);
+        strlcpy_tpl(m_threadName, thread_name);
     } else {
         // We know this is safe for string "No Name" as buffer is 67.
         strcpy(m_threadName, "No Name");

--- a/src/w3d/lib/thread.cpp
+++ b/src/w3d/lib/thread.cpp
@@ -58,7 +58,7 @@ ThreadClass::ThreadClass(const char *thread_name, except_t exception_handler) :
 {
     if (thread_name != nullptr) {
         // Safer copy, prevents buffer overrun
-        strlcpy(m_threadName, thread_name, sizeof(m_threadName));
+        strlcpy_t(m_threadName, thread_name);
     } else {
         // We know this is safe for string "No Name" as buffer is 67.
         strcpy(m_threadName, "No Name");

--- a/src/w3d/lib/threadtrack.cpp
+++ b/src/w3d/lib/threadtrack.cpp
@@ -40,7 +40,7 @@ void Register_Thread_ID(int id, const char *name, bool is_main)
 
     ThreadTracker *tt = new ThreadTracker;
     tt->id = id;
-    strlcpy(tt->name, name, sizeof(tt->name));
+    strlcpy_t(tt->name, name);
     tt->is_main = is_main;
     tt->unknown = -1;
     g_threadTracker.Add(tt);

--- a/src/w3d/lib/threadtrack.cpp
+++ b/src/w3d/lib/threadtrack.cpp
@@ -40,7 +40,7 @@ void Register_Thread_ID(int id, const char *name, bool is_main)
 
     ThreadTracker *tt = new ThreadTracker;
     tt->id = id;
-    strlcpy_t(tt->name, name);
+    strlcpy_tpl(tt->name, name);
     tt->is_main = is_main;
     tt->unknown = -1;
     g_threadTracker.Add(tt);

--- a/src/w3d/renderer/ddsfile.cpp
+++ b/src/w3d/renderer/ddsfile.cpp
@@ -44,7 +44,7 @@ DDSFileClass::DDSFileClass(const char *filename, unsigned reduction_factor) :
     m_totalSizeMaybe(0)
 {
     // Copy the name across and replace the extension with dds.
-    strlcpy(m_name, filename, sizeof(m_name));
+    strlcpy_t(m_name, filename);
     size_t name_len = strlen(m_name);
     m_name[name_len - 3] = 'd';
     m_name[name_len - 2] = 'd';

--- a/src/w3d/renderer/ddsfile.cpp
+++ b/src/w3d/renderer/ddsfile.cpp
@@ -44,7 +44,7 @@ DDSFileClass::DDSFileClass(const char *filename, unsigned reduction_factor) :
     m_totalSizeMaybe(0)
 {
     // Copy the name across and replace the extension with dds.
-    strlcpy_t(m_name, filename);
+    strlcpy_tpl(m_name, filename);
     size_t name_len = strlen(m_name);
     m_name[name_len - 3] = 'd';
     m_name[name_len - 2] = 'd';

--- a/src/w3d/renderer/dx8wrapper.cpp
+++ b/src/w3d/renderer/dx8wrapper.cpp
@@ -1722,7 +1722,7 @@ w3dsurface_t DX8Wrapper::Create_Surface(const char *name)
 
         // If the initial file is tga and isn't available try the dds version.
         if (!fptr->Is_Available()) {
-            strlcpy(buf, name, sizeof(buf));
+            strlcpy_t(buf, name);
             char *ext = strchr(buf, '.');
 
             if (strlen(ext) == 4) {

--- a/src/w3d/renderer/dx8wrapper.cpp
+++ b/src/w3d/renderer/dx8wrapper.cpp
@@ -1722,7 +1722,7 @@ w3dsurface_t DX8Wrapper::Create_Surface(const char *name)
 
         // If the initial file is tga and isn't available try the dds version.
         if (!fptr->Is_Available()) {
-            strlcpy_t(buf, name);
+            strlcpy_tpl(buf, name);
             char *ext = strchr(buf, '.');
 
             if (strlen(ext) == 4) {


### PR DESCRIPTION
These templates make passing size obsolete, because the template will deduce the size from the passed array type. This helps avoid making errors when passing array sizes.