### PR TITLE
Allow captnlog to log without printing file name if so desired 2

### DIFF
--- a/deps/captnlog/src/captainslog.h
+++ b/deps/captnlog/src/captainslog.h
@@ -37,7 +37,7 @@ extern "C" {
 /* Conditionally define the function like macros for logging levels, allows only certain logging to be compiled into client
  * program. */
 #if LOGLEVEL_TRACE <= LOGGING_LEVEL
-#define captainslog_trace(x, ...) captainslog_log(LOGLEVEL_TRACE, __FILE__, __LINE__, ##__VA_ARGS__)
+#define captainslog_trace(x, ...) captainslog_log(LOGLEVEL_TRACE, __FILE__, __LINE__, x, ##__VA_ARGS__)
 #else
 #define captainslog_trace(x, ...) ((void)0)
 #endif
@@ -73,15 +73,35 @@ extern "C" {
 #endif
 
 /**
+ * Logging system settings
+ *
+ * @param level Determines the max level of logging that will be carried out.
+ * @param filename Sets the filename to log to, if this is NULL or the file cannot be opened, file logging is disabled.
+ * @param console Does the logging system print to stderr?
+ * @param syslog Does the logging system log to either syslog or the windows system logs?
+ * @param print_time Does the logging system print the time on a log line?
+ * @param print_file Does the logging system print the file on a log line?
+ */
+typedef struct captains_settings_s
+{
+    int level;
+    const char *filename;
+    bool console;
+    bool syslog;
+    bool print_time;
+    bool print_file;
+} captains_settings_t;
+
+/**
  * Logging control functions.
  */
 #if LOGGING_LEVEL == LOGLEVEL_NONE
-#define captainslog_init(level, filename, console, syslog, print_time) ((void)0)
+#define captainslog_init(settings) ((void)0)
 #define captainslog_log(level, file, line, format, ...) ((void)0)
 #define captainslog_line(fmt, ...) ((void)0)
 #define captainslog_deinit() ((void)0)
 #else
-void captainslog_init(int level, const char *filename, bool console, bool syslog, bool print_time);
+void captainslog_init(const captains_settings_t *settings);
 void captainslog_log(int level, const char *file, int line, const char *fmt, ...);
 void captainslog_line(const char *fmt, ...);
 void captainslog_deinit();

--- a/deps/captnlog/src/captainslog.h
+++ b/deps/captnlog/src/captainslog.h
@@ -26,15 +26,16 @@ extern "C" {
 #define LOGGING_LEVEL 5
 #endif
 
-#define LOGLEVEL_NONE  0
+#define LOGLEVEL_NONE 0
 #define LOGLEVEL_FATAL 1
 #define LOGLEVEL_ERROR 2
-#define LOGLEVEL_WARN  3
-#define LOGLEVEL_INFO  4
+#define LOGLEVEL_WARN 3
+#define LOGLEVEL_INFO 4
 #define LOGLEVEL_DEBUG 5
 #define LOGLEVEL_TRACE 6
 
-/* Conditionally define the function like macros for logging levels, allows only certain logging to be compiled into client program. */
+/* Conditionally define the function like macros for logging levels, allows only certain logging to be compiled into client
+ * program. */
 #if LOGLEVEL_TRACE <= LOGGING_LEVEL
 #define captainslog_trace(x, ...) captainslog_log(LOGLEVEL_TRACE, __FILE__, __LINE__, ##__VA_ARGS__)
 #else
@@ -58,7 +59,7 @@ extern "C" {
 #else
 #define captainslog_warn(x, ...) ((void)0)
 #endif
-  
+
 #if LOGLEVEL_ERROR <= LOGGING_LEVEL
 #define captainslog_error(x, ...) captainslog_log(LOGLEVEL_ERROR, __FILE__, __LINE__, x, ##__VA_ARGS__)
 #else
@@ -107,26 +108,26 @@ void captainslog_deinit();
 /* If we have GCC or compiler that tries to be compatible, use GCC inline assembly. */
 #elif defined __GNUC__ || defined __clang__
 #if defined(__i386__) || defined(__x86_64__)
-    trap_inline void captainslog_debugtrap(void)
-    {
-        __asm__ volatile("int $0x03");
+trap_inline void captainslog_debugtrap(void)
+{
+    __asm__ volatile("int $0x03");
 }
 #elif defined(__arm__)
-    trap_inline void captainslog_debugtrap(void)
-    {
-        __asm__ volatile("bkpt #3");
-    }
+trap_inline void captainslog_debugtrap(void)
+{
+    __asm__ volatile("bkpt #3");
+}
 #elif defined(__aarch64__)
-    trap_inline void captainslog_debugtrap(void)
-    {
-        /* same values as used by msvc __debugbreak on arm64 */
-        __asm__ volatile("brk #0xF000");
-    }
+trap_inline void captainslog_debugtrap(void)
+{
+    /* same values as used by msvc __debugbreak on arm64 */
+    __asm__ volatile("brk #0xF000");
+}
 #elif defined(__powerpc__)
-    trap_inline void captainslog_debugtrap(void)
-    {
-        __asm__ volatile(".4byte 0x7d821008");
-    }
+trap_inline void captainslog_debugtrap(void)
+{
+    __asm__ volatile(".4byte 0x7d821008");
+}
 #else
 #error captainslog_debugtrap not currently supported on this processor platform, see captntrap.h
 #endif /* CPU architectures on GCC like compilers */
@@ -150,9 +151,8 @@ void captainslog_debugtrap(void);
             static volatile bool _ignore_assert = false; \
             static volatile bool _break = false; \
             if (!_ignore_assert) { \
-                captainslog_fatal( \
-                    "ASSERTION FAILED!\n" \
-                    "  Function:%s\n  Expression:%s\n\n", \
+                captainslog_fatal("ASSERTION FAILED!\n" \
+                                  "  Function:%s\n  Expression:%s\n\n", \
                     __CURRENT_FUNCTION__, \
                     #exp); \
                 captainslog_assertfail( \
@@ -170,9 +170,8 @@ void captainslog_debugtrap(void);
             static volatile bool _ignore_assert = false; \
             static volatile bool _break = false; \
             if (!_ignore_assert) { \
-                captainslog_fatal( \
-                    "ASSERTION FAILED!\n" \
-                    "  Function:%s\n  Expression:%s\n\n", \
+                captainslog_fatal("ASSERTION FAILED!\n" \
+                                  "  Function:%s\n  Expression:%s\n\n", \
                     __CURRENT_FUNCTION__, \
                     #exp); \
                 captainslog_assertfail( \
@@ -189,13 +188,11 @@ void captainslog_debugtrap(void);
             static volatile bool _ignore_assert = false; \
             static volatile bool _break = false; \
             if (!_ignore_assert) { \
-                captainslog_fatal( \
-                    "ASSERTION FAILED!\n" \
-                    "  Function:%s\n  Expression:%s\n\n", \
+                captainslog_fatal("ASSERTION FAILED!\n" \
+                                  "  Function:%s\n  Expression:%s\n\n", \
                     __CURRENT_FUNCTION__, \
                     #exp); \
-                captainslog_assertfail( \
-                    #exp, __FILE__, __LINE__, __CURRENT_FUNCTION__, &_ignore_assert, &_break, NULL); \
+                captainslog_assertfail(#exp, __FILE__, __LINE__, __CURRENT_FUNCTION__, &_ignore_assert, &_break, NULL); \
             } \
             if (_break) { \
                 captainslog_debugtrap(); \
@@ -223,8 +220,14 @@ void captainslog_debugtrap(void);
 #define captainslog_ignoreasserts(ignore) ((void)0)
 #define captainslog_allowpopups(allow) ((void)0)
 #else
-void captainslog_assertfail(const char *expr, const char *file, int line, const char *func, volatile bool *ignore,
-        volatile bool *allow_break, const char *msg, ...);
+void captainslog_assertfail(const char *expr,
+    const char *file,
+    int line,
+    const char *func,
+    volatile bool *ignore,
+    volatile bool *allow_break,
+    const char *msg,
+    ...);
 void captainslog_ignoreasserts(bool ignore);
 void captainslog_allowpopups(bool allow);
 #endif

--- a/deps/captnlog/src/captnlog.c
+++ b/deps/captnlog/src/captnlog.c
@@ -14,8 +14,8 @@
  */
 #include "captainslog.h"
 #include <stdarg.h>
-#include <stdlib.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <time.h>
 
@@ -40,7 +40,7 @@ static struct
     bool initialized;
 } g_state;
 
-static const char *levels[] = {"NONE", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE"};
+static const char *levels[] = { "NONE", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE" };
 
 static void lock()
 {

--- a/src/game/main.cpp
+++ b/src/game/main.cpp
@@ -331,7 +331,12 @@ int main(int argc, char **argv)
     rename(curbuf, prevbuf);
     logfile = curbuf;
 #endif
-    captainslog_init(LOGLEVEL_DEBUG, logfile, true, false, false);
+    captains_settings_t captains_settings = { 0 };
+    captains_settings.level = LOGLEVEL_DEBUG;
+    captains_settings.filename = logfile;
+    captains_settings.console = true;
+    captains_settings.print_file = true;
+    captainslog_init(&captains_settings);
 
     // Assign some critical sections for code sensitive to threaded calls.
     g_unicodeStringCriticalSection = &critSec1;


### PR DESCRIPTION
This Merge has 2 commits. The first one is just updating the formatting of the edited files to avoid format validation errors on test build step.