### PR TITLE
Improve game hooking lifetime and technique

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,6 +45,7 @@ set(GAMEENGINE_INCLUDES
 set(HOOKER_SRC
     hooker/dllmain.cpp
     hooker/hooker.cpp
+    hooker/mapview.cpp
     hooker/setupglobals_zh.cpp
 )
 

--- a/src/hooker/dllmain.cpp
+++ b/src/hooker/dllmain.cpp
@@ -26,12 +26,14 @@ BOOL WINAPI DllMain(HMODULE hModule, DWORD ul_reason_for_call, LPVOID lpReserved
 {
     switch (ul_reason_for_call) {
         case DLL_PROCESS_ATTACH:
-            StartHooking();
-            Setup_Hooks();
+            if (StartHooking()) {
+                Setup_Hooks();
+                StopHooking();
+            }
             break;
 
         case DLL_PROCESS_DETACH:
-            StopHooking();
+            // Currently does not unhook from module. Must shutdown.
             break;
 
         case DLL_THREAD_ATTACH:

--- a/src/hooker/hooker.cpp
+++ b/src/hooker/hooker.cpp
@@ -1,25 +1,25 @@
 /**
-* @file
-*
-* @author CCHyper
-* @author jonwil
-* @author LRFLEW
-* @author OmniBlade
-* @author Saberhawk
-*
-* @brief Hooking system for interacting with original binary.
-*
-* @copyright Thyme is free software: you can redistribute it and/or
-*            modify it under the terms of the GNU General Public License
-*            as published by the Free Software Foundation, either version
-*            2 of the License, or (at your option) any later version.
-*            A full copy of the GNU General Public License can be found in
-*            LICENSE
-*
-* Originally based on work by the Tiberian Technologies team to hook Renegade, rewritten based on work by LRFLEW for
-* OpenMC2. Provides methods for accessing data and functions in an existing binary and replacing functions with new
-* implementations from an injected DLL.
-*/
+ * @file
+ *
+ * @author CCHyper
+ * @author jonwil
+ * @author LRFLEW
+ * @author OmniBlade
+ * @author Saberhawk
+ *
+ * @brief Hooking system for interacting with original binary.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ *
+ * Originally based on work by the Tiberian Technologies team to hook Renegade, rewritten based on work by LRFLEW for
+ * OpenMC2. Provides methods for accessing data and functions in an existing binary and replacing functions with new
+ * implementations from an injected DLL.
+ */
 
 #include "hooker.h"
 

--- a/src/hooker/hooker.h
+++ b/src/hooker/hooker.h
@@ -179,8 +179,8 @@ template<typename T> void Hook_Method(uintptr_t in, T out)
       __asm call Hook_Func     \
       __asm add esp, 8 }
 
-__declspec(dllexport) void StartHooking();
-__declspec(dllexport) void StopHooking();
+__declspec(dllexport) bool StartHooking();
+__declspec(dllexport) bool StopHooking();
 
 #define ARRAY_DEC(type, var, size) ArrayHelper<type, size> &var
 #define ARRAY_DEF(address, type, var, size) ArrayHelper<type, size> &var = Make_Global<ArrayHelper<type, size>>(address);

--- a/src/hooker/hooker.h
+++ b/src/hooker/hooker.h
@@ -144,7 +144,7 @@ struct x86_jump
 #pragma pack(pop)
 
 // Use these to hook existing functions and replace them with newly written ones
-// to either replace them permenantly or just to test correctness of a newly
+// to either replace them permanently or just to test correctness of a newly
 // written one.
 
 // Base hooking function to apply the actual hook.
@@ -172,7 +172,7 @@ template<typename T> void Hook_Method(uintptr_t in, T out)
     Hook_Func(in, reinterpret_cast<uintptr_t>((void *&)out));
 }
 
-// Virtuals are even trickier so resort to inline asm for those curtesy of the TTScripts guys.
+// Virtuals are even trickier so resort to inline assembler for those courtesy of the TTScripts guys.
 #define Hook_Any(in, out) __asm { \
       __asm push out                  \
       __asm push in                         \

--- a/src/hooker/mapview.cpp
+++ b/src/hooker/mapview.cpp
@@ -68,8 +68,11 @@ bool GetModuleSectionInfo(ImageSectionInfo &info)
         PIMAGE_OPTIONAL_HEADER optionalHeader = mapView.GetOptionalHeader();
 
         if (optionalHeader != NULL) {
-            info.BaseOfCode = optionalHeader->ImageBase + optionalHeader->BaseOfCode;
-            info.SizeOfCode = optionalHeader->SizeOfCode;
+            info.BaseOfCode = LPVOID(optionalHeader->ImageBase + optionalHeader->BaseOfCode);
+            info.BaseOfData = LPVOID(optionalHeader->BaseOfData);
+            info.SizeOfCode = SIZE_T(optionalHeader->SizeOfCode);
+            info.SizeOfData = SIZE_T(optionalHeader->SizeOfInitializedData + optionalHeader->SizeOfUninitializedData);
+
             return true;
         }
     }

--- a/src/hooker/mapview.cpp
+++ b/src/hooker/mapview.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Map view helper to extract information from DOS executable.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "mapview.h"
+#include "bittype.h"
+#include "macros.h"
+
+MapViewOfFileClass::MapViewOfFileClass(const wchar_t *fileName) :
+    m_hFile(INVALID_HANDLE_VALUE),
+    m_hFileMapping(NULL),
+    m_lpFileBase(NULL),
+    m_dosHeader(NULL),
+    m_ntHeader(NULL),
+    m_optionalHeader(NULL),
+    m_sectionHeaders(NULL)
+{
+    m_hFile = CreateFileW(fileName, GENERIC_READ, FILE_SHARE_READ, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+
+    if (m_hFile != INVALID_HANDLE_VALUE) {
+        m_hFileMapping = CreateFileMapping(m_hFile, NULL, PAGE_READONLY, 0, 0, NULL);
+
+        if (m_hFileMapping != NULL) {
+            m_lpFileBase = MapViewOfFile(m_hFileMapping, FILE_MAP_READ, 0, 0, 0);
+
+            if (m_lpFileBase != NULL) {
+                m_dosHeader = (PIMAGE_DOS_HEADER)m_lpFileBase;
+
+                if (m_dosHeader->e_magic == IMAGE_DOS_SIGNATURE) {
+                    m_ntHeader = (PIMAGE_NT_HEADERS)((uint8_t *)m_dosHeader + m_dosHeader->e_lfanew);
+
+                    if (m_ntHeader->Signature == IMAGE_NT_SIGNATURE) {
+                        m_optionalHeader = (PIMAGE_OPTIONAL_HEADER)&m_ntHeader->OptionalHeader;
+                        m_sectionHeaders = IMAGE_FIRST_SECTION(m_ntHeader);
+                    }
+                }
+            }
+        }
+    }
+}
+
+MapViewOfFileClass::~MapViewOfFileClass()
+{
+    if (m_lpFileBase != NULL)
+        UnmapViewOfFile(m_lpFileBase);
+    if (m_hFileMapping != NULL)
+        CloseHandle(m_hFileMapping);
+    if (m_hFile != INVALID_HANDLE_VALUE)
+        CloseHandle(m_hFile);
+}
+
+bool GetModuleSectionInfo(ImageSectionInfo &info)
+{
+    wchar_t fileName[MAX_PATH] = { 0 };
+
+    if (GetModuleFileNameW(NULL, fileName, ARRAY_SIZE(fileName)) != 0) {
+        MapViewOfFileClass mapView(fileName);
+        PIMAGE_OPTIONAL_HEADER optionalHeader = mapView.GetOptionalHeader();
+
+        if (optionalHeader != NULL) {
+            info.BaseOfCode = optionalHeader->ImageBase + optionalHeader->BaseOfCode;
+            info.SizeOfCode = optionalHeader->SizeOfCode;
+            return true;
+        }
+    }
+    return false;
+}

--- a/src/hooker/mapview.h
+++ b/src/hooker/mapview.h
@@ -41,8 +41,10 @@ private:
 
 struct ImageSectionInfo
 {
-    DWORD BaseOfCode;
-    DWORD SizeOfCode;
+    LPVOID BaseOfCode;
+    LPVOID BaseOfData;
+    SIZE_T SizeOfCode;
+    SIZE_T SizeOfData;
 };
 
 bool GetModuleSectionInfo(ImageSectionInfo &info);

--- a/src/hooker/mapview.h
+++ b/src/hooker/mapview.h
@@ -1,0 +1,48 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Map view helper to extract information from DOS executable.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include <windows.h>
+
+class MapViewOfFileClass
+{
+public:
+    explicit MapViewOfFileClass(const wchar_t *fileName);
+    ~MapViewOfFileClass();
+
+    LPVOID GetMapViewOfFile() const { return m_lpFileBase; }
+    PIMAGE_DOS_HEADER GetDosHeader() const { return m_dosHeader; }
+    PIMAGE_NT_HEADERS GetNtHeader() const { return m_ntHeader; }
+    PIMAGE_OPTIONAL_HEADER GetOptionalHeader() const { return m_optionalHeader; }
+    PIMAGE_SECTION_HEADER GetSectionHeaders() const { return m_sectionHeaders; }
+    WORD GetSectionHeaderCount() const { return m_ntHeader ? m_ntHeader->FileHeader.NumberOfSections : 0; }
+
+private:
+    HANDLE m_hFile;
+    HANDLE m_hFileMapping;
+    LPVOID m_lpFileBase;
+    PIMAGE_DOS_HEADER m_dosHeader;
+    PIMAGE_NT_HEADERS m_ntHeader;
+    PIMAGE_OPTIONAL_HEADER m_optionalHeader;
+    PIMAGE_SECTION_HEADER m_sectionHeaders;
+};
+
+struct ImageSectionInfo
+{
+    DWORD BaseOfCode;
+    DWORD SizeOfCode;
+};
+
+bool GetModuleSectionInfo(ImageSectionInfo &info);


### PR DESCRIPTION
This change provides a little improvement for the hooker.

a) Replaces hard coded address value with value taken from DOS Header
b) Removes the very generous hooking life time

Having code and data page protected is a good thing, because we would not want any illegal writes to it. VirtualProtect will give an intermediate access violation if that would happen. That is desirable, because it will be easier to debug than a sneaky write to the pages.