### PR TITLE
Particle System Parse

### DIFF
--- a/src/game/client/system/particlesystem/particlesysmanager.cpp
+++ b/src/game/client/system/particlesystem/particlesysmanager.cpp
@@ -410,7 +410,7 @@ ParticleSystemID ParticleSystemManager::Create_Attached_Particle_System_ID(
 // zh: 0x005047E0 wb: 0x009B5160
 void ParticleSystemManager::Parse_Particle_System_Definition(INI *ini)
 {
-    auto particle_name = ini->Get_Next_Token();
+    auto *particle_name = ini->Get_Next_Token();
     auto *particle_template = g_theParticleSystemManager->Find_Template(particle_name);
     if (particle_template == nullptr) {
         particle_template = g_theParticleSystemManager->New_Template(particle_name);

--- a/src/game/client/system/particlesystem/particlesysmanager.cpp
+++ b/src/game/client/system/particlesystem/particlesysmanager.cpp
@@ -408,7 +408,8 @@ ParticleSystemID ParticleSystemManager::Create_Attached_Particle_System_ID(
 }
 
 // zh: 0x005047E0 wb: 0x009B5160
-void ParticleSystemManager::Parse_Particle_System_Definition(INI *ini) {
+void ParticleSystemManager::Parse_Particle_System_Definition(INI *ini)
+{
     auto particle_name = ini->Get_Next_Token();
     auto *particle_template = g_theParticleSystemManager->Find_Template(particle_name);
     if (particle_template == nullptr) {

--- a/src/game/client/system/particlesystem/particlesysmanager.cpp
+++ b/src/game/client/system/particlesystem/particlesysmanager.cpp
@@ -406,3 +406,14 @@ ParticleSystemID ParticleSystemManager::Create_Attached_Particle_System_ID(
     return PARTSYS_ID_NONE;
 #endif
 }
+
+// zh: 0x005047E0 wb: 0x009B5160
+void ParticleSystemManager::Parse_Particle_System_Definition(INI *ini) {
+    auto particle_name = ini->Get_Next_Token();
+    auto *particle_template = g_theParticleSystemManager->Find_Template(particle_name);
+    if (particle_template == nullptr) {
+        particle_template = g_theParticleSystemManager->New_Template(particle_name);
+    }
+
+    ini->Init_From_INI(particle_template, ParticleSystemTemplate::Get_Particle_System_Template_Field_Parse_Table());
+}

--- a/src/game/client/system/particlesystem/particlesysmanager.h
+++ b/src/game/client/system/particlesystem/particlesysmanager.h
@@ -33,6 +33,7 @@ class ParticleSystem;
 class ParticleSystemTemplate;
 class Object;
 class RenderInfoClass;
+class INI;
 
 #ifdef THYME_USE_STLPORT
 typedef std::hash_map<const Utf8String, ParticleSystemTemplate *, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
@@ -86,6 +87,7 @@ public:
 
     static ParticleSystemID Create_Attached_Particle_System_ID(
         const ParticleSystemTemplate *temp, Object *object, bool create_slaves);
+    static void Parse_Particle_System_Definition(INI *ini);
 
 private:
     Particle *m_allParticlesHead[PARTICLE_PRIORITY_COUNT];

--- a/src/game/client/system/particlesystem/particlesystemplate.cpp
+++ b/src/game/client/system/particlesystem/particlesystemplate.cpp
@@ -79,7 +79,7 @@ FieldParse ParticleSystemTemplate::s_fieldParseTable[] = {
      { "SlavePosOffset", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_slavePosOffset) },
      { "PerParticleAttachedSystem", &INI::Parse_AsciiString,  nullptr,  offsetof(ParticleSystemTemplate, m_attachedSystemName) },
      { "Lifetime", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_lifetime) },
-     { "SystemLifetime", &INI::Parse_Unsigned,  nullptr,  offsetof(ParticleSystemTemplate, m_systemLifetime) },
+     { "SystemLifetime", &INI::Parse_Unsigned_Int,  nullptr,  offsetof(ParticleSystemTemplate, m_systemLifetime) },
      { "Size", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_startSize) },
      { "StartSizeRate", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_startSizeRate) },
      { "SizeRate", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_sizeRate) },
@@ -173,7 +173,8 @@ void ParticleSystemTemplate::Parse(INI *ini, void *, void *store, const void *)
 
     auto *particle_template = g_theParticleSystemManager->Find_Template(template_name);
 
-    captainslog_dbgassert(particle_template != nullptr || template_name.Is_None(), "ParticleSystem %s not found!\n");
+    captainslog_dbgassert(
+        particle_template != nullptr || template_name.Is_None(), "ParticleSystem %s not found!\n", template_name.Str());
 
     *static_cast<ParticleSystemTemplate **>(store) = particle_template;
 }

--- a/src/game/client/system/particlesystem/particlesystemplate.cpp
+++ b/src/game/client/system/particlesystem/particlesystemplate.cpp
@@ -16,7 +16,7 @@
 #include "ini.h"
 #include "particlesysmanager.h"
 
-constexpr const char *_particleShaderTypeNames[] = {
+constexpr const char *ParticleShaderTypeNames[] = {
     "NONE",
     "ADDITIVE",
     "ALPHA",
@@ -25,7 +25,7 @@ constexpr const char *_particleShaderTypeNames[] = {
     nullptr,
 };
 
-constexpr const char *_particleTypeNames[] = {
+constexpr const char *ParticleTypeNames[] = {
     "NONE",
     "PARTICLE",
     "DRAWABLE",
@@ -35,7 +35,7 @@ constexpr const char *_particleTypeNames[] = {
     nullptr,
 };
 
-constexpr const char *_emissionVelocityTypeNames[] = {
+constexpr const char *EmissionVelocityTypeNames[] = {
     "NONE",
     "ORTHO",
     "SPHERICAL",
@@ -45,7 +45,7 @@ constexpr const char *_emissionVelocityTypeNames[] = {
     nullptr,
 };
 
-constexpr const char *_emssionVolumeTypeNames[] = {
+constexpr const char *EmssionVolumeTypeNames[] = {
     "NONE",
     "POINT",
     "LINE",
@@ -55,7 +55,7 @@ constexpr const char *_emssionVolumeTypeNames[] = {
     nullptr,
 };
 
-constexpr const char *_windMotionTypeNames[] = {
+constexpr const char *WindMotionTypeNames[] = {
     "NONE",
     "Unused",
     "PingPong",
@@ -67,8 +67,8 @@ constexpr const char *_windMotionTypeNames[] = {
 FieldParse ParticleSystemTemplate::s_fieldParseTable[] = {
      { "Priority", &INI::Parse_Index_List,  g_particlePriorityNames,  offsetof(ParticleSystemTemplate, m_priority) },
      { "IsOneShot", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isOneShot) },
-     { "Shader", &INI::Parse_Index_List,  _particleShaderTypeNames,  offsetof(ParticleSystemTemplate, m_shaderType) },
-     { "Type", &INI::Parse_Index_List,  _particleTypeNames,  offsetof(ParticleSystemTemplate, m_particleType) },
+     { "Shader", &INI::Parse_Index_List,  ParticleShaderTypeNames,  offsetof(ParticleSystemTemplate, m_shaderType) },
+     { "Type", &INI::Parse_Index_List,  ParticleTypeNames,  offsetof(ParticleSystemTemplate, m_particleType) },
      { "ParticleName", &INI::Parse_AsciiString,  nullptr,  offsetof(ParticleSystemTemplate, m_particleTypeName) },
      { "AngleZ", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angleZ) },
      { "AngularRateZ", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angularRateZ) },
@@ -105,7 +105,7 @@ FieldParse ParticleSystemTemplate::s_fieldParseTable[] = {
      { "BurstCount", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_burstCount) },
      { "InitialDelay", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_initialDelay) },
      { "DriftVelocity", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_driftVelocity) },
-     { "VelocityType", &INI::Parse_Index_List,  _emissionVelocityTypeNames,  offsetof(ParticleSystemTemplate, m_emissionVelocityType) },
+     { "VelocityType", &INI::Parse_Index_List,  EmissionVelocityTypeNames,  offsetof(ParticleSystemTemplate, m_emissionVelocityType) },
      { "VelOrthoX", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.ortho.x) },
      { "VelOrthoY", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.ortho.y) },
      { "VelOrthoZ", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.ortho.z) },
@@ -115,7 +115,7 @@ FieldParse ParticleSystemTemplate::s_fieldParseTable[] = {
      { "VelCylindricalNormal", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.cylindrical.normal) },
      { "VelOutward", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.outward.outward) },
      { "VelOutwardOther", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.outward.other) },
-     { "VolumeType", &INI::Parse_Index_List,  _emssionVolumeTypeNames,  offsetof(ParticleSystemTemplate, m_emissionVolumeType) },
+     { "VolumeType", &INI::Parse_Index_List,  EmssionVolumeTypeNames,  offsetof(ParticleSystemTemplate, m_emissionVolumeType) },
      { "VolLineStart", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.line.start) },
      { "VolLineEnd", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.line.end) },
      { "VolBoxHalfSize", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.box) },
@@ -126,7 +126,7 @@ FieldParse ParticleSystemTemplate::s_fieldParseTable[] = {
      { "IsGroundAligned", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isGroundAligned) },
      { "IsEmitAboveGroundOnly", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isEmitAboveGroundOnly) },
      { "IsParticleUpTowardsEmitter", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isParticleUpTowardsEmitter) },
-     { "WindMotion", &INI::Parse_Index_List,  _windMotionTypeNames,  offsetof(ParticleSystemTemplate, m_windMotion) },
+     { "WindMotion", &INI::Parse_Index_List,  WindMotionTypeNames,  offsetof(ParticleSystemTemplate, m_windMotion) },
      { "WindAngleChangeMin", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windAngleChangeMin) },
      { "WindAngleChangeMax", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windAngleChangeMax) },
      { "WindPingPongStartAngleMin", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windMotionStartAngleMin) },

--- a/src/game/client/system/particlesystem/particlesystemplate.cpp
+++ b/src/game/client/system/particlesystem/particlesystemplate.cpp
@@ -16,6 +16,127 @@
 #include "ini.h"
 #include "particlesysmanager.h"
 
+constexpr const char *_particleShaderTypeNames[] = {
+    "NONE",
+    "ADDITIVE",
+    "ALPHA",
+    "ALPHA_TEST",
+    "MULTIPLY",
+    nullptr,
+};
+
+constexpr const char *_particleTypeNames[] = {
+    "NONE",
+    "PARTICLE",
+    "DRAWABLE",
+    "STREAK",
+    "VOLUME_PARTICLE",
+    "SMUDGE",
+    nullptr,
+};
+
+constexpr const char *_emissionVelocityTypeNames[] = {
+    "NONE",
+    "ORTHO",
+    "SPHERICAL",
+    "HEMISPHERICAL",
+    "CYLINDRICAL",
+    "OUTWARD",
+    nullptr,
+};
+
+constexpr const char *_emssionVolumeTypeNames[] = {
+    "NONE",
+    "POINT",
+    "LINE",
+    "BOX",
+    "SPHERE",
+    "CYLINDER",
+    nullptr,
+};
+
+constexpr const char *_windMotionTypeNames[] = {
+    "NONE",
+    "Unused",
+    "PingPong",
+    "Circular",
+    nullptr,
+};
+
+// clang-format off
+FieldParse ParticleSystemTemplate::s_fieldParseTable[] = {
+     { "Priority", &INI::Parse_Index_List,  g_particlePriorityNames,  offsetof(ParticleSystemTemplate, m_priority) },
+     { "IsOneShot", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isOneShot) },
+     { "Shader", &INI::Parse_Index_List,  _particleShaderTypeNames,  offsetof(ParticleSystemTemplate, m_shaderType) },
+     { "Type", &INI::Parse_Index_List,  _particleTypeNames,  offsetof(ParticleSystemTemplate, m_particleType) },
+     { "ParticleName", &INI::Parse_AsciiString,  nullptr,  offsetof(ParticleSystemTemplate, m_particleTypeName) },
+     { "AngleZ", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angleZ) },
+     { "AngularRateZ", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angularRateZ) },
+     { "AngularDamping", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angularDamping) },
+     { "VelocityDamping", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_velDamping) },
+     { "Gravity", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_gravity) },
+     { "SlaveSystem", &INI::Parse_AsciiString,  nullptr,  offsetof(ParticleSystemTemplate, m_slaveSystemName) },
+     { "SlavePosOffset", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_slavePosOffset) },
+     { "PerParticleAttachedSystem", &INI::Parse_AsciiString,  nullptr,  offsetof(ParticleSystemTemplate, m_attachedSystemName) },
+     { "Lifetime", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_lifetime) },
+     { "SystemLifetime", &INI::Parse_Unsigned,  nullptr,  offsetof(ParticleSystemTemplate, m_systemLifetime) },
+     { "Size", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_startSize) },
+     { "StartSizeRate", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_startSizeRate) },
+     { "SizeRate", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_sizeRate) },
+     { "SizeRateDamping", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_sizeRateDamping) },
+     { "Alpha1", &ParticleSystemTemplate::Parse_Random_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_alphaKey[0]) },
+     { "Alpha2", &ParticleSystemTemplate::Parse_Random_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_alphaKey[1]) },
+     { "Alpha3", &ParticleSystemTemplate::Parse_Random_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_alphaKey[2]) },
+     { "Alpha4", &ParticleSystemTemplate::Parse_Random_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_alphaKey[3]) },
+     { "Alpha5", &ParticleSystemTemplate::Parse_Random_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_alphaKey[4]) },
+     { "Alpha6", &ParticleSystemTemplate::Parse_Random_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_alphaKey[5]) },
+     { "Alpha7", &ParticleSystemTemplate::Parse_Random_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_alphaKey[6]) },
+     { "Alpha8", &ParticleSystemTemplate::Parse_Random_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_alphaKey[7]) },
+     { "Color1", &ParticleSystemTemplate::Parse_RGB_Color_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_colorKey[0]) },
+     { "Color2", &ParticleSystemTemplate::Parse_RGB_Color_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_colorKey[1]) },
+     { "Color3", &ParticleSystemTemplate::Parse_RGB_Color_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_colorKey[2]) },
+     { "Color4", &ParticleSystemTemplate::Parse_RGB_Color_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_colorKey[3]) },
+     { "Color5", &ParticleSystemTemplate::Parse_RGB_Color_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_colorKey[4]) },
+     { "Color6", &ParticleSystemTemplate::Parse_RGB_Color_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_colorKey[5]) },
+     { "Color7", &ParticleSystemTemplate::Parse_RGB_Color_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_colorKey[6]) },
+     { "Color8", &ParticleSystemTemplate::Parse_RGB_Color_Keyframe,  nullptr,  offsetof(ParticleSystemTemplate, m_colorKey[7]) },
+     { "ColorScale", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_colorScale) },
+     { "BurstDelay", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_burstDelay) },
+     { "BurstCount", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_burstCount) },
+     { "InitialDelay", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_initialDelay) },
+     { "DriftVelocity", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_driftVelocity) },
+     { "VelocityType", &INI::Parse_Index_List,  _emissionVelocityTypeNames,  offsetof(ParticleSystemTemplate, m_emissionVelocityType) },
+     { "VelOrthoX", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.ortho.x) },
+     { "VelOrthoY", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.ortho.y) },
+     { "VelOrthoZ", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.ortho.z) },
+     { "VelSpherical", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.spherical) },
+     { "VelHemispherical", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.hemispherical) },
+     { "VelCylindricalRadial", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.cylindrical.radial) },
+     { "VelCylindricalNormal", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.cylindrical.normal) },
+     { "VelOutward", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.outward.outward) },
+     { "VelOutwardOther", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVelocity.outward.other) },
+     { "VolumeType", &INI::Parse_Index_List,  _emssionVolumeTypeNames,  offsetof(ParticleSystemTemplate, m_emissionVolumeType) },
+     { "VolLineStart", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.line.start) },
+     { "VolLineEnd", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.line.end) },
+     { "VolBoxHalfSize", &INI::Parse_Coord3D,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.box) },
+     { "VolSphereRadius", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.sphere) },
+     { "VolCylinderRadius", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.cylinder.radius) },
+     { "VolCylinderLength", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_emissionVolume.cylinder.length) },
+     { "IsHollow", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isEmissionVolumeHollow) },
+     { "IsGroundAligned", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isGroundAligned) },
+     { "IsEmitAboveGroundOnly", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isEmitAboveGroundOnly) },
+     { "IsParticleUpTowardsEmitter", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isParticleUpTowardsEmitter) },
+     { "WindMotion", &INI::Parse_Index_List,  _windMotionTypeNames,  offsetof(ParticleSystemTemplate, m_windMotion) },
+     { "WindAngleChangeMin", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windAngleChangeMin) },
+     { "WindAngleChangeMax", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windAngleChangeMax) },
+     { "WindPingPongStartAngleMin", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windMotionStartAngleMin) },
+     { "WindPingPongStartAngleMax", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windMotionStartAngleMax) },
+     { "WindPingPongEndAngleMin", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windMotionEndAngleMin) },
+     { "WindPingPongEndAngleMax", &INI::Parse_Real,  nullptr,  offsetof(ParticleSystemTemplate, m_windMotionEndAngleMax) },
+     { nullptr, nullptr,  nullptr,  0 },
+};
+// clang-format on
+
 /**
  * @brief Parses random keyframe data.
  *

--- a/src/game/client/system/particlesystem/particlesystemplate.cpp
+++ b/src/game/client/system/particlesystem/particlesystemplate.cpp
@@ -166,6 +166,18 @@ void ParticleSystemTemplate::Parse_RGB_Color_Keyframe(INI *ini, void *formal, vo
     INI::Parse_Int(ini, formal, &rkf->frame, user_data);
 }
 
+// zh: 0x0041CD00 wb: 0x007A3AE0
+void ParticleSystemTemplate::Parse(INI *ini, void *, void *store, const void *)
+{
+    Utf8String template_name = ini->Get_Next_Token();
+
+    auto *particle_template = g_theParticleSystemManager->Find_Template(template_name);
+
+    captainslog_dbgassert(particle_template != nullptr || template_name.Is_None(), "ParticleSystem %s not found!\n");
+
+    *static_cast<ParticleSystemTemplate **>(store) = particle_template;
+}
+
 /**
  * @brief Creates a new particle system from a slave template.
  */

--- a/src/game/client/system/particlesystem/particlesystemplate.cpp
+++ b/src/game/client/system/particlesystem/particlesystemplate.cpp
@@ -88,7 +88,15 @@ FieldParse ParticleSystemTemplate::s_fieldParseTable[] = {
      { "Shader", &INI::Parse_Index_List,  ParticleShaderTypeNames,  offsetof(ParticleSystemTemplate, m_shaderType) },
      { "Type", &INI::Parse_Index_List,  ParticleTypeNames,  offsetof(ParticleSystemTemplate, m_particleType) },
      { "ParticleName", &INI::Parse_AsciiString,  nullptr,  offsetof(ParticleSystemTemplate, m_particleTypeName) },
+#ifndef GAME_DLL
+     { "AngleX", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angleX) },
+     { "AngleY", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angleY) },
+#endif
      { "AngleZ", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angleZ) },
+#ifndef GAME_DLL
+     { "AngularRateX", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angularRateX) },
+     { "AngularRateY", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angularRateY) },
+#endif
      { "AngularRateZ", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angularRateZ) },
      { "AngularDamping", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_angularDamping) },
      { "VelocityDamping", &GameClientRandomVariable::Parse,  nullptr,  offsetof(ParticleSystemTemplate, m_velDamping) },

--- a/src/game/client/system/particlesystem/particlesystemplate.cpp
+++ b/src/game/client/system/particlesystem/particlesystemplate.cpp
@@ -16,6 +16,24 @@
 #include "ini.h"
 #include "particlesysmanager.h"
 
+constexpr const char *ParticlePriorityNames[PARTICLE_PRIORITY_COUNT + 1] = {
+    "NONE",
+    "WEAPON_EXPLOSION",
+    "SCORCHMARK",
+    "DUST_TRAIL",
+    "BUILDUP",
+    "DEBRIS_TRAIL",
+    "UNIT_DAMAGE_FX",
+    "DEATH_EXPLOSION",
+    "SEMI_CONSTANT",
+    "CONSTANT",
+    "WEAPON_TRAIL",
+    "AREA_EFFECT",
+    "CRITICAL",
+    "ALWAYS_RENDER",
+    nullptr,
+};
+
 constexpr const char *ParticleShaderTypeNames[] = {
     "NONE",
     "ADDITIVE",
@@ -65,7 +83,7 @@ constexpr const char *WindMotionTypeNames[] = {
 
 // clang-format off
 FieldParse ParticleSystemTemplate::s_fieldParseTable[] = {
-     { "Priority", &INI::Parse_Index_List,  g_particlePriorityNames,  offsetof(ParticleSystemTemplate, m_priority) },
+     { "Priority", &INI::Parse_Index_List,  ParticlePriorityNames,  offsetof(ParticleSystemTemplate, m_priority) },
      { "IsOneShot", &INI::Parse_Bool,  nullptr,  offsetof(ParticleSystemTemplate, m_isOneShot) },
      { "Shader", &INI::Parse_Index_List,  ParticleShaderTypeNames,  offsetof(ParticleSystemTemplate, m_shaderType) },
      { "Type", &INI::Parse_Index_List,  ParticleTypeNames,  offsetof(ParticleSystemTemplate, m_particleType) },

--- a/src/game/client/system/particlesystem/particlesystemplate.h
+++ b/src/game/client/system/particlesystem/particlesystemplate.h
@@ -21,6 +21,7 @@
 
 class INI;
 class ParticleSystem;
+struct FieldParse;
 
 class ParticleSystemTemplate : public MemoryPoolObject, public ParticleSystemInfo
 {
@@ -38,10 +39,14 @@ public:
 
     Utf8String Get_Name() const { return m_name; }
 
+    static FieldParse *Get_Particle_System_Template_Field_Parse_Table() { return s_fieldParseTable; }
+
 private:
     ParticleSystem *Create_Slave_System(bool create_slaves) const;
 
 private:
     Utf8String m_name;
     mutable ParticleSystemTemplate *m_slaveTemplate;
+
+    static FieldParse s_fieldParseTable[];
 };

--- a/src/game/client/system/particlesystem/particlesystemplate.h
+++ b/src/game/client/system/particlesystem/particlesystemplate.h
@@ -36,6 +36,7 @@ public:
 
     static void Parse_Random_Keyframe(INI *ini, void *formal, void *store, const void *user_data);
     static void Parse_RGB_Color_Keyframe(INI *ini, void *formal, void *store, const void *user_data);
+    static void Parse(INI *ini, void *, void *store, const void *);
 
     Utf8String Get_Name() const { return m_name; }
 

--- a/src/game/common/ini/ini.cpp
+++ b/src/game/common/ini/ini.cpp
@@ -30,6 +30,7 @@
 #include "globallanguage.h"
 #include "mouse.h"
 #include "objectcreationlist.h"
+#include "particlesysmanager.h"
 #include "playertemplate.h"
 #include "rankinfo.h"
 #include "science.h"
@@ -99,7 +100,7 @@ BlockParse TheTypeTable[] = {
     {"Object", (iniblockparse_t)(0x005048E0) /*&INI::parseObjectDefinition*/},
     {"ObjectCreationList", &ObjectCreationListStore::Parse_Object_Creation_List_Definition },
     {"ObjectReskin", (iniblockparse_t)(0x00504990) /*&INI::parseObjectReskinDefinition*/},
-    {"ParticleSystem", (iniblockparse_t)(0x005047E0) /*&INI::parseParticleSystemDefinition*/},
+    {"ParticleSystem", &ParticleSystemManager::Parse_Particle_System_Definition},
     //{ "PlayerTemplate", (iniblockparse_t)(0x004D3DC0)/*&INI::parsePlayerTemplateDefinition*/ },
     {"PlayerTemplate", &PlayerTemplateStore::Parse_Player_Template_Definition},
     {"Road", &TerrainRoadCollection::Parse_Terrain_Road_Definition},

--- a/src/game/common/randomvalue.cpp
+++ b/src/game/common/randomvalue.cpp
@@ -15,6 +15,7 @@
 #include "randomvalue.h"
 #include "crc.h"
 #include "gamemath.h"
+#include "ini.h"
 #include <captainslog.h>
 #include <ctime>
 
@@ -231,4 +232,25 @@ float GameClientRandomVariable::Get_Value() const
     }
 
     return 0.0f;
+}
+
+constexpr const char *_distributionTypeNames[] = {
+    "CONSTANT",
+    "UNIFORM",
+    // Additional types have not been included as they are not usable
+    nullptr,
+};
+
+// zh: 0x0041D9F0 wb: 0x007A4B4C
+void GameClientRandomVariable::Parse(INI *ini, void *, void *store, const void *)
+{
+    const auto min = ini->Scan_Real(ini->Get_Next_Token());
+    const auto max = ini->Scan_Real(ini->Get_Next_Token());
+
+    DistributionType type = DistributionType::UNIFORM;
+    auto *token = ini->Get_Next_Token_Or_Null();
+    if (token != nullptr) {
+        type = static_cast<DistributionType>(ini->Scan_IndexList(token, _distributionTypeNames));
+    }
+    static_cast<GameClientRandomVariable *>(store)->Set_Range(min, max, type);
 }

--- a/src/game/common/randomvalue.cpp
+++ b/src/game/common/randomvalue.cpp
@@ -234,7 +234,7 @@ float GameClientRandomVariable::Get_Value() const
     return 0.0f;
 }
 
-constexpr const char *_distributionTypeNames[] = {
+constexpr const char *DistributionTypeNames[] = {
     "CONSTANT",
     "UNIFORM",
     // Additional types have not been included as they are not usable
@@ -250,7 +250,7 @@ void GameClientRandomVariable::Parse(INI *ini, void *, void *store, const void *
     DistributionType type = DistributionType::UNIFORM;
     auto *token = ini->Get_Next_Token_Or_Null();
     if (token != nullptr) {
-        type = static_cast<DistributionType>(ini->Scan_IndexList(token, _distributionTypeNames));
+        type = static_cast<DistributionType>(ini->Scan_IndexList(token, DistributionTypeNames));
     }
     static_cast<GameClientRandomVariable *>(store)->Set_Range(min, max, type);
 }

--- a/src/game/common/randomvalue.h
+++ b/src/game/common/randomvalue.h
@@ -16,6 +16,8 @@
 
 #include "bittype.h"
 
+class INI;
+
 void Init_Random();
 void Init_Random(uint32_t initial);
 void Init_Game_Logic_Random(uint32_t initial);
@@ -71,6 +73,8 @@ public:
     float Get_Min() const { return m_low; }
     float Get_Max() const { return m_high; }
     DistributionType Get_Type() const { return m_type; }
+
+    static void Parse(INI *ini, void *, void *store, const void *);
 
 private:
     DistributionType m_type;

--- a/src/game/common/system/gametype.cpp
+++ b/src/game/common/system/gametype.cpp
@@ -103,21 +103,3 @@ const char *g_veterancyNames[VETERANCY_COUNT + 1] = {
     "HEROIC",
     nullptr,
 };
-
-const char *g_particlePriorityNames[PARTICLE_PRIORITY_COUNT + 1] = {
-    "NONE",
-    "WEAPON_EXPLOSION",
-    "SCORCHMARK",
-    "DUST_TRAIL",
-    "BUILDUP",
-    "DEBRIS_TRAIL",
-    "UNIT_DAMAGE_FX",
-    "DEATH_EXPLOSION",
-    "SEMI_CONSTANT",
-    "CONSTANT",
-    "WEAPON_TRAIL",
-    "AREA_EFFECT",
-    "CRITICAL",
-    "ALWAYS_RENDER",
-    nullptr,
-};

--- a/src/game/common/system/gametype.h
+++ b/src/game/common/system/gametype.h
@@ -238,4 +238,3 @@ extern const char *g_shakeIntensityNames[SHAKE_COUNT + 1];
 extern const char *g_weaponSlotNames[WEAPONSLOT_COUNT + 1];
 extern const char *g_commandSourceMaskNames[COMMANDSOURCE_COUNT + 1];
 extern const char *g_veterancyNames[VETERANCY_COUNT + 1];
-extern const char *g_particlePriorityNames[PARTICLE_PRIORITY_COUNT + 1];


### PR DESCRIPTION
Implements the main ParticleSystem::Parse_Particle_System_Definition and also ParticleSystemTemplate::Parse (this second one is not hooked so it is not actually in use atm)