### PR TITLE
Fix crash in LaserUpdate::Update_Start_Pos

### DIFF
--- a/src/game/logic/object/update/laserupdate.cpp
+++ b/src/game/logic/object/update/laserupdate.cpp
@@ -310,13 +310,13 @@ void LaserUpdate::Update_Start_Pos()
                 m_startPos.x = m.Get_X_Translation();
                 m_startPos.y = m.Get_Y_Translation();
                 m_startPos.z = m.Get_Z_Translation();
+            } else {
+                m_startPos = *drawable->Get_Position();
             }
-        } else {
-            m_startPos = *drawable->Get_Position();
-        }
 
-        if (!(m_startPos == oldpos)) {
-            m_dirty = true;
+            if (!(m_startPos == oldpos)) {
+                m_dirty = true;
+            }
         }
     }
 }


### PR DESCRIPTION
Not 100% this is correct as I have not seen code, but logically this looks right to begin with.