### PR TITLE
Move memdynalloc.h away from asciistring.h

### DIFF
--- a/src/game/client/crashpreferences.cpp
+++ b/src/game/client/crashpreferences.cpp
@@ -13,6 +13,7 @@
  *            LICENSE
  */
 #include "crashpreferences.h"
+#include <captainslog.h>
 #include <cstdio>
 #include <cstdlib>
 

--- a/src/game/common/registry.cpp
+++ b/src/game/common/registry.cpp
@@ -17,6 +17,7 @@
 #include <captainslog.h>
 
 #ifdef PLATFORM_WINDOWS
+#include <WinError.h>
 #include <winreg.h>
 
 static bool getStringFromReg(HKEY hkey, Utf8String subkey, Utf8String key, Utf8String &result)

--- a/src/game/common/system/asciistring.cpp
+++ b/src/game/common/system/asciistring.cpp
@@ -14,6 +14,7 @@
  */
 #include "asciistring.h"
 #include "endiantype.h"
+#include "memdynalloc.h"
 #include "unicodestring.h"
 #include <captainslog.h>
 #include <cctype>

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -15,7 +15,6 @@
 #pragma once
 
 #include "always.h"
-#include "memdynalloc.h"
 #include <cstdarg>
 #include <cstring>
 #include <new>

--- a/src/game/common/system/stackdump.h
+++ b/src/game/common/system/stackdump.h
@@ -21,6 +21,7 @@
 #ifdef PLATFORM_WINDOWS
 // clang-format off
 // Headers must be in this order.
+#include <winbase.h>
 #include <winver.h>
 #include <dbghelp.h>
 #include <eh.h>

--- a/src/game/common/system/unicodestring.cpp
+++ b/src/game/common/system/unicodestring.cpp
@@ -14,9 +14,9 @@
  */
 #include "unicodestring.h"
 #include "asciistring.h"
-#include "critsection.h"
+#include "memdynalloc.h"
+#include <captainslog.h>
 #include <stdio.h>
-#include <string.h>
 
 #if !defined BUILD_WITH_ICU && defined PLATFORM_WINDOWS
 #include <wctype.h>

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -19,6 +19,7 @@
 #include "gamemain.h"
 #include "gamememory.h"
 #include "gitverinfo.h"
+#include "memdynalloc.h"
 #include "mempool.h"
 #include "stackdump.h"
 #include "unicodestring.h"

--- a/src/game/network/filetransfer.cpp
+++ b/src/game/network/filetransfer.cpp
@@ -14,6 +14,7 @@
  */
 #include "filetransfer.h"
 #include <algorithm>
+#include <captainslog.h>
 #include <cstddef>
 
 using std::ptrdiff_t;

--- a/src/hooker/setuphooks_zh.cpp
+++ b/src/hooker/setuphooks_zh.cpp
@@ -69,6 +69,7 @@
 #include "main.h"
 #include "mapobject.h"
 #include "matpass.h"
+#include "memdynalloc.h"
 #include "mesh.h"
 #include "meshgeometry.h"
 #include "meshmatdesc.h"


### PR DESCRIPTION
I found memdynalloc.h included in asciistring.h, which trickled down into all sorts of other compile units. Moved to .cpp and fixed all follow up compile errors accordingly.