### PR TITLE
Set unique ID for water polygon trigger

### DIFF
--- a/src/game/logic/map/polygontrigger.cpp
+++ b/src/game/logic/map/polygontrigger.cpp
@@ -282,8 +282,6 @@ void PolygonTrigger::Clear_Selected()
     }
 }
 
-// #TODO Check if maxTriggerId must be incremented before assigning to new PolygonTrigger. 2 PolygonTriggers may share same
-// ID.
 bool PolygonTrigger::Parse_Polygon_Triggers_Data_Chunk(DataChunkInput &file, DataChunkInfo *info, void *user_data)
 {
     int maxTriggerId = 0;
@@ -359,8 +357,9 @@ bool PolygonTrigger::Parse_Polygon_Triggers_Data_Chunk(DataChunkInput &file, Dat
     if (info->version == 1) {
         PolygonTrigger *trigger = NEW_POOL_OBJ(PolygonTrigger, 4);
         trigger->Set_Water_Area(true);
-        trigger->m_triggerID = maxTriggerId;
-        maxTriggerId++;
+
+        // #BUGFIX Pre-increment to avoid having two Polygon Triggers share the same ID.
+        trigger->m_triggerID = ++maxTriggerId;
 
         ICoord3D loc;
         loc.x = -300;


### PR DESCRIPTION
I am 100% sure this is logically the right thing. In current implementation, the Water Trigger ID will either be 0 (invalid ID) or share the same ID as another Polygon Trigger. The pre-increment fixes that.

I don't know how this effectively can be tested in game, but I did load map and stepped through the code, and the trigger ID's looked good with this change.