### PR TITLE
Provide MotionChannelClass::Get_Vector_Safe function to help avoid mi…

### DIFF
--- a/src/w3d/renderer/hrawanim.cpp
+++ b/src/w3d/renderer/hrawanim.cpp
@@ -192,15 +192,15 @@ void HRawAnimClass::Get_Translation(Vector3 &trans, int pividx, float frame) con
         Vector3 t0;
 
         if (motion->X) {
-            motion->X->Get_Vector(frame0, &t0.X);
+            motion->X->Get_Vector_Safe(frame0, &t0.X);
         }
 
         if (motion->Y) {
-            motion->Y->Get_Vector(frame0, &t0.Y);
+            motion->Y->Get_Vector_Safe(frame0, &t0.Y);
         }
 
         if (motion->Z) {
-            motion->Z->Get_Vector(frame0, &t0.Z);
+            motion->Z->Get_Vector_Safe(frame0, &t0.Z);
         }
 
         if (delta == 0) {
@@ -209,15 +209,15 @@ void HRawAnimClass::Get_Translation(Vector3 &trans, int pividx, float frame) con
             Vector3 t1;
 
             if (motion->X) {
-                motion->X->Get_Vector(frame1, &t1.X);
+                motion->X->Get_Vector_Safe(frame1, &t1.X);
             }
 
             if (motion->Y) {
-                motion->Y->Get_Vector(frame1, &t1.Y);
+                motion->Y->Get_Vector_Safe(frame1, &t1.Y);
             }
 
             if (motion->Z) {
-                motion->Z->Get_Vector(frame1, &t1.Z);
+                motion->Z->Get_Vector_Safe(frame1, &t1.Z);
             }
 
             Vector3::Lerp(t0, t1, delta, &trans);
@@ -279,15 +279,15 @@ void HRawAnimClass::Get_Transform(Matrix3D &mtx, int pividx, float frame) const
         mtx = Build_Matrix3D(q);
 
         if (mot->X) {
-            mot->X->Get_Vector(frame0, &mtx[0].W);
+            mot->X->Get_Vector_Safe(frame0, &mtx[0].W);
         }
 
         if (mot->Y) {
-            mot->Y->Get_Vector(frame0, &mtx[1].W);
+            mot->Y->Get_Vector_Safe(frame0, &mtx[1].W);
         }
 
         if (mot->Z) {
-            mot->Z->Get_Vector(frame0, &mtx[2].W);
+            mot->Z->Get_Vector_Safe(frame0, &mtx[2].W);
         }
     } else {
         Quaternion q1;
@@ -300,29 +300,29 @@ void HRawAnimClass::Get_Transform(Matrix3D &mtx, int pividx, float frame) const
         Vector3 v1(0, 0, 0);
 
         if (mot->X) {
-            mot->X->Get_Vector(frame0, &v1.X);
+            mot->X->Get_Vector_Safe(frame0, &v1.X);
         }
 
         if (mot->Y) {
-            mot->Y->Get_Vector(frame0, &v1.Y);
+            mot->Y->Get_Vector_Safe(frame0, &v1.Y);
         }
 
         if (mot->Z) {
-            mot->Z->Get_Vector(frame0, &v1.Z);
+            mot->Z->Get_Vector_Safe(frame0, &v1.Z);
         }
 
         Vector3 v2(0, 0, 0);
 
         if (mot->X) {
-            mot->X->Get_Vector(frame1, &v2.X);
+            mot->X->Get_Vector_Safe(frame1, &v2.X);
         }
 
         if (mot->Y) {
-            mot->Y->Get_Vector(frame1, &v2.Y);
+            mot->Y->Get_Vector_Safe(frame1, &v2.Y);
         }
 
         if (mot->Z) {
-            mot->Z->Get_Vector(frame1, &v2.Z);
+            mot->Z->Get_Vector_Safe(frame1, &v2.Z);
         }
 
         Vector3 v3;

--- a/src/w3d/renderer/htree.cpp
+++ b/src/w3d/renderer/htree.cpp
@@ -300,15 +300,15 @@ void HTreeClass::Anim_Update(Matrix3D const &root, HRawAnimClass *motion, float 
             float z = 0;
 
             if (node->X) {
-                node->X->Get_Vector(fr, &x);
+                node->X->Get_Vector_Safe(fr, &x);
             }
 
             if (node->Y) {
-                node->Y->Get_Vector(fr, &y);
+                node->Y->Get_Vector_Safe(fr, &y);
             }
 
             if (node->Z) {
-                node->Z->Get_Vector(fr, &z);
+                node->Z->Get_Vector_Safe(fr, &z);
             }
 
             if (m_scaleFactor == 1.0f) {

--- a/src/w3d/renderer/motchan.h
+++ b/src/w3d/renderer/motchan.h
@@ -28,10 +28,11 @@ public:
     void Free();
     bool Load_W3D(ChunkLoadClass &cload);
 
-    int Get_Type() { return m_type; }
-    int Get_Pivot() { return m_pivotIdx; }
+    int Get_Type() const { return m_type; }
+    int Get_Pivot() const { return m_pivotIdx; }
 
-    void Get_Vector(int frame, float *vector)
+    // Legacy method: prefer Get_Vector_Safe
+    void Get_Vector(int frame, float *vector) const
     {
         if (!m_data || frame < m_firstFrame || frame > m_lastFrame) {
             Set_Identity(vector);
@@ -44,7 +45,7 @@ public:
         }
     }
 
-    void Get_Vector_As_Quat(int frame, Quaternion &quat)
+    void Get_Vector_As_Quat(int frame, Quaternion &quat) const
     {
         if (frame >= m_firstFrame && frame <= m_lastFrame) {
             float *f = &m_data[m_vectorLen * (frame - m_firstFrame)];
@@ -54,7 +55,8 @@ public:
         }
     }
 
-    void Set_Identity(float *setvec)
+private:
+    void Set_Identity(float *setvec) const
     {
         if (m_type == ANIM_CHANNEL_Q) {
             setvec[0] = 0;
@@ -79,6 +81,65 @@ private:
     int m_firstFrame;
     int m_lastFrame;
     friend class HRawAnimClass;
+
+public:
+    // #FEATURE Add new Get_Vector versions to help avoid misuse.
+    void Get_Vector_Safe(int frame, float *x) const
+    {
+        captainslog_dbgassert(m_vectorLen >= 1, "Vector length must match requested size");
+
+        if (!m_data || frame < m_firstFrame || frame > m_lastFrame) {
+            *x = 0.0f;
+        } else if (m_data) {
+            frame -= m_firstFrame;
+            *x = m_data[0 + m_vectorLen * frame];
+        }
+    }
+    void Get_Vector_Safe(int frame, float *x, float *y)
+    {
+        captainslog_dbgassert(m_vectorLen >= 2, "Vector length must match requested size");
+
+        if (!m_data || frame < m_firstFrame || frame > m_lastFrame) {
+            *x = 0.0f;
+            *y = 0.0f;
+        } else if (m_data) {
+            frame -= m_firstFrame;
+            *x = m_data[0 + m_vectorLen * frame];
+            *y = m_data[1 + m_vectorLen * frame];
+        }
+    }
+    void Get_Vector_Safe(int frame, float *x, float *y, float *z)
+    {
+        captainslog_dbgassert(m_vectorLen >= 3, "Vector length must match requested size");
+
+        if (!m_data || frame < m_firstFrame || frame > m_lastFrame) {
+            *x = 0.0f;
+            *y = 0.0f;
+            *z = 0.0f;
+        } else if (m_data) {
+            frame -= m_firstFrame;
+            *x = m_data[0 + m_vectorLen * frame];
+            *y = m_data[1 + m_vectorLen * frame];
+            *z = m_data[2 + m_vectorLen * frame];
+        }
+    }
+    void Get_Vector_Safe(int frame, float *x, float *y, float *z, float *w)
+    {
+        captainslog_dbgassert(m_vectorLen >= 4, "Vector length must match requested size");
+
+        if (!m_data || frame < m_firstFrame || frame > m_lastFrame) {
+            *x = 0.0f;
+            *y = 0.0f;
+            *z = 0.0f;
+            *w = (m_type != ANIM_CHANNEL_Q) ? 0.0f : 1.0f;
+        } else if (m_data) {
+            frame -= m_firstFrame;
+            *x = m_data[0 + m_vectorLen * frame];
+            *y = m_data[1 + m_vectorLen * frame];
+            *z = m_data[2 + m_vectorLen * frame];
+            *w = m_data[3 + m_vectorLen * frame];
+        }
+    }
 };
 
 class BitChannelClass : public W3DMPO


### PR DESCRIPTION
…suse and detect potential problems.

This is a proposal to discourage the use of the original unchecked function `Get_Vector` which allows for non-obvious memory corruptions. The new functions make corruption less likely, because it is checked in Debug.

Likely there is an even better solution, but it did not occur to me yet.