### PR TITLE
Improve hooker names

### DIFF
--- a/src/hooker/hooker.h
+++ b/src/hooker/hooker.h
@@ -34,8 +34,7 @@
 #define PICK_ADDRESS(a, b) (a)
 #endif
 
-template<typename T, const int size>
-class ArrayHelper
+template<typename T, const int size> class ArrayHelper
 {
 public:
     operator T *() { return (T *)this; };
@@ -49,8 +48,7 @@ protected:
     char _dummy[size * sizeof(T)];
 };
 
-template<typename T, const int y, const int x>
-class ArrayHelper2D
+template<typename T, const int y, const int x> class ArrayHelper2D
 {
 public:
     operator ArrayHelper<T, x> *() { return (ArrayHelper<T, x> *)this; };
@@ -74,14 +72,12 @@ protected:
 // #define SomeGlobalVar (Make_Global<bool>(0x00FF00FF))
 // allows you to use SomeGlobalVar as though it was a bool you declared, though
 // it will reflect the value the original exe sees at address 0x00FF00FF
-template<typename T>
-__forceinline T &Make_Global(const uintptr_t address)
+template<typename T> __forceinline T &Make_Global(const uintptr_t address)
 {
     return *reinterpret_cast<T *>(address);
 }
 
-template<typename T>
-__forceinline T *Make_Pointer(const uintptr_t address)
+template<typename T> __forceinline T *Make_Pointer(const uintptr_t address)
 {
     return reinterpret_cast<T *>(address);
 }
@@ -172,16 +168,14 @@ inline void Hook_Func(uintptr_t in, uintptr_t out)
 }
 
 // Hook regular functions and static methods.
-template<typename T>
-void Hook_Function(uintptr_t in, T out)
+template<typename T> void Hook_Function(uintptr_t in, T out)
 {
     Hook_Func(in, reinterpret_cast<uintptr_t>(out));
 }
 
 // Method pointers need funky syntax to get the underlying function address
 // hence the odd cast to void for the out pointer.
-template<typename T>
-void Hook_Method(uintptr_t in, T out)
+template<typename T> void Hook_Method(uintptr_t in, T out)
 {
     Hook_Func(in, reinterpret_cast<uintptr_t>((void *&)out));
 }
@@ -193,11 +187,11 @@ void Hook_Method(uintptr_t in, T out)
       __asm call Hook_Func     \
       __asm add esp, 8 }
 
-
 __declspec(dllexport) void StartHooking();
 __declspec(dllexport) void StopHooking();
 
 #define ARRAY_DEC(type, var, size) ArrayHelper<type, size> &var
 #define ARRAY_DEF(address, type, var, size) ArrayHelper<type, size> &var = Make_Global<ArrayHelper<type, size>>(address);
 #define ARRAY2D_DEC(type, var, x, y) ArrayHelper2D<type, x, y> &var
-#define ARRAY2D_DEF(address, type, var, x, y) ArrayHelper2D<type, x, y> &var = Make_Global<ArrayHelper2D<type, x, y>>(address);
+#define ARRAY2D_DEF(address, type, var, x, y) \
+    ArrayHelper2D<type, x, y> &var = Make_Global<ArrayHelper2D<type, x, y>>(address);

--- a/src/hooker/hooker.h
+++ b/src/hooker/hooker.h
@@ -84,31 +84,31 @@ template<typename T> __forceinline T *Make_Pointer(const uintptr_t address)
 
 // Call_Function and Call_Method can be used to call functions from the original
 // binary where they are required and a replacement hasn't been written yet.
-template<typename T, typename... Types>
-__forceinline T Call_Function(const uintptr_t address, Types... args)
+template<typename ReturnType, typename... Arguments>
+__forceinline ReturnType Call_Function(const uintptr_t address, Arguments... args)
 {
 #ifdef GAME_DLL
-    return reinterpret_cast<T(__cdecl *)(Types...)>(address)(args...);
+    return reinterpret_cast<ReturnType(__cdecl *)(Arguments...)>(address)(args...);
 #else
     return T();
 #endif
 }
 
-template<typename T, typename... Types>
-__forceinline T Call__StdCall_Function(const uintptr_t address, Types... args)
+template<typename ReturnType, typename... Arguments>
+__forceinline ReturnType Call__StdCall_Function(const uintptr_t address, Arguments... args)
 {
 #ifdef GAME_DLL
-    return reinterpret_cast<T(__stdcall *)(Types...)>(address)(args...);
+    return reinterpret_cast<ReturnType(__stdcall *)(Arguments...)>(address)(args...);
 #else
     return T();
 #endif
 }
 
-template<typename T, typename X, typename... Types>
-__forceinline T Call_Method(const uintptr_t address, X *const self, Types... args)
+template<typename ReturnType, typename ThisType, typename... Arguments>
+__forceinline ReturnType Call_Method(const uintptr_t address, ThisType *const self, Arguments... args)
 {
 #ifdef GAME_DLL
-    return reinterpret_cast<T(__thiscall *)(X *, Types...)>(address)(self, args...);
+    return reinterpret_cast<ReturnType(__thiscall *)(ThisType *, Arguments...)>(address)(self, args...);
 #else
     return T();
 #endif
@@ -116,28 +116,28 @@ __forceinline T Call_Method(const uintptr_t address, X *const self, Types... arg
 
 // These create pointers to various types of function where the return,
 // parameters and calling convention are known.
-template<typename T, typename... Types>
-__forceinline T(__cdecl *Make_Function_Ptr(const uintptr_t address))(Types...)
+template<typename ReturnType, typename... Arguments>
+__forceinline ReturnType(__cdecl *Make_Function_Ptr(const uintptr_t address))(Arguments...)
 {
-    return reinterpret_cast<T(__cdecl *)(Types...)>(address);
+    return reinterpret_cast<ReturnType(__cdecl *)(Arguments...)>(address);
 }
 
-template<typename T, typename... Types>
-__forceinline T(__stdcall *Make_StdCall_Ptr(const uintptr_t address))(Types...)
+template<typename ReturnType, typename... Arguments>
+__forceinline ReturnType(__stdcall *Make_StdCall_Ptr(const uintptr_t address))(Arguments...)
 {
-    return reinterpret_cast<T(__stdcall *)(Types...)>(address);
+    return reinterpret_cast<ReturnType(__stdcall *)(Arguments...)>(address);
 }
 
-template<typename T, typename C, typename... Types>
-__forceinline T(__thiscall *Make_Method_Ptr(const uintptr_t address))(C *, Types...)
+template<typename ReturnType, typename ThisType, typename... Arguments>
+__forceinline ReturnType(__thiscall *Make_Method_Ptr(const uintptr_t address))(ThisType *, Arguments...)
 {
-    return reinterpret_cast<T(__thiscall *)(C *, Types...)>(address);
+    return reinterpret_cast<ReturnType(__thiscall *)(ThisType *, Arguments...)>(address);
 }
 
-template<typename T, typename... Types>
-__forceinline T(__cdecl *Make_VA_Function_Ptr(const uintptr_t address))(Types..., ...)
+template<typename ReturnType, typename... Arguments>
+__forceinline ReturnType(__cdecl *Make_VA_Function_Ptr(const uintptr_t address))(Arguments..., ...)
 {
-    return reinterpret_cast<T(__cdecl *)(Types..., ...)>(address);
+    return reinterpret_cast<ReturnType(__cdecl *)(Arguments..., ...)>(address);
 }
 
 // A nice struct to pack the assembly in for jumping into replacement code.


### PR DESCRIPTION
This change just renames the template type names. As I was using some of these functions for testing, I found the type names not very useful when using them. Functionality is the same. Just renaming.