### PR TITLE
Fix CaveSystem calls and hook ctor

### DIFF
--- a/src/game/logic/system/cavesystem.cpp
+++ b/src/game/logic/system/cavesystem.cpp
@@ -24,7 +24,7 @@ CaveSystem *g_theCaveSystem = nullptr;
 void TunnelTracker::Xfer_Snapshot(Xfer *xfer)
 {
 #ifdef GAME_DLL
-    Call_Method<void, TunnelTracker, Xfer *>(PICK_ADDRESS(0x00587CC3, 0x009118AB), this, xfer);
+    Call_Method<void, SnapShot, Xfer *>(PICK_ADDRESS(0x00587CC3, 0x009118AB), this, xfer);
 #else
     // TODO
 #endif
@@ -51,7 +51,7 @@ void CaveSystem::Reset()
 void CaveSystem::Xfer_Snapshot(Xfer *xfer)
 {
 #ifdef GAME_DLL
-    Call_Method<void, CaveSystem, Xfer *>(PICK_ADDRESS(0x004D58A2, 0x0076E80B), this, xfer);
+    Call_Method<void, SnapShot, Xfer *>(PICK_ADDRESS(0x004D58A0, 0x0076E80B), this, xfer);
 #else
     // TODO
 #endif
@@ -83,7 +83,7 @@ bool CaveSystem::Can_Switch_Index_to_Index(size_t unk1, size_t unk2)
 TunnelTracker *CaveSystem::Register_New_Cave(int index)
 {
 #ifdef GAME_DLL
-    return Call_Method<TunnelTracker *, CaveSystem, int>(PICK_ADDRESS(0x004D58A2, 0x0076E69D), this, index);
+    return Call_Method<TunnelTracker *, CaveSystem, int>(PICK_ADDRESS(0x004D5790, 0x0076E69D), this, index);
 #else
     // TODO
     return nullptr;

--- a/src/game/logic/system/cavesystem.h
+++ b/src/game/logic/system/cavesystem.h
@@ -60,6 +60,9 @@ public:
     TunnelTracker *Register_New_Cave(int index);
     TunnelTracker *Get_Tunnel_Tracker_For_Cave_Index(size_t index);
 
+    // zh: 0x004D55D0 wb: 0x0076E506
+    CaveSystem *Hook_Ctor() { return new (this) CaveSystem; }
+
 private:
     std::vector<TunnelTracker *> m_caves;
 };

--- a/src/hooker/setuphooks_zh.cpp
+++ b/src/hooker/setuphooks_zh.cpp
@@ -548,8 +548,9 @@ void Setup_Hooks()
 
     // cave.h CaveSystem
     Hook_Method(0x004D5730, &CaveSystem::Can_Switch_Index_to_Index);
-    Hook_Method(0x004D5790, &CaveSystem::Register_New_Cave);
+    // Hook_Method(0x004D5790, &CaveSystem::Register_New_Cave);
     Hook_Method(0x004D5880, &CaveSystem::Get_Tunnel_Tracker_For_Cave_Index);
+    Hook_Method(PICK_ADDRESS(0x004D55D0, 0x0076E506), &CaveSystem::Hook_Ctor);
 
     // teamsinfo.h TeamsInfoRec
     Hook_Method(0x004D8F80, &TeamsInfoRec::Clear);


### PR DESCRIPTION
Small little fix. Incorrect offsets were being used and also there was a circular calling due to hooking an unimplemented function. 

The SnapShot changes are required as otherwise the this pointer is at the wrong offset.