### PR TITLE
Remove rts::equal_to and use std::equal_to. Switch rts::hash impl

### DIFF
--- a/src/game/client/system/particlesystem/particlesysmanager.h
+++ b/src/game/client/system/particlesystem/particlesysmanager.h
@@ -36,10 +36,10 @@ class RenderInfoClass;
 class INI;
 
 #ifdef THYME_USE_STLPORT
-typedef std::hash_map<const Utf8String, ParticleSystemTemplate *, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
+typedef std::hash_map<const Utf8String, ParticleSystemTemplate *, rts::hash<Utf8String>, std::equal_to<Utf8String>>
     partsystempmap_t;
 #else
-typedef std::unordered_map<const Utf8String, ParticleSystemTemplate *, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
+typedef std::unordered_map<const Utf8String, ParticleSystemTemplate *, rts::hash<Utf8String>, std::equal_to<Utf8String>>
     partsystempmap_t;
 #endif
 

--- a/src/game/common/audio/audiomanager.h
+++ b/src/game/common/audio/audiomanager.h
@@ -62,9 +62,9 @@ class MusicManager;
 class SoundManager;
 
 #ifdef THYME_USE_STLPORT
-typedef std::hash_map<const Utf8String, AudioEventInfo *, rts::hash<Utf8String>, rts::equal_to<Utf8String>> audioinfomap_t;
+typedef std::hash_map<const Utf8String, AudioEventInfo *, rts::hash<Utf8String>, std::equal_to<Utf8String>> audioinfomap_t;
 #else
-typedef std::unordered_map<const Utf8String, AudioEventInfo *, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
+typedef std::unordered_map<const Utf8String, AudioEventInfo *, rts::hash<Utf8String>, std::equal_to<Utf8String>>
     audioinfomap_t;
 #endif
 

--- a/src/game/common/thing/thingfactory.h
+++ b/src/game/common/thing/thingfactory.h
@@ -55,9 +55,9 @@ private:
     ThingTemplate *m_firstTemplate;
     unsigned short m_nextTemplateID;
 #ifdef THYME_USE_STLPORT
-    std::hash_map<const Utf8String, ThingTemplate *, rts::hash<Utf8String>, rts::equal_to<Utf8String>> m_templateMap;
+    std::hash_map<const Utf8String, ThingTemplate *, rts::hash<Utf8String>, std::equal_to<Utf8String>> m_templateMap;
 #else
-    std::unordered_map<const Utf8String, ThingTemplate *, rts::hash<Utf8String>, rts::equal_to<Utf8String>> m_templateMap;
+    std::unordered_map<const Utf8String, ThingTemplate *, rts::hash<Utf8String>, std::equal_to<Utf8String>> m_templateMap;
 #endif
 };
 

--- a/src/game/logic/system/gamelogic.h
+++ b/src/game/logic/system/gamelogic.h
@@ -206,13 +206,13 @@ public:
 
 private:
 #ifdef THYME_USE_STLPORT
-    std::hash_map<Utf8String, BuildableStatus, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
+    std::hash_map<Utf8String, BuildableStatus, rts::hash<Utf8String>, std::equal_to<Utf8String>>
         m_thingTemplateBuildableOverrides;
-    std::hash_map<Utf8String, CommandButton const *, rts::hash<Utf8String>, rts::equal_to<Utf8String>> m_controlBarOverrides;
+    std::hash_map<Utf8String, CommandButton const *, rts::hash<Utf8String>, std::equal_to<Utf8String>> m_controlBarOverrides;
 #else
-    std::unordered_map<Utf8String, BuildableStatus, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
+    std::unordered_map<Utf8String, BuildableStatus, rts::hash<Utf8String>, std::equal_to<Utf8String>>
         m_thingTemplateBuildableOverrides;
-    std::unordered_map<Utf8String, CommandButton const *, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
+    std::unordered_map<Utf8String, CommandButton const *, rts::hash<Utf8String>, std::equal_to<Utf8String>>
         m_controlBarOverrides;
 #endif
     float m_width;

--- a/src/game/rtsutils.h
+++ b/src/game/rtsutils.h
@@ -15,6 +15,7 @@
 #pragma once
 
 #include "always.h"
+#include "asciistring.h"
 #include "endiantype.h"
 #include <ctime>
 
@@ -58,14 +59,14 @@ template<typename T> struct less_than_nocase
     bool operator()(const T &left, const T &right) const { return (left.Compare_No_Case(right) < 0); }
 };
 
-template<typename T> struct equal_to
-{
-    bool operator()(const T &left, const T &right) const { return (left.Compare(right) == 0); }
-};
-
 template<typename T> struct hash
 {
-    size_t operator()(const T &object) const
+    size_t operator()(const T &object) const { return static_cast<size_t>(object); }
+};
+
+template<> struct hash<Utf8String>
+{
+    size_t operator()(const Utf8String &object) const
     {
         const char *c = reinterpret_cast<const char *>(object.Str());
         size_t hash = 0;

--- a/src/platform/audio/milesaudiofilecache.h
+++ b/src/platform/audio/milesaudiofilecache.h
@@ -40,9 +40,9 @@ struct OpenAudioFile
 };
 
 #ifdef THYME_USE_STLPORT
-typedef std::hash_map<const Utf8String, OpenAudioFile, rts::hash<Utf8String>, rts::equal_to<Utf8String>> audiocachemap_t;
+typedef std::hash_map<const Utf8String, OpenAudioFile, rts::hash<Utf8String>, std::equal_to<Utf8String>> audiocachemap_t;
 #else
-typedef std::unordered_map<const Utf8String, OpenAudioFile, rts::hash<Utf8String>, rts::equal_to<Utf8String>>
+typedef std::unordered_map<const Utf8String, OpenAudioFile, rts::hash<Utf8String>, std::equal_to<Utf8String>>
     audiocachemap_t;
 #endif
 


### PR DESCRIPTION
`std::equal_to` is identical to `rts::equal_to` so I've removed it. Utf8String has an `==operator` that uses `Compare`.
I've swapped around the hash impl so that it can be used with any enums (used in #307).