### PR TITLE
Add support for sized enum operators

### DIFF
--- a/deps/baseconfig/src/always.h
+++ b/deps/baseconfig/src/always.h
@@ -25,11 +25,12 @@
 #include "macros.h"
 #include "platform.h"
 #include "stringex.h"
+#include "typeoperators.h"
 #include "unichar.h"
 
 #ifdef PLATFORM_WINDOWS
-#include <windef.h>
 #include "utf.h"
+#include <windef.h>
 #define NAME_MAX FILENAME_MAX
 
 #ifndef PATH_MAX
@@ -92,18 +93,16 @@ template<size_t Size> size_t u_strlcpy_tpl(unichar_t (&dst)[Size], const unichar
 
 namespace std
 {
-    template<class T, class Compare>
-    constexpr const T &clamp(const T &v, const T &lo, const T &hi, Compare comp)
-    {
-        return comp(v, lo) ? lo : comp(hi, v) ? hi : v;
-    }
-
-    template<class T>
-    constexpr const T &clamp(const T &v, const T &lo, const T &hi)
-    {
-        return clamp(v, lo, hi, std::less<T>());
-    }
+template<class T, class Compare> constexpr const T &clamp(const T &v, const T &lo, const T &hi, Compare comp)
+{
+    return comp(v, lo) ? lo : comp(hi, v) ? hi : v;
 }
+
+template<class T> constexpr const T &clamp(const T &v, const T &lo, const T &hi)
+{
+    return clamp(v, lo, hi, std::less<T>());
+}
+} // namespace std
 #endif
 
 #endif // BASE_ALWAYS_H

--- a/deps/baseconfig/src/macros.h
+++ b/deps/baseconfig/src/macros.h
@@ -20,7 +20,7 @@
 #ifndef STRINGIZE
 #define STRINGIZE_HELPER(str) #str
 #define STRINGIZE(str) STRINGIZE_HELPER(str)
-#define STRINGIZE_JOIN(str1, str2) STRINGIZE_HELPER(str1 ## str2)
+#define STRINGIZE_JOIN(str1, str2) STRINGIZE_HELPER(str1##str2)
 #endif // STRINGIZE
 
 // Define some C++ keywords when standard is less than C++11, mainly for watcom support
@@ -33,7 +33,7 @@
 #define noexcept
 #endif
 
-// These allow evaluation of compiler specific attributes and intrinics on GCC like compilers.
+// These allow evaluation of compiler specific attributes and intrinsics on GCC like compilers.
 // If they don't exist we want them to evaluate to false.
 #ifndef __has_attribute
 #define __has_attribute(x) 0
@@ -175,116 +175,5 @@
 #ifndef SIZE_OF
 #define SIZE_OF(typ, id) sizeof(((typ *)0)->id)
 #endif // !SIZE_OF
-
-/**
- * Defines operator overloads to enable bit operations on enum values, useful for
- * using an enum to define flags for a bitfield.
- *
- * Example usage:
- *  enum MyEnum {
- *      ENUM_A = 0,
- *      ENUM_B = 1,
- *      ENUM_C = 2,
- *  };
- *
- *  DEFINE_ENUMERATION_BITWISE_OPERATORS(MyEnum);
- */
-#ifdef __cplusplus
-#if !defined(DEFINE_ENUMERATION_BITWISE_OPERATORS)
-#define DEFINE_ENUMERATION_BITWISE_OPERATORS(ENUMTYPE) \
-    extern "C++" { \
-    __forceinline constexpr ENUMTYPE operator|(ENUMTYPE const a, ENUMTYPE const b) \
-    { \
-        return ENUMTYPE(((int)a) | ((int)b)); \
-    } \
-    __forceinline constexpr ENUMTYPE operator&(ENUMTYPE const a, ENUMTYPE const b) \
-    { \
-        return ENUMTYPE(((int)a) & ((int)b)); \
-    } \
-    __forceinline constexpr ENUMTYPE operator~(ENUMTYPE const a) { return ENUMTYPE(~((int)a)); } \
-    __forceinline constexpr ENUMTYPE operator^(ENUMTYPE const a, ENUMTYPE const b) \
-    { \
-        return ENUMTYPE(((int)a) ^ ((int)b)); \
-    } \
-    __forceinline ENUMTYPE &operator^=(ENUMTYPE &a, ENUMTYPE const &b) { return (ENUMTYPE &)(((int &)a) ^= ((int &)b)); } \
-    __forceinline ENUMTYPE &operator&=(ENUMTYPE &a, ENUMTYPE const &b) { return (ENUMTYPE &)(((int &)a) &= ((int &)b)); } \
-    __forceinline ENUMTYPE &operator|=(ENUMTYPE &a, ENUMTYPE const &b) { return (ENUMTYPE &)(((int &)a) |= ((int &)b)); } \
-    __forceinline constexpr ENUMTYPE operator<<(ENUMTYPE a, int const b) { return (ENUMTYPE)(((int)a) << ((int)b)); } \
-    __forceinline constexpr ENUMTYPE operator>>(ENUMTYPE a, int const b) { return (ENUMTYPE)(((int)a) >> ((int)b)); } \
-    __forceinline ENUMTYPE &operator<<=(ENUMTYPE &a, int const b) \
-    { \
-        return (ENUMTYPE &)((int &)a = ((int &)a) << ((int)b)); \
-    } \
-    __forceinline ENUMTYPE &operator>>=(ENUMTYPE &a, int const b) \
-    { \
-        return (ENUMTYPE &)((int &)a = ((int &)a) >> ((int)b)); \
-    } \
-    }
-#endif // !DEFINE_ENUMERATION_BITWISE_OPERATORS
-#else
-#define DEFINE_ENUMERATION_BITWISE_OPERATORS(ENUMTYPE) // NOP, C allows these operators.
-#endif // __cplusplus
-
-/**
- * Defines operator overloads to enable stadard math operations on an enum.
- * Useful when an enum represents a range that can be iterated over.
- *
- * Example usage:
- *  enum MyEnum {
- *      ENUM_A = 0,
- *      ENUM_B = 1,
- *      ENUM_C = 2,
- *  };
- *
- *  DEFINE_ENUMERATION_OPERATORS(MyEnum);
- */
-#ifdef __cplusplus
-#if !defined(DEFINE_ENUMERATION_OPERATORS)
-#define DEFINE_ENUMERATION_OPERATORS(ENUMTYPE) \
-    extern "C++" { \
-    __forceinline ENUMTYPE operator++(ENUMTYPE const &a) { return (ENUMTYPE)(++((int &)a)); } \
-    __forceinline ENUMTYPE operator--(ENUMTYPE const &a) { return (ENUMTYPE)(--((int &)a)); } \
-    __forceinline constexpr ENUMTYPE operator+(ENUMTYPE const a, ENUMTYPE const b) \
-    { \
-        return (ENUMTYPE)(((int)a) + ((int)b)); \
-    } \
-    __forceinline constexpr ENUMTYPE operator-(ENUMTYPE const a, ENUMTYPE const b) \
-    { \
-        return (ENUMTYPE)(((int)a) - ((int)b)); \
-    } \
-    __forceinline constexpr ENUMTYPE operator*(ENUMTYPE const a, ENUMTYPE const b) \
-    { \
-        return (ENUMTYPE)(((int)a) * ((int)b)); \
-    } \
-    __forceinline constexpr ENUMTYPE operator/(ENUMTYPE const a, ENUMTYPE const b) \
-    { \
-        return (ENUMTYPE)(((int)a) / ((int)b)); \
-    } \
-    __forceinline constexpr ENUMTYPE operator%(ENUMTYPE const a, ENUMTYPE const b) \
-    { \
-        return (ENUMTYPE)(((int)a) % ((int)b)); \
-    } \
-    __forceinline ENUMTYPE &operator+=(ENUMTYPE &a, ENUMTYPE const b) \
-    { \
-        return (ENUMTYPE &)((int &)a = ((int &)a) + ((ENUMTYPE)b)); \
-    } \
-    __forceinline ENUMTYPE &operator-=(ENUMTYPE &a, ENUMTYPE const b) \
-    { \
-        return (ENUMTYPE &)((int &)a = ((int &)a) - ((ENUMTYPE)b)); \
-    } \
-    __forceinline ENUMTYPE operator++(ENUMTYPE const &a, int const b) { return (ENUMTYPE)(++((int &)a)); } \
-    __forceinline ENUMTYPE operator--(ENUMTYPE const &a, int const b) { return (ENUMTYPE)(--((int &)a)); } \
-    __forceinline constexpr ENUMTYPE operator+(ENUMTYPE const a, int const b) { return (ENUMTYPE)(((int)a) + ((int)b)); } \
-    __forceinline constexpr ENUMTYPE operator-(ENUMTYPE const a, int const b) { return (ENUMTYPE)(((int)a) - ((int)b)); } \
-    __forceinline constexpr ENUMTYPE operator*(ENUMTYPE const a, int const b) { return (ENUMTYPE)(((int)a) * ((int)b)); } \
-    __forceinline constexpr ENUMTYPE operator/(ENUMTYPE const a, int const b) { return (ENUMTYPE)(((int)a) / ((int)b)); } \
-    __forceinline constexpr ENUMTYPE operator%(ENUMTYPE const a, int const b) { return (ENUMTYPE)(((int)a) % ((int)b)); } \
-    __forceinline ENUMTYPE &operator+=(ENUMTYPE &a, int const b) { return (ENUMTYPE &)((int &)a = ((int &)a) + ((int)b)); } \
-    __forceinline ENUMTYPE &operator-=(ENUMTYPE &a, int const b) { return (ENUMTYPE &)((int &)a = ((int &)a) - ((int)b)); } \
-    }
-#endif // !DEFINE_ENUMERATION_OPERATORS
-#else
-#define DEFINE_ENUMERATION_OPERATORS(ENUMTYPE) // NOP, C allows these operators.
-#endif // __cplusplus
 
 #endif // BASE_MACROS_H

--- a/deps/baseconfig/src/typeoperators.h
+++ b/deps/baseconfig/src/typeoperators.h
@@ -1,0 +1,101 @@
+/**
+ * @file
+ *
+ * @author CCHyper
+ * @author OmniBlade
+ * @author xezon
+ *
+ * @brief Basic header files and defines that are always needed.
+ *
+ * @copyright BaseConfig is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#ifndef BASE_TYPEOPERATORS_H
+#define BASE_TYPEOPERATORS_H
+
+#include "typesize.h"
+
+/**
+ * Defines operator overloads to enable bit operations on enum values, useful for
+ * using an enum to define flags for a bitfield.
+ *
+ * Example usage:
+ *  enum MyEnum {
+ *      ENUM_A = 0,
+ *      ENUM_B = 1,
+ *      ENUM_C = 2,
+ *  };
+ *
+ *  DEFINE_ENUMERATION_BITWISE_OPERATORS(MyEnum);
+ */
+#ifdef __cplusplus
+#if !defined(DEFINE_ENUMERATION_BITWISE_OPERATORS)
+// clang-format off
+#define DEFINE_ENUMERATION_BITWISE_OPERATORS(ENUMTYPE) \
+extern "C++" { \
+__forceinline constexpr ENUMTYPE operator|(ENUMTYPE const a, ENUMTYPE const b) { return ENUMTYPE(((SizedInteger<ENUMTYPE>::type)a) | ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator&(ENUMTYPE const a, ENUMTYPE const b) { return ENUMTYPE(((SizedInteger<ENUMTYPE>::type)a) & ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator~(ENUMTYPE const a) { return ENUMTYPE(~((SizedInteger<ENUMTYPE>::type)a)); } \
+__forceinline constexpr ENUMTYPE operator^(ENUMTYPE const a, ENUMTYPE const b) { return ENUMTYPE(((SizedInteger<ENUMTYPE>::type)a) ^ ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline ENUMTYPE &operator^=(ENUMTYPE &a, ENUMTYPE const &b) { return (ENUMTYPE &)(((SizedInteger<ENUMTYPE>::type &)a) ^= ((SizedInteger<ENUMTYPE>::type &)b)); } \
+__forceinline ENUMTYPE &operator&=(ENUMTYPE &a, ENUMTYPE const &b) { return (ENUMTYPE &)(((SizedInteger<ENUMTYPE>::type &)a) &= ((SizedInteger<ENUMTYPE>::type &)b)); } \
+__forceinline ENUMTYPE &operator|=(ENUMTYPE &a, ENUMTYPE const &b) { return (ENUMTYPE &)(((SizedInteger<ENUMTYPE>::type &)a) |= ((SizedInteger<ENUMTYPE>::type &)b)); } \
+__forceinline constexpr ENUMTYPE operator<<(ENUMTYPE a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) << ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator>>(ENUMTYPE a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) >> ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline ENUMTYPE &operator<<=(ENUMTYPE &a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE &)((SizedInteger<ENUMTYPE>::type &)a = ((SizedInteger<ENUMTYPE>::type &)a) << ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline ENUMTYPE &operator>>=(ENUMTYPE &a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE &)((SizedInteger<ENUMTYPE>::type &)a = ((SizedInteger<ENUMTYPE>::type &)a) >> ((SizedInteger<ENUMTYPE>::type)b)); } \
+}
+// clang-format on
+#endif // !DEFINE_ENUMERATION_BITWISE_OPERATORS
+#else
+#define DEFINE_ENUMERATION_BITWISE_OPERATORS(ENUMTYPE) // NOP, C allows these operators.
+#endif // __cplusplus
+
+/**
+ * Defines operator overloads to enable standard math operations on an enum.
+ * Useful when an enum represents a range that can be iterated over.
+ *
+ * Example usage:
+ *  enum MyEnum {
+ *      ENUM_A = 0,
+ *      ENUM_B = 1,
+ *      ENUM_C = 2,
+ *  };
+ *
+ *  DEFINE_ENUMERATION_OPERATORS(MyEnum);
+ */
+#ifdef __cplusplus
+#if !defined(DEFINE_ENUMERATION_OPERATORS)
+// clang-format off
+#define DEFINE_ENUMERATION_OPERATORS(ENUMTYPE) \
+extern "C++" { \
+__forceinline ENUMTYPE operator++(ENUMTYPE const &a) { return (ENUMTYPE)(++((SizedInteger<ENUMTYPE>::type &)a)); } \
+__forceinline ENUMTYPE operator--(ENUMTYPE const &a) { return (ENUMTYPE)(--((SizedInteger<ENUMTYPE>::type &)a)); } \
+__forceinline constexpr ENUMTYPE operator+(ENUMTYPE const a, ENUMTYPE const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) + ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator-(ENUMTYPE const a, ENUMTYPE const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) - ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator*(ENUMTYPE const a, ENUMTYPE const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) * ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator/(ENUMTYPE const a, ENUMTYPE const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) / ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator%(ENUMTYPE const a, ENUMTYPE const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) % ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline ENUMTYPE &operator+=(ENUMTYPE &a, ENUMTYPE const b) { return (ENUMTYPE &)((SizedInteger<ENUMTYPE>::type &)a = ((SizedInteger<ENUMTYPE>::type &)a) + ((ENUMTYPE)b)); } \
+__forceinline ENUMTYPE &operator-=(ENUMTYPE &a, ENUMTYPE const b) { return (ENUMTYPE &)((SizedInteger<ENUMTYPE>::type &)a = ((SizedInteger<ENUMTYPE>::type &)a) - ((ENUMTYPE)b)); } \
+__forceinline ENUMTYPE operator++(ENUMTYPE const &a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(++((SizedInteger<ENUMTYPE>::type &)a)); } \
+__forceinline ENUMTYPE operator--(ENUMTYPE const &a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(--((SizedInteger<ENUMTYPE>::type &)a)); } \
+__forceinline constexpr ENUMTYPE operator+(ENUMTYPE const a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) + ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator-(ENUMTYPE const a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) - ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator*(ENUMTYPE const a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) * ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator/(ENUMTYPE const a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) / ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline constexpr ENUMTYPE operator%(ENUMTYPE const a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE)(((SizedInteger<ENUMTYPE>::type)a) % ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline ENUMTYPE &operator+=(ENUMTYPE &a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE &)((SizedInteger<ENUMTYPE>::type &)a = ((SizedInteger<ENUMTYPE>::type &)a) + ((SizedInteger<ENUMTYPE>::type)b)); } \
+__forceinline ENUMTYPE &operator-=(ENUMTYPE &a, SizedInteger<ENUMTYPE>::type const b) { return (ENUMTYPE &)((SizedInteger<ENUMTYPE>::type &)a = ((SizedInteger<ENUMTYPE>::type &)a) - ((SizedInteger<ENUMTYPE>::type)b)); } \
+}
+// clang-format on
+#endif // !DEFINE_ENUMERATION_OPERATORS
+#else
+#define DEFINE_ENUMERATION_OPERATORS(ENUMTYPE) // NOP, C allows these operators.
+#endif // __cplusplus
+
+#endif // BASE_TYPEOPERATORS_H

--- a/deps/baseconfig/src/typesize.h
+++ b/deps/baseconfig/src/typesize.h
@@ -1,0 +1,53 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Basic header files and defines that are always needed.
+ *
+ * @copyright BaseConfig is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#ifndef BASE_TYPESIZE_H
+#define BASE_TYPESIZE_H
+
+#include "bittype.h"
+
+#ifdef __cplusplus
+extern "C++" {
+
+template<size_t S> struct IntegerForSize;
+
+template<> struct IntegerForSize<1>
+{
+    typedef int8_t type;
+};
+
+template<> struct IntegerForSize<2>
+{
+    typedef int16_t type;
+};
+
+template<> struct IntegerForSize<4>
+{
+    typedef int32_t type;
+};
+
+template<> struct IntegerForSize<8>
+{
+    typedef int64_t type;
+};
+
+// Used as an approximation of std::underlying_type<T>
+template<class T> struct SizedInteger
+{
+    typedef typename IntegerForSize<sizeof(T)>::type type;
+};
+}
+#endif // __cplusplus
+
+#endif // BASE_TYPESIZE_H


### PR DESCRIPTION
I noticed the enum operators do not support custom sizes. For robustness sake I added support same way as seen in winnt.h. I had to move the macros into a new file, otherwise there would have been a cyclic include dependency with bittype.h. I disabled clang-format on the enum macros, because otherwise they just become a huge mess.

In always.h there are some unrelated lines touched because of the clang format. It seems when clang format was introduced in compile check, the files were not updated with this format.