### PR TITLE
Fix uninitialized variable in ScreenMotionBlurFilter::Post_Render

### DIFF
--- a/src/game/client/shader/motionblurfilter.cpp
+++ b/src/game/client/shader/motionblurfilter.cpp
@@ -108,7 +108,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
     float f1 = 0.5f;
     float f2 = 0.5f;
     bool b1 = false;
-    bool b2;
+    bool b2 = true;
 
     if (mode < FM_VIEW_MB_PAN_ALPHA) {
         if (mode == FM_VIEW_MB_END_PAN_ALPHA) {


### PR DESCRIPTION
Jonathan wrote `true` is good. And it also makes sense, because it is set to false in all branches below exclusively.