### PR TITLE
Refactor TRANS_LIT_TEX_VERTEX into two instances

### DIFF
--- a/src/game/client/shader/bwfilter.cpp
+++ b/src/game/client/shader/bwfilter.cpp
@@ -76,14 +76,6 @@ bool ScreenBWFilter::Pre_Render(bool &skip, CustomScenePassModes &mode)
 bool ScreenBWFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
 {
 #ifdef BUILD_WITH_D3D8
-    struct _TRANS_LIT_TEX_VERTEX
-    {
-        D3DXVECTOR4 p;
-        unsigned long color;
-        float u;
-        float v;
-    };
-
     w3dtexture_t tex = W3DShaderManager::End_Render_To_Texture();
     captainslog_dbgassert(tex, "Require rendered texture.");
 
@@ -95,7 +87,7 @@ bool ScreenBWFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
         return false;
     }
 
-    _TRANS_LIT_TEX_VERTEX vertex[4];
+    TransformedTexture1Vertex vertex[4];
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
     int32_t x;
     int32_t y;
@@ -120,8 +112,8 @@ bool ScreenBWFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
     vertex[3].color = 0xFFFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(_TRANS_LIT_TEX_VERTEX));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
     Reset();
     return true;
 #else
@@ -245,14 +237,6 @@ bool ScreenBWFilterDOT3::Pre_Render(bool &skip, CustomScenePassModes &mode)
 bool ScreenBWFilterDOT3::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
 {
 #ifdef BUILD_WITH_D3D8
-    struct _TRANS_LIT_TEX_VERTEX
-    {
-        D3DXVECTOR4 p;
-        unsigned long color;
-        float u;
-        float v;
-    };
-
     w3dtexture_t tex = W3DShaderManager::End_Render_To_Texture();
     captainslog_dbgassert(tex, "Require rendered texture.");
 
@@ -264,7 +248,7 @@ bool ScreenBWFilterDOT3::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
         return false;
     }
 
-    _TRANS_LIT_TEX_VERTEX vertex[4];
+    TransformedTexture1Vertex vertex[4];
     int32_t x;
     int32_t y;
     g_theTacticalView->Get_Origin(&x, &y);
@@ -289,7 +273,7 @@ bool ScreenBWFilterDOT3::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     vertex[1].color = (color << 24) | 0xFFFFFF;
     vertex[2].color = (color << 24) | 0xFFFFFF;
     vertex[3].color = (color << 24) | 0xFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW);
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
 
     if (DX8Wrapper::Get_Current_Caps()->Supports_Dot3_Blend()) {
         DX8Wrapper::Set_DX8_Render_State(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(128, 165, 202, 142));
@@ -308,14 +292,14 @@ bool ScreenBWFilterDOT3::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     }
 
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(_TRANS_LIT_TEX_VERTEX));
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
     ShaderClass::Invalidate();
     ShaderClass s = ShaderClass::s_presetAlphaShader;
     s.Set_Depth_Compare(ShaderClass::PASS_ALWAYS);
     DX8Wrapper::Set_Shader(s);
     DX8Wrapper::Apply_Render_State_Changes();
     DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG2);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(_TRANS_LIT_TEX_VERTEX));
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
     Reset();
     return true;
 #else

--- a/src/game/client/shader/bwfilter.cpp
+++ b/src/game/client/shader/bwfilter.cpp
@@ -96,18 +96,35 @@ bool ScreenBWFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     int32_t h = g_theTacticalView->Get_Height();
     int32_t w2 = g_theDisplay->Get_Width();
     int32_t h2 = g_theDisplay->Get_Height();
-    vertex[0].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[0].x = (float)(w + x) - 0.5f;
+    vertex[0].y = (float)(h + y) - 0.5f;
+    vertex[0].z = 0.0f;
+    vertex[0].w = 1.0f;
     vertex[0].u = (float)(w + x) / (float)w2;
     vertex[0].v = (float)(h + y) / (float)h2;
-    vertex[1].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[1].x = (float)(w + x) - 0.5f;
+    vertex[1].y = (float)y - 0.5f;
+    vertex[1].z = 0.0f;
+    vertex[1].w = 1.0f;
     vertex[1].u = (float)(w + x) / (float)w2;
     vertex[1].v = (float)y / (float)h2;
-    vertex[2].p = D3DXVECTOR4((float)x - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[2].x = (float)x - 0.5f;
+    vertex[2].y = (float)(h + y) - 0.5f;
+    vertex[2].z = 0.0f;
+    vertex[2].w = 1.0f;
     vertex[2].u = (float)x / (float)w2;
     vertex[2].v = (float)(h + y) / (float)h2;
-    vertex[3].p = D3DXVECTOR4((float)x - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[3].x = (float)x - 0.5f;
+    vertex[3].y = (float)y - 0.5f;
+    vertex[3].z = 0.0f;
+    vertex[3].w = 1.0f;
     vertex[3].u = (float)x / (float)w2;
     vertex[3].v = (float)y / (float)h2;
+
     vertex[0].color = 0xFFFFFFFF;
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
@@ -256,18 +273,35 @@ bool ScreenBWFilterDOT3::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     int32_t h = g_theTacticalView->Get_Height();
     int32_t w2 = g_theDisplay->Get_Width();
     int32_t h2 = g_theDisplay->Get_Height();
-    vertex[0].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[0].x = (float)(w + x) - 0.5f;
+    vertex[0].y = (float)(h + y) - 0.5f;
+    vertex[0].z = 0.0f;
+    vertex[0].w = 1.0f;
     vertex[0].u = (float)(w + x) / (float)w2;
     vertex[0].v = (float)(h + y) / (float)h2;
-    vertex[1].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[1].x = (float)(w + x) - 0.5f;
+    vertex[1].y = (float)y - 0.5f;
+    vertex[1].z = 0.0f;
+    vertex[1].w = 1.0f;
     vertex[1].u = (float)(w + x) / (float)w2;
     vertex[1].v = (float)y / (float)h2;
-    vertex[2].p = D3DXVECTOR4((float)x - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[2].x = (float)x - 0.5f;
+    vertex[2].y = (float)(h + y) - 0.5f;
+    vertex[2].z = 0.0f;
+    vertex[2].w = 1.0f;
     vertex[2].u = (float)x / (float)w2;
     vertex[2].v = (float)(h + y) / (float)h2;
-    vertex[3].p = D3DXVECTOR4((float)x - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[3].x = (float)x - 0.5f;
+    vertex[3].y = (float)y - 0.5f;
+    vertex[3].z = 0.0f;
+    vertex[3].w = 1.0f;
     vertex[3].u = (float)x / (float)w2;
     vertex[3].v = (float)y / (float)h2;
+
     unsigned int color = (unsigned int)((1.0f - ScreenBWFilter::s_curFadeValue) * 255.0f);
     vertex[0].color = (color << 24) | 0xFFFFFF;
     vertex[1].color = (color << 24) | 0xFFFFFF;

--- a/src/game/client/shader/bwfilter.cpp
+++ b/src/game/client/shader/bwfilter.cpp
@@ -87,7 +87,7 @@ bool ScreenBWFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
         return false;
     }
 
-    TransformedTexture1Vertex vertex[4];
+    VertexFormatXYZWDUV1 vertex[4];
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
     int32_t x;
     int32_t y;
@@ -112,8 +112,8 @@ bool ScreenBWFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
     vertex[3].color = 0xFFFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZWDUV1::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV1));
     Reset();
     return true;
 #else
@@ -248,7 +248,7 @@ bool ScreenBWFilterDOT3::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
         return false;
     }
 
-    TransformedTexture1Vertex vertex[4];
+    VertexFormatXYZWDUV1 vertex[4];
     int32_t x;
     int32_t y;
     g_theTacticalView->Get_Origin(&x, &y);
@@ -273,7 +273,7 @@ bool ScreenBWFilterDOT3::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     vertex[1].color = (color << 24) | 0xFFFFFF;
     vertex[2].color = (color << 24) | 0xFFFFFF;
     vertex[3].color = (color << 24) | 0xFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZWDUV1::DX8FVF);
 
     if (DX8Wrapper::Get_Current_Caps()->Supports_Dot3_Blend()) {
         DX8Wrapper::Set_DX8_Render_State(D3DRS_TEXTUREFACTOR, D3DCOLOR_RGBA(128, 165, 202, 142));
@@ -292,14 +292,14 @@ bool ScreenBWFilterDOT3::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     }
 
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV1));
     ShaderClass::Invalidate();
     ShaderClass s = ShaderClass::s_presetAlphaShader;
     s.Set_Depth_Compare(ShaderClass::PASS_ALWAYS);
     DX8Wrapper::Set_Shader(s);
     DX8Wrapper::Apply_Render_State_Changes();
     DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG2);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV1));
     Reset();
     return true;
 #else

--- a/src/game/client/shader/crossfadefilter.cpp
+++ b/src/game/client/shader/crossfadefilter.cpp
@@ -71,16 +71,6 @@ bool ScreenCrossFadeFilter::Pre_Render(bool &skip, CustomScenePassModes &mode)
 bool ScreenCrossFadeFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
 {
 #ifdef BUILD_WITH_D3D8
-    struct _TRANS_LIT_TEX_VERTEX
-    {
-        D3DXVECTOR4 p;
-        unsigned long color;
-        float u1;
-        float v1;
-        float u2;
-        float v2;
-    };
-
     if (s_skipRender) {
         s_skipRender = false;
         b = true;
@@ -99,7 +89,7 @@ bool ScreenCrossFadeFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &
         return false;
     }
 
-    _TRANS_LIT_TEX_VERTEX vertex[4];
+    TransformedTexture2Vertex vertex[4];
     float f1 = 0.0f;
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
 
@@ -145,8 +135,8 @@ bool ScreenCrossFadeFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
     vertex[3].color = 0xFFFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(D3DFVF_TEX2 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(_TRANS_LIT_TEX_VERTEX));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture2Vertex::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture2Vertex));
     Reset();
     return true;
 #else

--- a/src/game/client/shader/crossfadefilter.cpp
+++ b/src/game/client/shader/crossfadefilter.cpp
@@ -89,7 +89,7 @@ bool ScreenCrossFadeFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &
         return false;
     }
 
-    TransformedTexture2Vertex vertex[4];
+    VertexFormatXYZDUV2 vertex[4];
     float f1 = 0.0f;
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
 
@@ -135,8 +135,8 @@ bool ScreenCrossFadeFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
     vertex[3].color = 0xFFFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture2Vertex::DX8FVF);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture2Vertex));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZDUV2::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZDUV2));
     Reset();
     return true;
 #else

--- a/src/game/client/shader/crossfadefilter.cpp
+++ b/src/game/client/shader/crossfadefilter.cpp
@@ -89,7 +89,7 @@ bool ScreenCrossFadeFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &
         return false;
     }
 
-    VertexFormatXYZDUV2 vertex[4];
+    VertexFormatXYZWDUV2 vertex[4];
     float f1 = 0.0f;
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
 
@@ -111,32 +111,49 @@ bool ScreenCrossFadeFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &
     int32_t h = g_theTacticalView->Get_Height();
     int32_t w2 = g_theDisplay->Get_Width();
     int32_t h2 = g_theDisplay->Get_Height();
-    vertex[0].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[0].x = (float)(w + x) - 0.5f;
+    vertex[0].y = (float)(h + y) - 0.5f;
+    vertex[0].z = 0.0f;
+    vertex[0].w = 1.0f;
     vertex[0].u1 = (float)(w + x) / (float)w2;
     vertex[0].v1 = (float)(h + y) / (float)h2;
     vertex[0].u2 = f1 + 0.5f;
     vertex[0].v2 = f1 + 0.5f;
-    vertex[1].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[1].x = (float)(w + x) - 0.5f;
+    vertex[1].y = (float)y - 0.5f;
+    vertex[1].z = 0.0f;
+    vertex[1].w = 1.0f;
     vertex[1].u1 = (float)(w + x) / (float)w2;
     vertex[1].v1 = (float)y / (float)h2;
     vertex[1].u2 = f1 + 0.5f;
     vertex[1].v2 = 0.5f - f1;
-    vertex[2].p = D3DXVECTOR4((float)x - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[2].x = (float)x - 0.5f;
+    vertex[2].y = (float)(h + y) - 0.5f;
+    vertex[2].z = 0.0f;
+    vertex[2].w = 1.0f;
     vertex[2].u1 = (float)x / (float)w2;
     vertex[2].v1 = (float)(h + y) / (float)h2;
     vertex[2].u2 = 0.5f - f1;
     vertex[2].v2 = f1 + 0.5f;
-    vertex[3].p = D3DXVECTOR4((float)x - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[3].x = (float)x - 0.5f;
+    vertex[3].y = (float)y - 0.5f;
+    vertex[3].z = 0.0f;
+    vertex[3].w = 1.0f;
     vertex[3].u1 = (float)x / (float)w2;
     vertex[3].v1 = (float)y / (float)h2;
     vertex[3].u2 = 0.5f - f1;
     vertex[3].v2 = 0.5f - f1;
+
     vertex[0].color = 0xFFFFFFFF;
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
     vertex[3].color = 0xFFFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZDUV2::DX8FVF);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZDUV2));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZWDUV2::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV2));
     Reset();
     return true;
 #else

--- a/src/game/client/shader/defaultfilter.cpp
+++ b/src/game/client/shader/defaultfilter.cpp
@@ -42,14 +42,6 @@ bool ScreenDefaultFilter::Pre_Render(bool &skip, CustomScenePassModes &mode)
 bool ScreenDefaultFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
 {
 #ifdef BUILD_WITH_D3D8
-    struct _TRANS_LIT_TEX_VERTEX
-    {
-        D3DXVECTOR4 p;
-        unsigned long color;
-        float u;
-        float v;
-    };
-
     w3dtexture_t tex = W3DShaderManager::End_Render_To_Texture();
     captainslog_dbgassert(tex, "Require rendered texture.");
 
@@ -61,7 +53,7 @@ bool ScreenDefaultFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
         return false;
     }
 
-    _TRANS_LIT_TEX_VERTEX vertex[4];
+    TransformedTexture1Vertex vertex[4];
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
     int32_t x;
     int32_t y;
@@ -86,8 +78,8 @@ bool ScreenDefaultFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
     vertex[3].color = 0xFFFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(_TRANS_LIT_TEX_VERTEX));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
     Reset();
     return true;
 #else

--- a/src/game/client/shader/defaultfilter.cpp
+++ b/src/game/client/shader/defaultfilter.cpp
@@ -53,7 +53,7 @@ bool ScreenDefaultFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
         return false;
     }
 
-    TransformedTexture1Vertex vertex[4];
+    VertexFormatXYZWDUV1 vertex[4];
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
     int32_t x;
     int32_t y;
@@ -78,8 +78,8 @@ bool ScreenDefaultFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
     vertex[3].color = 0xFFFFFFFF;
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZWDUV1::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV1));
     Reset();
     return true;
 #else

--- a/src/game/client/shader/defaultfilter.cpp
+++ b/src/game/client/shader/defaultfilter.cpp
@@ -62,22 +62,40 @@ bool ScreenDefaultFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
     int32_t h = g_theTacticalView->Get_Height();
     int32_t w2 = g_theDisplay->Get_Width();
     int32_t h2 = g_theDisplay->Get_Height();
-    vertex[0].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[0].x = (float)(w + x) - 0.5f;
+    vertex[0].y = (float)(h + y) - 0.5f;
+    vertex[0].z = 0.0f;
+    vertex[0].w = 1.0f;
     vertex[0].u = (float)(w + x) / (float)w2;
     vertex[0].v = (float)(h + y) / (float)h2;
-    vertex[1].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[1].x = (float)(w + x) - 0.5f;
+    vertex[1].y = (float)y - 0.5f;
+    vertex[1].z = 0.0f;
+    vertex[1].w = 1.0f;
     vertex[1].u = (float)(w + x) / (float)w2;
     vertex[1].v = (float)y / (float)h2;
-    vertex[2].p = D3DXVECTOR4((float)x - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[2].x = (float)x - 0.5f;
+    vertex[2].y = (float)(h + y) - 0.5f;
+    vertex[2].z = 0.0f;
+    vertex[2].w = 1.0f;
     vertex[2].u = (float)x / (float)w2;
     vertex[2].v = (float)(h + y) / (float)h2;
-    vertex[3].p = D3DXVECTOR4((float)x - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[3].x = (float)x - 0.5f;
+    vertex[3].y = (float)y - 0.5f;
+    vertex[3].z = 0.0f;
+    vertex[3].w = 1.0f;
     vertex[3].u = (float)x / (float)w2;
     vertex[3].v = (float)y / (float)h2;
+
     vertex[0].color = 0xFFFFFFFF;
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;
     vertex[3].color = 0xFFFFFFFF;
+
     DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZWDUV1::DX8FVF);
     DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV1));
     Reset();

--- a/src/game/client/shader/motionblurfilter.cpp
+++ b/src/game/client/shader/motionblurfilter.cpp
@@ -49,14 +49,6 @@ bool ScreenMotionBlurFilter::Pre_Render(bool &skip, CustomScenePassModes &mode)
 bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool &b)
 {
 #ifdef BUILD_WITH_D3D8
-    struct _TRANS_LIT_TEX_VERTEX
-    {
-        D3DXVECTOR4 p;
-        unsigned long color;
-        float u;
-        float v;
-    };
-
     w3dtexture_t tex = W3DShaderManager::End_Render_To_Texture();
     captainslog_dbgassert(tex, "Require rendered texture.");
 
@@ -68,7 +60,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
         return false;
     }
 
-    _TRANS_LIT_TEX_VERTEX vertex[4];
+    TransformedTexture1Vertex vertex[4];
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
     int32_t x;
     int32_t y;
@@ -104,7 +96,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
 
     DX8Wrapper::Set_DX8_Render_State(D3DRS_ALPHABLENDENABLE, FALSE);
     DX8Wrapper::Apply_Render_State_Changes();
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW);
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
     float f1 = 0.5f;
     float f2 = 0.5f;
     bool b1 = false;
@@ -183,7 +175,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
     DX8Wrapper::Get_D3D_Device8()->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_CURRENT);
     DX8Wrapper::Get_D3D_Device8()->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_TEXTURE);
     DX8Wrapper::Get_D3D_Device8()->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(_TRANS_LIT_TEX_VERTEX));
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
     DX8Wrapper::Set_DX8_Render_State(D3DRS_ALPHABLENDENABLE, TRUE);
     DX8Wrapper::Apply_Render_State_Changes();
     int count = m_maxCount;
@@ -224,7 +216,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
             vertex[j].v = (vertex[j].v - f2) * f3 + f2;
         }
 
-        DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(_TRANS_LIT_TEX_VERTEX));
+        DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
     }
 
     m_lastFrame = g_theGameLogic->Get_Frame();

--- a/src/game/client/shader/motionblurfilter.cpp
+++ b/src/game/client/shader/motionblurfilter.cpp
@@ -69,18 +69,35 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
     int32_t h = g_theTacticalView->Get_Height();
     int32_t w2 = g_theDisplay->Get_Width();
     int32_t h2 = g_theDisplay->Get_Height();
-    vertex[0].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[0].x = (float)(w + x) - 0.5f;
+    vertex[0].y = (float)(h + y) - 0.5f;
+    vertex[0].z = 0.0f;
+    vertex[0].w = 1.0f;
     vertex[0].u = (float)(w + x) / (float)w2;
     vertex[0].v = (float)(h + y) / (float)h2;
-    vertex[1].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[1].x = (float)(w + x) - 0.5f;
+    vertex[1].y = (float)y - 0.5f;
+    vertex[1].z = 0.0f;
+    vertex[1].w = 1.0f;
     vertex[1].u = (float)(w + x) / (float)w2;
     vertex[1].v = (float)y / (float)h2;
-    vertex[2].p = D3DXVECTOR4((float)x - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[2].x = (float)x - 0.5f;
+    vertex[2].y = (float)(h + y) - 0.5f;
+    vertex[2].z = 0.0f;
+    vertex[2].w = 1.0f;
     vertex[2].u = (float)x / (float)w2;
     vertex[2].v = (float)(h + y) / (float)h2;
-    vertex[3].p = D3DXVECTOR4((float)x - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[3].x = (float)x - 0.5f;
+    vertex[3].y = (float)y - 0.5f;
+    vertex[3].z = 0.0f;
+    vertex[3].w = 1.0f;
     vertex[3].u = (float)x / (float)w2;
     vertex[3].v = (float)y / (float)h2;
+
     vertex[0].color = 0xFFFFFFFF;
     vertex[1].color = 0xFFFFFFFF;
     vertex[2].color = 0xFFFFFFFF;

--- a/src/game/client/shader/motionblurfilter.cpp
+++ b/src/game/client/shader/motionblurfilter.cpp
@@ -60,7 +60,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
         return false;
     }
 
-    TransformedTexture1Vertex vertex[4];
+    VertexFormatXYZWDUV1 vertex[4];
     DX8Wrapper::Get_D3D_Device8()->SetTexture(0, tex);
     int32_t x;
     int32_t y;
@@ -96,7 +96,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
 
     DX8Wrapper::Set_DX8_Render_State(D3DRS_ALPHABLENDENABLE, FALSE);
     DX8Wrapper::Apply_Render_State_Changes();
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZWDUV1::DX8FVF);
     float f1 = 0.5f;
     float f2 = 0.5f;
     bool b1 = false;
@@ -175,7 +175,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
     DX8Wrapper::Get_D3D_Device8()->SetTextureStageState(0, D3DTSS_ALPHAARG1, D3DTA_CURRENT);
     DX8Wrapper::Get_D3D_Device8()->SetTextureStageState(0, D3DTSS_ALPHAARG2, D3DTA_TEXTURE);
     DX8Wrapper::Get_D3D_Device8()->SetTextureStageState(0, D3DTSS_ALPHAOP, D3DTOP_SELECTARG1);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV1));
     DX8Wrapper::Set_DX8_Render_State(D3DRS_ALPHABLENDENABLE, TRUE);
     DX8Wrapper::Apply_Render_State_Changes();
     int count = m_maxCount;
@@ -216,7 +216,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
             vertex[j].v = (vertex[j].v - f2) * f3 + f2;
         }
 
-        DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
+        DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV1));
     }
 
     m_lastFrame = g_theGameLogic->Get_Frame();

--- a/src/game/client/shadermanager.cpp
+++ b/src/game/client/shadermanager.cpp
@@ -285,18 +285,34 @@ void W3DShaderManager::Draw_Viewport(unsigned int color)
     int32_t w2 = g_theDisplay->Get_Width();
     int32_t h2 = g_theDisplay->Get_Height();
 
-    vertex[0].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+    vertex[0].x = (float)(w + x) - 0.5f;
+    vertex[0].y = (float)(h + y) - 0.5f;
+    vertex[0].z = 0.0f;
+    vertex[0].w = 1.0f;
     vertex[0].u = (float)(w + x) / (float)w2;
     vertex[0].v = (float)(h + y) / (float)h2;
-    vertex[1].p = D3DXVECTOR4((float)(w + x) - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[1].x = (float)(w + x) - 0.5f;
+    vertex[1].y = (float)y - 0.5f;
+    vertex[1].z = 0.0f;
+    vertex[1].w = 1.0f;
     vertex[1].u = (float)(w + x) / (float)w2;
     vertex[1].v = (float)y / (float)h2;
-    vertex[2].p = D3DXVECTOR4((float)x - 0.5f, (float)(h + y) - 0.5f, 0.0f, 1.0f);
+
+    vertex[2].x = (float)x - 0.5f;
+    vertex[2].y = (float)(h + y) - 0.5f;
+    vertex[2].z = 0.0f;
+    vertex[2].w = 1.0f;
     vertex[2].u = (float)x / (float)w2;
     vertex[2].v = (float)(h + y) / (float)h2;
-    vertex[3].p = D3DXVECTOR4((float)x - 0.5f, (float)y - 0.5f, 0.0f, 1.0f);
+
+    vertex[3].x = (float)x - 0.5f;
+    vertex[3].y = (float)y - 0.5f;
+    vertex[3].z = 0.0f;
+    vertex[3].w = 1.0f;
     vertex[3].u = (float)x / (float)w2;
     vertex[3].v = (float)y / (float)h2;
+
     vertex[0].color = color;
     vertex[1].color = color;
     vertex[2].color = color;

--- a/src/game/client/shadermanager.cpp
+++ b/src/game/client/shadermanager.cpp
@@ -275,15 +275,7 @@ bool W3DShaderManager::Filter_Setup(FilterTypes filter, FilterModes mode)
 void W3DShaderManager::Draw_Viewport(unsigned int color)
 {
 #ifdef BUILD_WITH_D3D8
-    struct _TRANS_LIT_TEX_VERTEX
-    {
-        D3DXVECTOR4 p;
-        unsigned long color;
-        float u;
-        float v;
-    };
-
-    _TRANS_LIT_TEX_VERTEX vertex[4];
+    TransformedTexture1Vertex vertex[4];
 
     int32_t x;
     int32_t y;
@@ -310,8 +302,8 @@ void W3DShaderManager::Draw_Viewport(unsigned int color)
     vertex[2].color = color;
     vertex[3].color = color;
 
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(_TRANS_LIT_TEX_VERTEX));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
 #endif
 }
 

--- a/src/game/client/shadermanager.cpp
+++ b/src/game/client/shadermanager.cpp
@@ -275,7 +275,7 @@ bool W3DShaderManager::Filter_Setup(FilterTypes filter, FilterModes mode)
 void W3DShaderManager::Draw_Viewport(unsigned int color)
 {
 #ifdef BUILD_WITH_D3D8
-    TransformedTexture1Vertex vertex[4];
+    VertexFormatXYZWDUV1 vertex[4];
 
     int32_t x;
     int32_t y;
@@ -302,8 +302,8 @@ void W3DShaderManager::Draw_Viewport(unsigned int color)
     vertex[2].color = color;
     vertex[3].color = color;
 
-    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(TransformedTexture1Vertex::DX8FVF);
-    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(TransformedTexture1Vertex));
+    DX8Wrapper::Get_D3D_Device8()->SetVertexShader(VertexFormatXYZWDUV1::DX8FVF);
+    DX8Wrapper::Get_D3D_Device8()->DrawPrimitiveUP(D3DPT_TRIANGLESTRIP, 2, vertex, sizeof(VertexFormatXYZWDUV1));
 #endif
 }
 

--- a/src/w3d/renderer/dx8wrapper.h
+++ b/src/w3d/renderer/dx8wrapper.h
@@ -65,6 +65,30 @@ extern uint32_t g_numberOfDx8Calls;
     ++g_numberOfDx8Calls;
 #endif
 
+#ifdef BUILD_WITH_D3D8
+struct TransformedTexture1Vertex
+{
+    static constexpr uint32_t DX8FVF = D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW;
+
+    D3DXVECTOR4 p;
+    unsigned long color;
+    float u;
+    float v;
+};
+
+struct TransformedTexture2Vertex
+{
+    static constexpr uint32_t DX8FVF = D3DFVF_TEX2 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW;
+
+    D3DXVECTOR4 p;
+    unsigned long color;
+    float u1;
+    float v1;
+    float u2;
+    float v2;
+};
+#endif
+
 struct RenderStateStruct
 {
     ShaderClass shader;

--- a/src/w3d/renderer/dx8wrapper.h
+++ b/src/w3d/renderer/dx8wrapper.h
@@ -70,18 +70,24 @@ struct VertexFormatXYZWDUV1
 {
     static constexpr uint32_t DX8FVF = D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW;
 
-    D3DXVECTOR4 p;
-    unsigned long color;
+    float x;
+    float y;
+    float z;
+    float w;
+    uint32_t color;
     float u;
     float v;
 };
 
-struct VertexFormatXYZDUV2
+struct VertexFormatXYZWDUV2
 {
     static constexpr uint32_t DX8FVF = D3DFVF_TEX2 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW;
 
-    D3DXVECTOR4 p;
-    unsigned long color;
+    float x;
+    float y;
+    float z;
+    float w;
+    uint32_t color;
     float u1;
     float v1;
     float u2;

--- a/src/w3d/renderer/dx8wrapper.h
+++ b/src/w3d/renderer/dx8wrapper.h
@@ -66,7 +66,7 @@ extern uint32_t g_numberOfDx8Calls;
 #endif
 
 #ifdef BUILD_WITH_D3D8
-struct TransformedTexture1Vertex
+struct VertexFormatXYZWDUV1
 {
     static constexpr uint32_t DX8FVF = D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW;
 
@@ -76,7 +76,7 @@ struct TransformedTexture1Vertex
     float v;
 };
 
-struct TransformedTexture2Vertex
+struct VertexFormatXYZDUV2
 {
     static constexpr uint32_t DX8FVF = D3DFVF_TEX2 | D3DFVF_DIFFUSE | D3DFVF_XYZRHW;
 


### PR DESCRIPTION
_TRANS_LIT_TEX_VERTEX was a problem child in the clang-tidy PR so had a closer look at it. We have two different instances of this in different forms in the codebase. I've created TransformedTexture1Vertex and TransformedTexture2Vertex to replace the two different types. I've also extracted out the D3DFVF values for each struct so its clear why they are being set.