### PR TITLE
Implement a number of missing rendering engine functions

### DIFF
--- a/src/hooker/setuphooks_zh.cpp
+++ b/src/hooker/setuphooks_zh.cpp
@@ -894,6 +894,7 @@ void Setup_Hooks()
     Hook_Method(0x008095F0, &Render2DClass::Enable_Alpha);
     Hook_Any(0x008094E0, Render2DClass::Reset);
     Hook_Method(0x008090C0, &Render2DClass::Hook_Ctor);
+    Hook_Method(0x0080AAC0, &Render2DClass::Render);
 
     // wwstring.h
     Hook_Method(0x0089D4E0, &StringClass::Format);
@@ -948,6 +949,7 @@ void Setup_Hooks()
     Hook_Method(0x00804D00, &DX8Wrapper::Get_DX8_Render_State_Value_Name);
     Hook_Method(0x00805520, &DX8Wrapper::Get_DX8_Texture_Stage_State_Value_Name);
     Hook_Method(0x00805B60, &DX8Wrapper::Get_Back_Buffer_Format);
+    Hook_Method(0x00804200, &DX8Wrapper::Set_Light_Environment);
 
     // dinputkeybd.h
     // Hooks all the virtual functions for DirectInputKeyboard.

--- a/src/w3d/renderer/assetmgr.cpp
+++ b/src/w3d/renderer/assetmgr.cpp
@@ -650,7 +650,7 @@ RenderObjClass *GameAssetManager::Create_Render_Obj(
     }
 
     if (has_scaling) {
-        robj->Set_ObjectScale(scale);
+        robj->Scale(scale);
     }
 
     Make_Unique(robj, has_scaling, has_colour);

--- a/src/w3d/renderer/assetmgr.h
+++ b/src/w3d/renderer/assetmgr.h
@@ -98,6 +98,7 @@ public:
 
     bool Get_W3D_Load_On_Demand() const { return m_loadOnDemand; }
     void Set_W3D_Load_On_Demand(bool state) { m_loadOnDemand = state; }
+    HashTemplateClass<StringClass, TextureClass *> &Texture_Hash() { return m_textureHash; }
 
 protected:
     virtual AssetIterator *Create_Font3DData_Iterator();

--- a/src/w3d/renderer/dx8vertexbuffer.h
+++ b/src/w3d/renderer/dx8vertexbuffer.h
@@ -205,7 +205,12 @@ public:
     public:
         WriteLockClass(DynamicVBAccessClass *dynamic_vb_access_);
         ~WriteLockClass();
-        VertexFormatXYZNDUV2 *Get_Formatted_Vertex_Array() { return m_vertices; }
+        VertexFormatXYZNDUV2 *Get_Formatted_Vertex_Array()
+        {
+            captainslog_assert(m_dynamicVBAccess->m_vertexBuffer->FVF_Info().Get_FVF()
+                == (D3DFVF_XYZ | D3DFVF_NORMAL | D3DFVF_TEX2 | D3DFVF_DIFFUSE));
+            return m_vertices;
+        }
 
     private:
 #ifdef GAME_DLL

--- a/src/w3d/renderer/dx8wrapper.h
+++ b/src/w3d/renderer/dx8wrapper.h
@@ -555,7 +555,11 @@ inline void DX8Wrapper::Set_DX8_Texture(unsigned stage, w3dbasetexture_t texture
     }
 
     s_textures[stage] = texture;
-    s_textures[stage]->AddRef();
+
+    if (s_textures[stage]) {
+        s_textures[stage]->AddRef();
+    }
+
     DX8CALL(SetTexture(stage, texture));
     ++s_textureChanges;
 }

--- a/src/w3d/renderer/intersec.h
+++ b/src/w3d/renderer/intersec.h
@@ -1,0 +1,103 @@
+/**
+ * @file
+ *
+ * @author Jonathan Wilson
+ *
+ * @brief intersection class
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "always.h"
+#include "matrix3d.h"
+#include "sphere.h"
+#include "vector3.h"
+class RenderObjClass;
+
+typedef unsigned short POLYGONINDEX;
+class IntersectionResultClass
+{
+public:
+    RenderObjClass *m_intersectedRenderObject;
+    POLYGONINDEX m_intersectedPolygon;
+    Matrix3D m_modelMatrix;
+    Vector3 m_modelLocation;
+    Vector3 m_intersection;
+    float m_range;
+    float m_alpha;
+    float m_beta;
+    bool m_intersects;
+    int m_CollisionType;
+
+    enum INTERSECTION_TYPE
+    {
+        NONE = 0,
+        GENERIC,
+        POLYGON
+    } m_intersectionType;
+};
+
+class IntersectionClass
+{
+public:
+    enum
+    {
+        MAX_POLY_INTERSECTION_COUNT = 1000,
+        MAX_HIERARCHY_NODE_COUNT = 256
+    };
+
+    Vector3 *m_rayLocation;
+    Vector3 *m_rayDirection;
+    Vector3 *m_intersectionNormal;
+    float m_screenX;
+    float m_screenY;
+    bool m_interpolateNormal;
+    bool m_convexTest;
+    float m_maxDistance;
+    IntersectionResultClass m_result;
+
+    virtual ~IntersectionClass() {}
+
+    bool Intersect_Sphere_Quick(SphereClass &Sphere, IntersectionResultClass *FinalResult)
+    {
+        Vector3 sphere_vector(Sphere.Center - *m_rayLocation);
+        FinalResult->m_alpha = Vector3::Dot_Product(sphere_vector, *m_rayDirection);
+        FinalResult->m_beta = Sphere.Radius * Sphere.Radius
+            - (Vector3::Dot_Product(sphere_vector, sphere_vector) - FinalResult->m_alpha * FinalResult->m_alpha);
+
+        if (FinalResult->m_beta < 0.0f) {
+            FinalResult->m_intersects = false;
+        }
+
+        FinalResult->m_intersects = true;
+        return FinalResult->m_intersects;
+    }
+
+    bool Intersect_Sphere(SphereClass &Sphere, IntersectionResultClass *FinalResult)
+    {
+        if (!Intersect_Sphere_Quick(Sphere, FinalResult)) {
+            return false;
+        }
+
+        float d = GameMath::Sqrt(FinalResult->m_beta);
+        FinalResult->m_range = FinalResult->m_alpha - d;
+
+        if (FinalResult->m_range > m_maxDistance) {
+            return false;
+        }
+
+        FinalResult->m_intersection = *m_rayLocation + FinalResult->m_range * (*m_rayDirection);
+
+        if (m_intersectionNormal != nullptr) {
+            (*m_intersectionNormal) = FinalResult->m_intersection - Sphere.Center;
+        }
+
+        return true;
+    }
+};

--- a/src/w3d/renderer/texturebase.h
+++ b/src/w3d/renderer/texturebase.h
@@ -100,7 +100,7 @@ public:
     bool Is_Initialized() const { return m_initialized; }
     void Set_Dirty(bool dirty) { m_dirty = dirty; }
 
-    static void Invalidate_Old_Unused_Textures(unsigned unk);
+    static void Invalidate_Old_Unused_Textures(unsigned age);
     static void Apply_Null(unsigned stage);
 
 protected:

--- a/src/w3d/renderer/w3d.cpp
+++ b/src/w3d/renderer/w3d.cpp
@@ -14,7 +14,11 @@
  *            LICENSE
  */
 #include "w3d.h"
+#include "assetmgr.h"
+#include "dx8renderer.h"
 #include "dx8wrapper.h"
+#include "hashtemplate.h"
+#include "textureloader.h"
 
 #ifndef GAME_DLL
 unsigned W3D::s_syncTime;
@@ -55,16 +59,20 @@ int W3D::Get_Texture_Bit_Depth()
 
 void W3D::Invalidate_Mesh_Cache()
 {
-#ifdef GAME_DLL
-    Call_Function<void>(PICK_ADDRESS(0x00807840, 0x00503700));
-#endif
+    g_theDX8MeshRenderer.Invalidate(false);
 }
 
 void W3D::Invalidate_Textures()
 {
-#ifdef GAME_DLL
-    Call_Function<void>(PICK_ADDRESS(0x00807850, 0x00503710));
-#endif
+    if (W3DAssetManager::Get_Instance()) {
+        TextureLoader::Flush_Pending_Load_Tasks();
+        for (HashTemplateIterator<StringClass, TextureClass *> textureIter(W3DAssetManager::Get_Instance()->Texture_Hash());
+             textureIter;
+             ++textureIter) {
+            TextureClass *texture = textureIter.getValue();
+            texture->Invalidate();
+        }
+    }
 }
 
 W3DErrorType W3D::Set_Device_Resolution(int width, int height, int bits, int windowed, bool resize_window)


### PR DESCRIPTION
Add Texture_Hash function to W3DAssetManager
Implement DX8Wrapper::Set_Light_Environment
Implement Render2DClass::Render
Add IntersectionResultClass and IntersectionClass
Implement RenderObjClass::Get_Screen_Size
Implement RenderObjClass::Intersect, RenderObjClass::Intersect_Sphere
and RenderObjClass::Intersect_Sphere_Quick
Implement TextureBaseClass::Invalidate_Old_Unused_Textures
Implement TextureBaseClass::Apply_Null
Implement W3D::Invalidate_Textures
Fix DX8Wrapper::Set_DX8_Texture to not crash when the passed in texture
is nullptr