### PR TITLE
Move definition of std::clamp into STL Port

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,7 +42,7 @@ if(MSVC)
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W3 /wd4244 /wd4800")
 endif()
 
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 # We don't support in tree builds, so help people make the right choice.
 if (CMAKE_BINARY_DIR STREQUAL CMAKE_SOURCE_DIR)

--- a/deps/baseconfig/src/always.h
+++ b/deps/baseconfig/src/always.h
@@ -73,9 +73,7 @@
 #define strtrim ex_strtrim
 #endif
 
-#if !defined HAVE_STD_CLAMP && defined __cplusplus
-#include <functional>
-
+#if defined __cplusplus
 template<size_t Size> size_t strlcat_tpl(char (&dst)[Size], const char *src)
 {
     return strlcat(dst, src, Size);
@@ -95,19 +93,6 @@ template<size_t Size> size_t u_strlcat_tpl(unichar_t (&dst)[Size], const unichar
 {
     return u_strlcat(dst, src, Size);
 }
-
-namespace std
-{
-template<class T, class Compare> constexpr const T &clamp(const T &v, const T &lo, const T &hi, Compare comp)
-{
-    return comp(v, lo) ? lo : comp(hi, v) ? hi : v;
-}
-
-template<class T> constexpr const T &clamp(const T &v, const T &lo, const T &hi)
-{
-    return clamp(v, lo, hi, std::less<T>());
-}
-} // namespace std
 #endif
 
 #endif // BASE_ALWAYS_H

--- a/deps/stlport/stl/_algo.h
+++ b/deps/stlport/stl/_algo.h
@@ -584,6 +584,20 @@ void inplace_merge(_BidirectionalIter __first,
 		   _BidirectionalIter __middle,
 		   _BidirectionalIter __last, _Compare __comp);
 
+
+// compare functions.
+
+
+template<class _Tp, class _Compare> constexpr const _Tp &clamp(const _Tp &__v, const _Tp &__lo, const _Tp &__hi, _Compare __comp)
+{
+    return __comp(__v, __lo) ? __lo : __comp(__hi, __v) ? __hi : __v;
+}
+
+template<class _Tp> constexpr const _Tp &clamp(const _Tp &__v, const _Tp &__lo, const _Tp &__hi)
+{
+    return clamp(__v, __lo, __hi, less<_Tp>());
+}
+
 // Set algorithms: includes, set_union, set_intersection, set_difference,
 // set_symmetric_difference.  All of these algorithms have the precondition
 // that their input ranges are sorted and the postcondition that their output

--- a/deps/stlport/stl/_algo.h
+++ b/deps/stlport/stl/_algo.h
@@ -12,6 +12,9 @@
  * Copyright (c) 1999 
  * Boris Fomitchev
  *
+ * Copyright (c) 2022
+ * Thyme Project - Code has been modified to add 'clamp' function from C++ 2017
+ * 
  * This material is provided "as is", with absolutely no warranty expressed
  * or implied. Any use is at your own risk.
  *
@@ -585,8 +588,7 @@ void inplace_merge(_BidirectionalIter __first,
 		   _BidirectionalIter __last, _Compare __comp);
 
 
-// compare functions.
-
+// **MODIFICATION C++17** clamp functions.
 
 template<class _Tp, class _Compare> constexpr const _Tp &clamp(const _Tp &__v, const _Tp &__lo, const _Tp &__hi, _Compare __comp)
 {

--- a/src/game/client/view.cpp
+++ b/src/game/client/view.cpp
@@ -16,6 +16,7 @@
 #include "view.h"
 #include "globaldata.h"
 #include "xfer.h"
+#include <algorithm>
 
 #ifndef GAME_DLL
 uint32_t View::s_idNext = 1;

--- a/src/w3d/math/colmathobbtri.cpp
+++ b/src/w3d/math/colmathobbtri.cpp
@@ -16,6 +16,7 @@
 #include "obbox.h"
 #include "tri.h"
 #include "vector3.h"
+#include <algorithm>
 
 struct OBBTCollisionStruct
 {

--- a/src/w3d/math/vp.cpp
+++ b/src/w3d/math/vp.cpp
@@ -19,6 +19,7 @@
 #include "vector2.h"
 #include "vector3.h"
 #include "vector4.h"
+#include <algorithm>
 #include <cstring>
 
 using std::memcpy;

--- a/src/w3d/renderer/dx8wrapper.h
+++ b/src/w3d/renderer/dx8wrapper.h
@@ -29,6 +29,7 @@
 #include "vertmaterial.h"
 #include "w3dtypes.h"
 #include "wwstring.h"
+#include <algorithm>
 #include <captainslog.h>
 class SurfaceClass;
 class DynamicVBAccessClass;


### PR DESCRIPTION
https://en.cppreference.com/w/cpp/algorithm/clamp

Clamp is located in the algorithm header. The way STL Port works _algo.h is the equivalent header.

This also bumps the min c++ version to 17 as that is the version with std::clamp.