### PR TITLE
Implement StandardFile with buffered IO to allow speed up File operations where necessary

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -229,6 +229,7 @@ set(GAMEENGINE_SRC
     game/network/networkutil.cpp
     platform/fpusetting.cpp
     platform/input/win32mouse.cpp
+    platform/standardfile.cpp
     platform/w3dfilesystem.cpp
     platform/w3dfunctionlexicon.cpp
     platform/win32bigfile.cpp

--- a/src/game/common/system/file.cpp
+++ b/src/game/common/system/file.cpp
@@ -13,7 +13,38 @@
  *            LICENSE
  */
 #include "file.h"
+#include <algorithm>
 #include <cstdio>
+
+namespace Thyme
+{
+static_assert(File::FileMode::LASTMODE <= 0x10000, "Not enough room to encode buffer size");
+
+// Buffer size is encoded into the upper 16 bits of target integer value.
+// 0xFFFF0000
+//   ^^^^ buffer size
+// The encoded value itself is scaled up/down by 64 (6 bit shift),
+// therefore giving an effective range of 1 * 64 to 0xFFFF * 64.
+
+constexpr unsigned int LOCATOR = 16;
+constexpr unsigned int SCALER = 6;
+
+int Encode_Buffered_File_Mode(int mode, int buffer_size)
+{
+    buffer_size = std::clamp(buffer_size, (1 << SCALER), (0xFFFF << SCALER));
+
+    return mode | File::FileMode::BUFFERED | (static_cast<unsigned int>(buffer_size) >> SCALER << LOCATOR);
+}
+
+bool Decode_Buffered_File_Mode(int mode, int &buffer_size)
+{
+    if (mode & File::FileMode::BUFFERED) {
+        buffer_size = static_cast<unsigned int>(mode) >> LOCATOR << SCALER;
+        return true;
+    }
+    return false;
+}
+} // namespace Thyme
 
 File::~File()
 {
@@ -45,6 +76,7 @@ bool File::Open(const char *filename, int mode)
         open_mode = mode | READ;
     }
 
+    // Clear file if not read or appended.
     if ((mode & (READ | APPEND)) == 0) {
         open_mode |= TRUNCATE;
     }

--- a/src/game/common/system/file.h
+++ b/src/game/common/system/file.h
@@ -26,6 +26,18 @@ struct FileInfo
     int write_time_low;
 };
 
+namespace Thyme
+{
+// Thyme specific
+
+// Returns integer of given mode and BUFFERED flag and encoded buffer size.
+// Buffer size min: 0, max: 4194240, in 64 byte increments.
+int Encode_Buffered_File_Mode(int mode, int buffer_size);
+
+// Decodes buffer size from given mode.
+bool Decode_Buffered_File_Mode(int mode, int &buffer_size);
+} // namespace Thyme
+
 class File : public MemoryPoolObject
 {
     IMPLEMENT_ABSTRACT_POOL(File);
@@ -48,6 +60,11 @@ public:
         TEXT = 0x20,
         BINARY = 0x40,
         STREAMING = 0x100,
+        BUFFERED = 0x8000, // Thyme specific. When set, opens file with buffered read & write as opposed to instant file IO.
+                           // Optionally, the high 16 bits of FileMode can be used to specify the buffer size, otherwise uses
+                           // default buffer size.
+
+        LASTMODE, // Just marks the enum end.
     };
 
 protected:

--- a/src/game/common/system/gamememoryinit.cpp
+++ b/src/game/common/system/gamememoryinit.cpp
@@ -648,6 +648,7 @@ static PoolSizeRec UserMemoryPools[] = {
     { "ThumbnailManagerClass", 32, 32 },
     { "SmudgeSet", 32, 32 },
     { "Smudge", 128, 32 },
+    { "StandardFile", 32, 32 }, // Thyme specific.
     { nullptr, 0, 0 } // Last entry always null.
 };
 

--- a/src/platform/standardfile.cpp
+++ b/src/platform/standardfile.cpp
@@ -1,0 +1,291 @@
+/**
+ * @file
+ *
+ * @author OmniBlade
+ * @author xezon
+ *
+ * @brief Same as Win32LocalFile, but with buffered read and write. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "standardfile.h"
+#include <cctype>
+#include <fcntl.h>
+
+namespace Thyme
+{
+
+StandardFile::StandardFile() : m_file(nullptr) {}
+
+StandardFile::~StandardFile()
+{
+    if (m_file != nullptr) {
+        fclose(m_file);
+        m_file = nullptr;
+        --s_totalOpen;
+    }
+
+    File::Close();
+}
+
+bool StandardFile::Open(const char *filename, int mode)
+{
+    int buffer_size;
+
+    if (!Decode_Buffered_File_Mode(mode, buffer_size)) {
+        return false;
+    }
+
+    if (!File::Open(filename, mode)) {
+        return false;
+    }
+
+    // r    open for reading (The file must exist)
+    // w    open for writing (creates file if it doesn't exist). Deletes content and overwrites the file.
+    // a    open for appending (creates file if it doesn't exist).
+    // r+   open for reading and writing (The file must exist).
+    // w+   open for reading and writing.
+    //      If file exists deletes content and overwrites the file, otherwise creates an empty new file.
+    // a+   open for reading and writing (append if file exists).
+
+    Utf8String modestr;
+
+    if ((m_openMode & FileMode::APPEND) != 0) {
+        modestr.Concat('a');
+        if ((m_openMode & FileMode::READ) != 0) {
+            modestr.Concat('+');
+        }
+    } else if ((m_openMode & FileMode::CREATE) != 0) {
+        if ((m_openMode & FileMode::READ) != 0) {
+            modestr.Concat("w+");
+        } else {
+            modestr.Concat('w');
+        }
+    } else if ((m_openMode & FileMode::WRITE) != 0) {
+        if ((m_openMode & FileMode::READ) != 0) {
+            modestr.Concat("r+");
+        } else {
+            modestr.Concat('w');
+        }
+    } else if ((m_openMode & FileMode::READ) != 0) {
+        modestr.Concat('r');
+    } else {
+        return false;
+    }
+
+    if ((m_openMode & FileMode::BINARY) != 0) {
+        modestr.Concat('b');
+    }
+
+    // #TODO Treat filename as UTF8 and call wide char version of fopen?
+
+    m_file = fopen(filename, modestr.Str());
+
+    if (m_file == nullptr) {
+        return false;
+    }
+
+    ++s_totalOpen;
+
+    if ((m_openMode & FileMode::APPEND) != 0 && Seek(0, SeekMode::END) < 0) {
+        Close();
+        return false;
+    }
+
+    if (buffer_size != 0) {
+        if (0 != setvbuf(m_file, nullptr, _IOFBF, buffer_size)) {
+            captainslog_dbgassert(0, "File buffer could not be set");
+        }
+    } else {
+        // Uses default buffer size - likely 512.
+    }
+
+    return true;
+}
+
+int StandardFile::Read(void *dst, int bytes)
+{
+    if (!m_access) {
+        return -1;
+    }
+
+    if (dst != nullptr) {
+        return fread(dst, 1, bytes, m_file);
+    } else {
+        Seek(bytes, SeekMode::CURRENT);
+    }
+
+    return bytes;
+}
+
+int StandardFile::Write(void const *src, int bytes)
+{
+    if (!m_access || src == nullptr) {
+        return -1;
+    }
+
+    return fwrite(src, 1, bytes, m_file);
+}
+
+int StandardFile::Seek(int offset, File::SeekMode mode)
+{
+    int fmode;
+    switch (mode) {
+        case SeekMode::START:
+            fmode = SEEK_SET;
+            break;
+        case SeekMode::CURRENT:
+            fmode = SEEK_CUR;
+            break;
+        case SeekMode::END:
+            fmode = SEEK_END;
+            break;
+        default:
+            return -1;
+    }
+
+    return fseek(m_file, (long)offset, fmode);
+}
+
+void StandardFile::Next_Line(char *dst, int bytes)
+{
+    captainslog_trace("Seeking getting next line from StandardFile %s.", m_filename.Str());
+
+    int i;
+
+    for (i = 0; i < bytes - 1; ++i) {
+        char tmp;
+        size_t ret = fread(&tmp, sizeof(tmp), 1, m_file);
+
+        if (ret == 0 || tmp == '\n') {
+            break;
+        }
+
+        if (dst != nullptr) {
+            dst[i] = tmp;
+        }
+    }
+
+    if (dst != nullptr) {
+        dst[i] = '\0';
+    }
+}
+
+bool StandardFile::Scan_Int(int &integer)
+{
+    captainslog_trace("Scanning Int from StandardFile %s.", m_filename.Str());
+    char tmp;
+    Utf8String number;
+
+    integer = 0;
+
+    // Loop to find the first numeric character.
+    do {
+        if (fread(&tmp, sizeof(tmp), 1, m_file) == 0) {
+            return false;
+        }
+    } while (!isdigit(tmp) && tmp != '-');
+
+    // Build up our string of numeric characters
+    while (true) {
+        number.Concat(tmp);
+
+        if (fread(&tmp, sizeof(tmp), 1, m_file) == 0) {
+            break;
+        }
+
+        if (!isdigit(tmp)) {
+            // If we read a byte, seek back that byte for the next read
+            // as we are done with the current number.
+            Seek(-1, SeekMode::CURRENT);
+
+            break;
+        }
+    }
+
+    integer = atoi(number.Str());
+
+    return true;
+}
+
+bool StandardFile::Scan_Real(float &real)
+{
+    captainslog_trace("Scanning Real from StandardFile %s.", m_filename.Str());
+    char tmp;
+    Utf8String number;
+
+    real = 0.0f;
+
+    // Loop to find the first numeric character.
+    do {
+        if (fread(&tmp, sizeof(tmp), 1, m_file) == 0) {
+            return false;
+        }
+    } while (!isdigit(tmp) && tmp != '-' && tmp != '.');
+
+    // Build up our string of numeric characters
+    bool have_point = false;
+
+    while (true) {
+        number.Concat(tmp);
+
+        if (tmp == '.') {
+            have_point = true;
+        }
+
+        if (fread(&tmp, sizeof(tmp), 1, m_file) == 0) {
+            break;
+        }
+
+        if (!isdigit(tmp) && (tmp != '.' || have_point)) {
+            // If we read a byte, seek back that byte for the next read
+            // as we are done with the current number.
+            Seek(-1, SeekMode::CURRENT);
+
+            break;
+        }
+    }
+
+    real = atof(number.Str());
+
+    return true;
+}
+
+bool StandardFile::Scan_String(Utf8String &string)
+{
+    captainslog_trace("Scanning String from StandardFile %s.", m_filename.Str());
+    char tmp;
+    string.Clear();
+
+    // Loop to find the non-space character.
+    do {
+        if (fread(&tmp, sizeof(tmp), 1, m_file) == 0) {
+            return false;
+        }
+    } while (isspace(tmp));
+
+    while (true) {
+        string.Concat(tmp);
+
+        if (fread(&tmp, sizeof(tmp), 1, m_file) == 0) {
+            break;
+        }
+
+        if (isspace(tmp)) {
+            // If we read a byte, seek back that byte for the next read
+            // as we are done with the current number.
+            Seek(-1, SeekMode::CURRENT);
+
+            break;
+        }
+    }
+
+    return true;
+}
+
+} // namespace Thyme

--- a/src/platform/standardfile.h
+++ b/src/platform/standardfile.h
@@ -1,0 +1,52 @@
+/**
+ * @file
+ *
+ * @author OmniBlade
+ * @author xezon
+ *
+ * @brief Same as Win32LocalFile, but with buffered read and write. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "localfile.h"
+#include <cstdio>
+
+class Win32LocalFileSystem;
+
+namespace Thyme
+{
+
+class StandardFile : public LocalFile
+{
+    IMPLEMENT_POOL(StandardFile);
+
+    friend class ::Win32LocalFileSystem;
+
+protected:
+    virtual ~StandardFile() override;
+
+private:
+    StandardFile();
+
+public:
+    virtual bool Open(const char *filename, int mode) override;
+    virtual int Read(void *dst, int bytes) override;
+    virtual int Write(void const *src, int bytes) override;
+    virtual int Seek(int offset, File::SeekMode mode) override;
+    virtual void Next_Line(char *dst, int bytes) override;
+    virtual bool Scan_Int(int &integer) override;
+    virtual bool Scan_Real(float &real) override;
+    virtual bool Scan_String(Utf8String &string) override;
+
+private:
+    FILE *m_file;
+};
+
+} // namespace Thyme

--- a/src/platform/win32localfilesystem.cpp
+++ b/src/platform/win32localfilesystem.cpp
@@ -13,6 +13,7 @@
  *            LICENSE
  */
 #include "win32localfilesystem.h"
+#include "standardfile.h"
 #include "win32localfile.h"
 
 // Headers needed for posix open, close, read... etc.
@@ -29,11 +30,17 @@
 
 File *Win32LocalFileSystem::Open_File(const char *filename, int mode)
 {
-    if (strlen(filename) <= 0) {
+    if (filename == nullptr || *filename == '\0') {
         return nullptr;
     }
 
-    Win32LocalFile *file = NEW_POOL_OBJ(Win32LocalFile);
+    File *file;
+
+    if (mode & File::BUFFERED) {
+        file = new Thyme::StandardFile;
+    } else {
+        file = new Win32LocalFile;
+    }
 
     // If we need to write a file, ensure the needed directory exists.
     if ((mode & File::WRITE) != 0) {


### PR DESCRIPTION
`Win32BufferedFile` is a copy of `Win32LocalFile` for the most part. Instead of read/write it uses the more sophisticated fread/fwrite. This allows it to make use of the buffered file IO. Custom buffer size can be controlled by encoding size value into `filemode` integer.

Usage:

before:
```c++
File *file = g_theFileSystem->Open("myfile.aaa", File::READ | File::BINARY);
```

after:
```c++
File *file = g_theFileSystem->Open("myfile.aaa", File::READ | File::BINARY | File::BUFFERED);
```

with encoded custom buffer size (here: 1024)
```c++
File *file = g_theFileSystem->Open("myfile.aaa", Thyme::Encode_Buffered_File_Mode(File::READ | File::BINARY, 1024));
```

Closes #304