### PR TITLE
Fix terrain blend bug

### DIFF
--- a/src/game/client/worldheightmap.cpp
+++ b/src/game/client/worldheightmap.cpp
@@ -1830,7 +1830,7 @@ TextureClass *WorldHeightMap::Get_Terrain_Texture()
 
 TextureClass *WorldHeightMap::Get_Edge_Terrain_Texture()
 {
-    if (!m_alphaEdgeTex) {
+    if (m_alphaEdgeTex == nullptr) {
         Get_Terrain_Texture();
     }
 
@@ -2341,7 +2341,7 @@ void WorldHeightMap::Get_UV_For_Blend(int edge_class, Region2D *range)
 
 TextureClass *WorldHeightMap::Get_Alpha_Terrain_Texture()
 {
-    if (!m_alphaTerrainTex) {
+    if (m_alphaTerrainTex == nullptr) {
         Get_Terrain_Texture();
     }
 

--- a/src/hooker/setuphooks_zh.cpp
+++ b/src/hooker/setuphooks_zh.cpp
@@ -1843,7 +1843,7 @@ void Setup_Hooks()
     Hook_Any(0x00747610, WorldHeightMap::Get_Alpha_UV_Data);
     Hook_Any(0x007478F0, WorldHeightMap::Set_Texture_LOD);
     Hook_Any(0x00747910, WorldHeightMap::Get_Terrain_Texture);
-    Hook_Any(0x00747C50, WorldHeightMap::Get_Edge_Terrain_Texture);
+    Hook_Any(0x00747C50, WorldHeightMap::Get_Alpha_Terrain_Texture);
     Hook_Any(0x00747C70, WorldHeightMap::Get_Flat_Texture);
     Hook_Any(0x00747D60, WorldHeightMap::Set_Draw_Origin);
     Hook_Any(0x00747E30, WorldHeightMap::Set_Cell_Cliff_Flag_From_Heights);


### PR DESCRIPTION
![unknown](https://user-images.githubusercontent.com/1277401/148639365-1701d9fb-26d9-40d6-bdc0-efcc2a1be35d.png)
Fixes this.
Also switched to == nullptr for the two functions that were getting hooked wrong.