### PR TITLE
Improve game memory pool setup

### DIFF
--- a/src/game/logic/object/update/clientupdatemodule.h
+++ b/src/game/logic/object/update/clientupdatemodule.h
@@ -19,9 +19,13 @@
 
 class ClientUpdateModule : public DrawableModule
 {
+    IMPLEMENT_ABSTRACT_POOL(ClientUpdateModule)
+
+protected:
+    virtual ~ClientUpdateModule() override {}
+
 public:
     ClientUpdateModule(Thing *thing, const ModuleData *module_data) : DrawableModule(thing, module_data) {}
-    virtual ~ClientUpdateModule() override {}
     virtual void Client_Update() = 0;
 
     static ModuleType Get_Module_Type() { return MODULE_CLIENT_UPDATE; }


### PR DESCRIPTION
Pool object can now be created with new operator. Calling `NEW_POOL_OBJ` is no longer necessary.

Using `delete MyPoolObject` does not compile. Not sure why, but it's good as is.

The reason delete operator must be used with this setup, is the fact that the virtual table is deleted before code in delete function is run. Therefore virtual function to access Memory Pool cannot be called anymore.

See this test code:
https://godbolt.org/z/qWc9TEbze

Therefore only `Delete_Instance` should be called.

An `operator delete` still needs to be there because `operator new` requires the pairing. But given the `MagicEnum`, no one practically calls it by mistake.