### PR TITLE
Fix format buffer overflow, utf conversion, character access functions, const correctness in Utf8String and Utf16String

### DIFF
--- a/src/game/common/system/asciistring.cpp
+++ b/src/game/common/system/asciistring.cpp
@@ -54,7 +54,17 @@ Utf8String::Utf8String(const char *s) : m_data(nullptr)
 /**
  * A utility method to test nullptr on string content and log if that happens
  */
-char *Utf8String::Peek() const
+const char *Utf8String::Peek() const
+{
+    captainslog_dbgassert(m_data != nullptr, "null string ptr");
+
+    return m_data->Peek();
+}
+
+/**
+ * A utility method to test nullptr on string content and log if that happens
+ */
+char *Utf8String::Peek()
 {
     captainslog_dbgassert(m_data != nullptr, "null string ptr");
 
@@ -152,8 +162,16 @@ int Utf8String::Get_Length() const
 
 char Utf8String::Get_Char(int index) const
 {
-    captainslog_dbgassert(index >= 0, "bad index in getCharAt.");
-    captainslog_dbgassert(Get_Length() > 0, "strlen returned less than or equal to 0 in getCharAt.");
+    captainslog_dbgassert(index >= 0, "Index must be equal or larger than 0.");
+    captainslog_dbgassert(index < Get_Length(), "Index must be smaller than length.");
+
+    return Peek()[index];
+}
+
+char &Utf8String::Get_Char(int index)
+{
+    captainslog_dbgassert(index >= 0, "Index must be equal or larger than 0.");
+    captainslog_dbgassert(index < Get_Length(), "Index must be smaller than length.");
 
     return Peek()[index];
 }

--- a/src/game/common/system/asciistring.cpp
+++ b/src/game/common/system/asciistring.cpp
@@ -459,7 +459,7 @@ void Utf8String::Format_VA(const char *format, va_list args)
 {
     char buf[MAX_FORMAT_BUF_LEN];
 
-    int res = vsnprintf(buf, sizeof(buf), format, args);
+    int res = vsnprintf(buf, ARRAY_SIZE(buf), format, args);
     captainslog_relassert(res > 0, 0xDEAD0002, "Unable to format buffer");
 
     Set(buf);
@@ -471,7 +471,7 @@ void Utf8String::Format_VA(const char *format, va_list args)
 void Utf8String::Format_VA(Utf8String &format, va_list args)
 {
     char buf[MAX_FORMAT_BUF_LEN];
-    int res = vsnprintf(buf, sizeof(buf), format.Str(), args);
+    int res = vsnprintf(buf, ARRAY_SIZE(buf), format.Str(), args);
     captainslog_relassert(res > 0, 0xDEAD0002, "Unable to format buffer");
 
     Set(buf);

--- a/src/game/common/system/asciistring.cpp
+++ b/src/game/common/system/asciistring.cpp
@@ -27,7 +27,7 @@ Utf8String const Utf8String::s_emptyString(nullptr);
 Utf8String::Utf8String() : m_data(nullptr) {}
 
 /**
- * Inits this string with an existing string (copy) and increments reference count
+ * Initializes this string with an existing string (copy) and increments reference count.
  */
 Utf8String::Utf8String(Utf8String const &string) : m_data(string.m_data)
 {
@@ -37,7 +37,7 @@ Utf8String::Utf8String(Utf8String const &string) : m_data(string.m_data)
 }
 
 /**
- * Inits this string with a reference to the start of a char array.
+ * Initializes this string with a reference to the start of a char array.
  */
 Utf8String::Utf8String(const char *s) : m_data(nullptr)
 {
@@ -219,7 +219,7 @@ void Utf8String::Translate(Utf16String const &string)
 {
     Release_Buffer();
 
-#if defined BUILD_WITH_ICU // Use ICU convertors
+#if defined BUILD_WITH_ICU // Use ICU converters.
     int32_t length;
     UErrorCode error = U_ZERO_ERROR;
     u_strToUTF8(nullptr, 0, &length, string, -1, &error);
@@ -231,7 +231,7 @@ void Utf8String::Translate(Utf16String const &string)
             Clear();
         }
     }
-#elif defined PLATFORM_WINDOWS // Use WIN32 API convertors.
+#elif defined PLATFORM_WINDOWS // Use WIN32 API converters.
     int length = WideCharToMultiByte(CP_UTF8, 0, string, -1, nullptr, 0, nullptr, nullptr);
 
     if (length > 0) {
@@ -351,7 +351,7 @@ void Utf8String::Trim()
  */
 void Utf8String::To_Lower()
 {
-    // Size specifically matches original code for compatability
+    // Size specifically matches original code for compatibility.
     char buf[MAX_TO_LOWER_BUF_LEN];
 
     if (m_data == nullptr) {
@@ -624,12 +624,12 @@ bool Utf8String::Next_Token(Utf8String *tok, const char *delims)
 
 void Utf8String::Validate()
 {
-    // TODO, doesnt seem to be implimented anywhere? It is called though...
+    // TODO, does not seem to be implemented anywhere? It is called though...
 }
 
 #ifdef GAME_DEBUG
 void Utf8String::Debug_Ignore_Leaks()
 {
-    // TODO, doesnt seem to be implimented anywhere? It is called though...
+    // TODO, does not seem to be implemented anywhere? It is called though...
 }
 #endif // GAME_DEBUG

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -113,7 +113,8 @@ public:
     void Set(const char *s);
     void Set(Utf8String const &string);
 
-    void Translate(Utf16String const &stringSrc);
+    void Translate(Utf16String const &utf16_string);
+    void Translate(const unichar_t *utf16_string);
 
     // Concat should probably be private and += used as the preferred interface.
     void Concat(char c);
@@ -188,6 +189,8 @@ public:
 #endif
 
 private:
+    void Translate_Internal(const unichar_t *utf16_string, const int utf16_len);
+
     // Probably supposed to be private
     void Ensure_Unique_Buffer_Of_Size(
         int chars_needed, bool keep_data = false, const char *str_to_copy = nullptr, const char *str_to_cat = nullptr);

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -124,7 +124,7 @@ public:
     void Format(const char *format, ...);
     void Format(Utf8String format, ...);
 
-    // Compare funcs should probably be private and operators should be friends and the
+    // Compare functions should probably be private and operators should be friends and the.
     // preferred interface.
     int Compare(const char *s) const { return strcmp(Str(), s); }
     int Compare(Utf8String const &string) const { return strcmp(Str(), string.Str()); }

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -72,11 +72,9 @@ public:
 #endif
         }
 
-        char *Peek()
-        {
-            // Actual string data is stored immediately after the AsciiStringData header.
-            return reinterpret_cast<char *>(&this[1]);
-        }
+        // Actual string data is stored immediately after the AsciiStringData header.
+        const char *Peek() const { return reinterpret_cast<const char *>(&this[1]); }
+        char *Peek() { return reinterpret_cast<char *>(&this[1]); }
     };
 
     Utf8String();
@@ -97,13 +95,18 @@ public:
 
     operator const char *() const { return Str(); }
 
+    char operator[](int index) const { return Get_Char(index); }
+    char &operator[](int index) { return Get_Char(index); }
+
     void Validate();
-    char *Peek() const;
+    const char *Peek() const;
+    char *Peek();
     void Release_Buffer();
     int Get_Length() const;
 
     void Clear() { Release_Buffer(); }
     char Get_Char(int index) const;
+    char &Get_Char(int index);
     const char *Str() const;
     char *Get_Buffer_For_Read(int len);
     // These two should probably be private with the = operator being the preferred interface?

--- a/src/game/common/system/unicodestring.cpp
+++ b/src/game/common/system/unicodestring.cpp
@@ -212,62 +212,67 @@ void Utf16String::Set(Utf16String const &string)
     }
 }
 
-void Utf16String::Translate(Utf8String const &string)
+/**
+ * Converts a Utf8 string to Utf16
+ */
+void Utf16String::Translate_Internal(const char *utf8_string, const int utf8_len)
 {
     Release_Buffer();
 
-    int str_len = string.Get_Length();
+#if defined BUILD_WITH_ICU
+    // Use ICU converters.
+    if (utf8_len > 0) {
+        int32_t utf16_len;
+        UErrorCode error = U_ZERO_ERROR;
+        // Get utf16 string length.
+        u_strFromUTF8(nullptr, 0, &utf16_len, utf8_string, utf8_len, &error);
 
-    for (int i = 0; i < str_len; ++i) {
-        unichar_t c;
+        if (U_SUCCESS(error) && utf16_len > 0) {
+            // Allocate and fill new utf16 string.
+            unichar_t *utf16_buffer = Get_Buffer_For_Read(utf16_len);
+            u_strFromUTF8(utf16_buffer, utf16_len, nullptr, utf8_string, utf8_len, &error);
 
-        if (string.m_data != nullptr) {
-            c = string.Get_Char(i);
-        } else {
-            c = U_CHAR('\0');
-        }
-
-        Concat(c);
-    }
-}
-
-void Utf16String::Translate(const char *string)
-{
-    Release_Buffer();
-
-#if defined BUILD_WITH_ICU // Use ICU converters
-    int32_t length;
-    UErrorCode error = U_ZERO_ERROR;
-    u_strFromUTF8(nullptr, 0, &length, string, -1, &error);
-
-    if (U_SUCCESS(error) && length > 0) {
-        u_strFromUTF8(Get_Buffer_For_Read(length), length, nullptr, string, -1, &error);
-
-        if (U_FAILURE(error)) {
-            Clear();
+            if (U_FAILURE(error)) {
+                Clear();
+            } else {
+                // Add null terminator manually.
+                utf16_buffer[utf16_len] = U_CHAR('\0');
+            }
         }
     }
-#elif defined PLATFORM_WINDOWS // Use WIN32 API converters.
-    int length = MultiByteToWideChar(CP_UTF8, 0, string, -1, nullptr, 0);
+#elif defined PLATFORM_WINDOWS
+    // Use WIN32 API converters.
+    if (utf8_len > 0) {
+        // Get utf16 string length.
+        const int utf16_len = MultiByteToWideChar(CP_UTF8, 0, utf8_string, utf8_len, nullptr, 0);
 
-    if (length > 0) {
-        MultiByteToWideChar(CP_UTF8, 0, string, -1, Get_Buffer_For_Read(length), length);
-    }
-#else // Naive copy, this is what the original does.
-    size_t str_len = strlen(string);
+        if (utf16_len > 0) {
+            // Allocate and fill new utf16 string.
+            unichar_t *utf16_buffer = Get_Buffer_For_Read(utf16_len);
+            MultiByteToWideChar(CP_UTF8, 0, utf8_string, utf8_len, utf16_buffer, utf16_len);
 
-    for (size_t i = 0; i < str_len; ++i) {
-        unichar_t c;
-
-        if (string[i] != '\0') {
-            c = string[i];
-        } else {
-            c = U_CHAR('\0');
+            // Add null terminator manually.
+            utf16_buffer[utf16_len] = U_CHAR('\0');
         }
-
+    }
+#else
+    // Naive copy, this is what the original does.
+    for (int i = 0; i < utf8_len; ++i) {
+        unichar_t c = static_cast<unichar_t>(utf8_string[i]);
         Concat(c);
     }
 #endif
+}
+
+void Utf16String::Translate(Utf8String const &utf8_string)
+{
+    Translate_Internal(utf8_string.Str(), utf8_string.Get_Length());
+}
+
+void Utf16String::Translate(const char *utf8_string)
+{
+    int utf8_len = static_cast<int>(strlen(utf8_string));
+    Translate_Internal(utf8_string, utf8_len);
 }
 
 void Utf16String::Concat(unichar_t c)

--- a/src/game/common/system/unicodestring.cpp
+++ b/src/game/common/system/unicodestring.cpp
@@ -363,7 +363,7 @@ void Utf16String::Format(Utf16String format, ...)
 void Utf16String::Format_VA(const unichar_t *format, va_list args)
 {
     unichar_t buf[MAX_FORMAT_BUF_LEN];
-    int res = u_vsnprintf_u(buf, sizeof(buf), format, args);
+    int res = u_vsnprintf_u(buf, ARRAY_SIZE(buf), format, args);
     captainslog_relassert(res > 0, 0xDEAD0002, "Unable to format buffer.");
 
     Set(buf);
@@ -372,7 +372,7 @@ void Utf16String::Format_VA(const unichar_t *format, va_list args)
 void Utf16String::Format_VA(Utf16String &format, va_list args)
 {
     unichar_t buf[MAX_FORMAT_BUF_LEN];
-    int res = u_vsnprintf_u(buf, sizeof(buf), format.Str(), args);
+    int res = u_vsnprintf_u(buf, ARRAY_SIZE(buf), format.Str(), args);
     captainslog_relassert(res > 0, 0xDEAD0002, "Unable to format buffer");
 
     Set(buf);

--- a/src/game/common/system/unicodestring.cpp
+++ b/src/game/common/system/unicodestring.cpp
@@ -55,11 +55,17 @@ Utf16String::~Utf16String()
 
 void Utf16String::Validate() {}
 
-unichar_t *Utf16String::Peek() const
+const unichar_t *Utf16String::Peek() const
 {
     captainslog_dbgassert(m_data != nullptr, "null string ptr");
 
-    // Actual string data is stored immediately after the UnicodeStringData header.
+    return m_data->Peek();
+}
+
+unichar_t *Utf16String::Peek()
+{
+    captainslog_dbgassert(m_data != nullptr, "null string ptr");
+
     return m_data->Peek();
 }
 
@@ -141,11 +147,22 @@ void Utf16String::Clear()
 
 unichar_t Utf16String::Get_Char(int index) const
 {
-    if (m_data != nullptr) {
+    captainslog_dbgassert(index >= 0, "Index must be equal or larger than 0.");
+    captainslog_dbgassert(index < Get_Length(), "Index must be smaller than length.");
+
+    if (m_data != nullptr) { // #TODO Remove condition if possible; Utf8String does not have it
         return m_data->Peek()[index];
     }
 
     return U_CHAR('\0');
+}
+
+unichar_t &Utf16String::Get_Char(int index)
+{
+    captainslog_dbgassert(index >= 0, "Index must be equal or larger than 0.");
+    captainslog_dbgassert(index < Get_Length(), "Index must be smaller than length.");
+
+    return m_data->Peek()[index];
 }
 
 const unichar_t *Utf16String::Str() const

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -128,8 +128,8 @@ public:
     void Set(const unichar_t *s);
     void Set(Utf16String const &string);
 
-    void Translate(Utf8String const &string);
-    void Translate(const char *string);
+    void Translate(Utf8String const &utf8_string);
+    void Translate(const char *utf8_string);
 
     void Concat(unichar_t c);
     void Concat(const unichar_t *s);
@@ -183,6 +183,8 @@ public:
     static Utf16String const s_emptyString;
 
 private:
+    void Translate_Internal(const char *utf8_string, const int utf8_len);
+
     UnicodeStringData *m_data;
 };
 

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -155,10 +155,13 @@ public:
 
     bool Next_Token(Utf16String *tok, Utf16String delims);
 
-    bool Is_None() { return m_data != nullptr && u_strcasecmp(Peek(), U_CHAR("None"), U_COMPARE_CODE_POINT_ORDER) == 0; }
-    bool Is_Empty() { return Get_Length() <= 0; }
-    bool Is_Not_Empty() { return !Is_Empty(); }
-    bool Is_Not_None() { return !Is_None(); }
+    bool Is_None() const
+    {
+        return m_data != nullptr && u_strcasecmp(Peek(), U_CHAR("None"), U_COMPARE_CODE_POINT_ORDER) == 0;
+    }
+    bool Is_Empty() const { return Get_Length() <= 0; }
+    bool Is_Not_Empty() const { return !Is_Empty(); }
+    bool Is_Not_None() const { return !Is_None(); }
 
     friend bool operator==(Utf16String const &left, Utf16String const &right) { return left.Compare(right) == 0; }
     friend bool operator==(Utf16String const &left, const unichar_t *right) { return left.Compare(right) == 0; }

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -49,12 +49,10 @@ public:
         uint16_t ref_count;
         uint16_t num_chars_allocated;
 
-        unichar_t *Peek()
-        {
-            // Actual string data is stored immediately after the UnicodeStringData header.
-            // wchar_a to avoid strict aliasing issues on gcc/clang
-            return reinterpret_cast<unichar_a *>(&this[1]);
-        }
+        // Actual string data is stored immediately after the UnicodeStringData header.
+        // wchar_a to avoid strict aliasing issues on gcc/clang
+        const unichar_t *Peek() const { return reinterpret_cast<const unichar_a *>(&this[1]); }
+        unichar_t *Peek() { return reinterpret_cast<unichar_a *>(&this[1]); }
     };
 
     Utf16String() : m_data(nullptr) {}
@@ -110,11 +108,12 @@ public:
 
     operator const unichar_t *() const { return Str(); }
 
-    // TODO
-    // unichar_t *operator[](int index) const { return m_data->Peek()[index]; }
+    unichar_t operator[](int index) const { return Get_Char(index); }
+    unichar_t &operator[](int index) { return Get_Char(index); }
 
     void Validate();
-    unichar_t *Peek() const;
+    const unichar_t *Peek() const;
+    unichar_t *Peek();
     void Release_Buffer();
     void Ensure_Unique_Buffer_Of_Size(int chars_needed,
         bool keep_data = false,
@@ -122,7 +121,8 @@ public:
         const unichar_t *str_to_cat = nullptr);
     int Get_Length() const;
     void Clear();
-    unichar_t Get_Char(int) const;
+    unichar_t Get_Char(int index) const;
+    unichar_t &Get_Char(int index);
     const unichar_t *Str() const;
     unichar_t *Get_Buffer_For_Read(int len);
     void Set(const unichar_t *s);

--- a/src/hooker/setuphooks_zh.cpp
+++ b/src/hooker/setuphooks_zh.cpp
@@ -246,7 +246,7 @@ void Setup_Hooks()
     Hook_Method(0x00415980, &Utf8String::Starts_With_No_Case);
     Hook_Method(0x00404210, &Utf8String::Str);
     Hook_Method(0x00415630, &Utf8String::To_Lower);
-    Hook_Method(0x00415450, &Utf8String::Translate);
+    Hook_Method(0x00415450, static_cast<void (Utf8String::*)(Utf16String const &)>(&Utf8String::Translate));
     Hook_Method(0x00415530, &Utf8String::Trim);
 
     // Replace Win32GameEngine


### PR DESCRIPTION
I organized all changes in atomic commits, so its all clean. When merging, ideally don't squash it to preserve clean history. I was not able to test ICU, but I am confident the code is correct anyway.