### PR TITLE
Fix incorrect shader reference in seglinerenderer.cpp

### DIFF
--- a/src/w3d/renderer/seglinerenderer.cpp
+++ b/src/w3d/renderer/seglinerenderer.cpp
@@ -741,7 +741,7 @@ void SegLineRendererClass::Render(RenderInfoClass &rinfo,
             shader.Set_Primary_Gradient(ShaderClass::GRADIENT_DISABLE);
             material = VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_NODIFFUSE);
         } else {
-            shader.Set_Primary_Gradient(ShaderClass::GRADIENT_MAX);
+            shader.Set_Primary_Gradient(ShaderClass::GRADIENT_MODULATE);
             material = VertexMaterialClass::Get_Preset(VertexMaterialClass::PRELIT_DIFFUSE);
         }
 


### PR DESCRIPTION
`GRADIENT_MAX` is an internal enum. This line should, based on the context of the code, instead be using `GRADIENT_MODULATE` as it is a default primary gradient option that renders color multiplied by ambient and diffuse lighting.