### PR TITLE
Fix polygon trigger radius

### DIFF
--- a/src/game/logic/map/polygontrigger.cpp
+++ b/src/game/logic/map/polygontrigger.cpp
@@ -39,7 +39,7 @@ PolygonTrigger::PolygonTrigger(int initial_allocation) :
     m_isShownInLayer(true),
     m_isSelected(false),
     m_bounds{},
-    m_radius(0),
+    m_radius(0.0f),
     m_boundsNeedsUpdate(false)
 {
     if (initial_allocation < 2) {
@@ -104,10 +104,10 @@ void PolygonTrigger::Reallocate()
 
 void PolygonTrigger::Update_Bounds() const
 {
-    m_bounds.lo.y = 8388592;
-    m_bounds.lo.x = 8388592;
-    m_bounds.hi.y = -8388592;
-    m_bounds.hi.x = -8388592;
+    m_bounds.lo.y = 0x7FFFF0;
+    m_bounds.lo.x = 0x7FFFF0;
+    m_bounds.hi.y = -0x7FFFF0;
+    m_bounds.hi.x = -0x7FFFF0;
 
     for (int i = 0; i < m_numPoints; i++) {
         if (m_points[i].x < m_bounds.lo.x) {
@@ -128,8 +128,11 @@ void PolygonTrigger::Update_Bounds() const
     }
 
     m_boundsNeedsUpdate = false;
-    float x = (float)(m_bounds.hi.x - m_bounds.lo.x) / 2.0f;
-    float y = (float)(m_bounds.lo.y + m_bounds.hi.y) / 2.0f;
+
+    // #BUGFIX Calculate correct height value here.
+    float x = (float)(m_bounds.Width()) / 2.0f;
+    float y = (float)(m_bounds.Height()) / 2.0f;
+
     m_radius = GameMath::Sqrt(x * x + y * y);
 }
 

--- a/src/game/logic/map/polygontrigger.cpp
+++ b/src/game/logic/map/polygontrigger.cpp
@@ -129,11 +129,11 @@ void PolygonTrigger::Update_Bounds() const
 
     m_boundsNeedsUpdate = false;
 
-    // #BUGFIX Calculate correct height value here.
-    float x = (float)(m_bounds.Width()) / 2.0f;
-    float y = (float)(m_bounds.Height()) / 2.0f;
-
-    m_radius = GameMath::Sqrt(x * x + y * y);
+    // #BUGFIX Corrected h to use correct value for Pythagoras theorem.
+    const float w = m_bounds.Width();
+    const float h = m_bounds.Height();
+    const float d = GameMath::Sqrt(w * w + h * h);
+    m_radius = d / 2.0f;
 }
 
 void PolygonTrigger::Add_Point(ICoord3D const &point)
@@ -209,8 +209,8 @@ void PolygonTrigger::Get_Center_Point(Coord3D *pOutCoord) const
             Update_Bounds();
         }
 
-        pOutCoord->x = (float)(m_bounds.hi.x + m_bounds.lo.x) / 2.0f;
-        pOutCoord->y = (float)(m_bounds.hi.y + m_bounds.lo.y) / 2.0f;
+        pOutCoord->x = (m_bounds.hi.x + m_bounds.lo.x) / 2.0f;
+        pOutCoord->y = (m_bounds.hi.y + m_bounds.lo.y) / 2.0f;
         pOutCoord->z = g_theTerrainLogic->Get_Ground_Height(pOutCoord->x, pOutCoord->y, nullptr);
     }
 }

--- a/src/w3d/lib/coord.h
+++ b/src/w3d/lib/coord.h
@@ -304,8 +304,8 @@ public:
 class Region2D
 {
 public:
-    float Height() const { return hi.y - lo.y; }
     float Width() const { return hi.x - lo.x; }
+    float Height() const { return hi.y - lo.y; }
 
     Coord2D lo;
     Coord2D hi;
@@ -314,8 +314,8 @@ public:
 class IRegion2D
 {
 public:
-    int Height() const { return hi.y - lo.y; }
     int Width() const { return hi.x - lo.x; }
+    int Height() const { return hi.y - lo.y; }
 
     ICoord2D lo;
     ICoord2D hi;
@@ -330,8 +330,8 @@ public:
         hi.Zero();
     }
 
-    float Height() const { return hi.y - lo.y; }
     float Width() const { return hi.x - lo.x; }
+    float Height() const { return hi.y - lo.y; }
     float Depth() const { return hi.z - lo.z; }
     bool Is_In_Region_No_Z(Coord3D *c) const { return lo.x < c->x && c->x < hi.x && lo.y < c->y && c->y < hi.y; }
 


### PR DESCRIPTION
OmniBlade on behalf of OpenSAGE developer:

> I found one little thing you might be interested in - while parsing .sav files, specifically the state for PolygonTrigger, I think I found a bug in the original game. I found a value that looks like it's supposed to be the radius of the polygon trigger, but it's wrong. Maybe it's something you can fix in Thyme? The value stored in .sav files is what you get if you do this:

```c++
width = (bottomRight.X - topLeft.X) * 0.5
height = (bottomRight.Y + topLeft.Y) * 0.5
radius = sqrt(width * width + height * height)
```

> ... but that's wrong. The height should be bottomRight.Y - topLeft.Y, not bottomRight.Y + topLeft.Y. If this is indeed a bug in the original game, the radius would be way too large, and would presumably lead to many false-positives when doing the radius check, which would be bad for performance. Presumably there's then a more precise check that uses the actual polygon, so this bug wouldn't actually change anything... it would just make it slower than it needs to be.

> I added a comment about this buggy radius here: https://github.com/OpenSAGE/OpenSAGE/blob/899b380545a7ca17aa9cae936974a3ce367ec018/src/OpenSage.Game/Data/Map/PolygonTrigger.cs#L185-L199