### PR TITLE
Avoid nullptr crash in W3DDisplay::Gather_Debug_Stats

### DIFF
--- a/src/platform/w3dengine/client/w3ddisplay.cpp
+++ b/src/platform/w3dengine/client/w3ddisplay.cpp
@@ -1925,7 +1925,8 @@ void W3DDisplay::Gather_Debug_Stats()
                 drawable->Get_Position()->y,
                 drawable->Get_Position()->z);
 
-            const PhysicsBehavior *phys = object->Get_Physics();
+            // #BUGFIX Test object before getting physics.
+            const PhysicsBehavior *phys = object ? object->Get_Physics() : nullptr;
 
             PhysicsTurningType turn;
             if (phys) {


### PR DESCRIPTION
Just a few lines above, `object` is tested, but when getting its physics, it was untested.