### PR TITLE
Add trailing commas (as per style guide) to improve readability

### DIFF
--- a/src/game/common/bitflags.cpp
+++ b/src/game/common/bitflags.cpp
@@ -16,7 +16,8 @@
 
 // TODO move this somewhere more appropriate?
 template<>
-const char *BitFlags<OBJECT_STATUS_COUNT>::s_bitNamesList[] = { "NONE",
+const char *BitFlags<OBJECT_STATUS_COUNT>::s_bitNamesList[] = {
+    "NONE",
     "DESTROYED",
     "CAN_ATTACK",
     "UNDER_CONSTRUCTION",
@@ -61,10 +62,12 @@ const char *BitFlags<OBJECT_STATUS_COUNT>::s_bitNamesList[] = { "NONE",
     "IMMOBILE",
     "DISGUISED",
     "DEPLOYED",
-    nullptr };
+    nullptr,
+};
 
 template<>
-const char *BitFlags<DISABLED_TYPE_COUNT>::s_bitNamesList[] = { "DEFAULT",
+const char *BitFlags<DISABLED_TYPE_COUNT>::s_bitNamesList[] = {
+    "DEFAULT",
     "DISABLED_HACKED",
     "DISABLED_EMP",
     "DISABLED_HELD",
@@ -77,7 +80,8 @@ const char *BitFlags<DISABLED_TYPE_COUNT>::s_bitNamesList[] = { "DEFAULT",
     "DISABLED_SUBDUED",
     "DISABLED_SCRIPT_DISABLED",
     "DISABLED_SCRIPT_UNDERPOWERED",
-    nullptr };
+    nullptr,
+};
 
 // TODO Temp to force instantiation. Fixes issue with Parameter::Read_Parameter.
 // template class BitFlags<KIND_OF_COUNT>;

--- a/src/game/common/system/gametype.cpp
+++ b/src/game/common/system/gametype.cpp
@@ -14,34 +14,98 @@
  */
 #include "gametype.h"
 
-const char *g_timeOfDayNames[TIME_OF_DAY_COUNT + 1] = { "NONE", "MORNING", "AFTERNOON", "EVENING", "NIGHT", nullptr };
+const char *g_timeOfDayNames[TIME_OF_DAY_COUNT + 1] = {
+    "NONE",
+    "MORNING",
+    "AFTERNOON",
+    "EVENING",
+    "NIGHT",
+    nullptr,
+};
 
-const char *g_weatherNames[WEATHER_COUNT + 1]{ "NORMAL", "SNOWY", nullptr };
-const char *g_bodyDamageNames[BODY_COUNT + 1] = { "PRISTINE", "DAMAGED", "REALLYDAMAGED", "RUBBLE", nullptr };
+const char *g_weatherNames[WEATHER_COUNT + 1]{
+    "NORMAL",
+    "SNOWY",
+    nullptr,
+};
+const char *g_bodyDamageNames[BODY_COUNT + 1] = {
+    "PRISTINE",
+    "DAMAGED",
+    "REALLYDAMAGED",
+    "RUBBLE",
+    nullptr,
+};
 
 const char *g_speakerTypes[SPEAKERS_COUNT + 1] = {
-    "2 Speakers", "Headphones", "Surround Sound", "4 Speaker", "5.1 Surround", "7.1 Surround", nullptr
+    "2 Speakers",
+    "Headphones",
+    "Surround Sound",
+    "4 Speaker",
+    "5.1 Surround",
+    "7.1 Surround",
+    nullptr,
 };
 
-const char *g_audioPriorityNames[PRIORITY_COUNT + 1] = { "LOWEST", "LOW", "NORMAL", "HIGH", "CRITICAL", nullptr };
+const char *g_audioPriorityNames[PRIORITY_COUNT + 1] = {
+    "LOWEST",
+    "LOW",
+    "NORMAL",
+    "HIGH",
+    "CRITICAL",
+    nullptr,
+};
 
-const char *g_buildableStatusNames[BSTATUS_COUNT + 1] = { "Yes", "Ignore_Prerequisites", "No", "Only_By_AI", nullptr };
+const char *g_buildableStatusNames[BSTATUS_COUNT + 1] = {
+    "Yes",
+    "Ignore_Prerequisites",
+    "No",
+    "Only_By_AI",
+    nullptr,
+};
 
-const char *g_surfaceNames[SURFACE_COUNT + 1] = { "Ground", "Air", "Ground or Air", nullptr };
+const char *g_surfaceNames[SURFACE_COUNT + 1] = {
+    "Ground",
+    "Air",
+    "Ground or Air",
+    nullptr,
+};
 
 const char *g_shakeIntensityNames[SHAKE_COUNT + 1] = {
-    "Subtle", "Normal", "Strong", "Severe", "Cine_Extreme", "Cine_Insane", nullptr
+    "Subtle",
+    "Normal",
+    "Strong",
+    "Severe",
+    "Cine_Extreme",
+    "Cine_Insane",
+    nullptr,
 };
 
-const char *g_weaponSlotNames[WEAPONSLOT_COUNT + 1] = { "PRIMARY", "SECONDARY", "TERTIARY", nullptr };
+const char *g_weaponSlotNames[WEAPONSLOT_COUNT + 1] = {
+    "PRIMARY",
+    "SECONDARY",
+    "TERTIARY",
+    nullptr,
+};
 
 const char *g_commandSourceMaskNames[COMMANDSOURCE_COUNT + 1] = {
-    "FROM_PLAYER", "FROM_SCRIPT", "FROM_AI", "FROM_DOZER", "DEFAULT_SWITCH_WEAPON", nullptr
+    "FROM_PLAYER",
+    "FROM_SCRIPT",
+    "FROM_AI",
+    "FROM_DOZER",
+    "DEFAULT_SWITCH_WEAPON",
+    nullptr,
 };
 
-const char *g_veterancyNames[VETERANCY_COUNT + 1] = { "REGULAR", "VETERAN", "ELITE", "HEROIC", nullptr };
+const char *g_veterancyNames[VETERANCY_COUNT + 1] = {
+    "REGULAR",
+    "VETERAN",
+    "ELITE",
+    "HEROIC",
+    nullptr,
+};
 
-const char *g_particlePriorityNames[PARTICLE_PRIORITY_COUNT + 1] = { "NONE",
+const char *g_particlePriorityNames[PARTICLE_PRIORITY_COUNT + 1] = {
+    "NONE",
     "WEAPON_EXPLOSION",
     "SCORCHMARK",
     "DUST_TRAIL",
@@ -55,4 +119,5 @@ const char *g_particlePriorityNames[PARTICLE_PRIORITY_COUNT + 1] = { "NONE",
     "AREA_EFFECT",
     "CRITICAL",
     "ALWAYS_RENDER",
-    nullptr };
+    nullptr,
+};

--- a/src/game/logic/object/weapon.cpp
+++ b/src/game/logic/object/weapon.cpp
@@ -15,7 +15,8 @@
 #include "weapon.h"
 #include "ini.h"
 
-const char *TheWeaponBonusNames[] = { "GARRISONED",
+const char *TheWeaponBonusNames[] = {
+    "GARRISONED",
     "HORDE",
     "CONTINUOUS_FIRE_MEAN",
     "CONTINUOUS_FIRE_FAST",
@@ -42,9 +43,17 @@ const char *TheWeaponBonusNames[] = { "GARRISONED",
     "FRENZY_ONE",
     "FRENZY_TWO",
     "FRENZY_THREE",
-    nullptr };
+    nullptr,
+};
 
-const char *TheWeaponBonusFieldNames[] = { "DAMAGE", "RADIUS", "RANGE", "RATE_OF_FIRE", "PRE_ATTACK", nullptr };
+const char *TheWeaponBonusFieldNames[] = {
+    "DAMAGE",
+    "RADIUS",
+    "RANGE",
+    "RATE_OF_FIRE",
+    "PRE_ATTACK",
+    nullptr,
+};
 
 void WeaponBonusSet::Parse_Weapon_Bonus_Set_Ptr(INI *ini, void *formal, void *store, void const *user_data)
 {


### PR DESCRIPTION
When implementing a couple of the parse functions I kept not seeing the first item on a list as it would be inline with the name confusing me as to if a list was identical. This makes it much clearer and follows the style guide

```
Leave a trailing ',' in an enum to make it easier for anyone wanting to expand it.
```
Okay these aren't enums but the same reasoning should be applied to the enum's name arrays.