### PR TITLE
Refactor HRESULT error handling wording in w3d

### DIFF
--- a/src/game/client/shadow/w3dprojectedshadow.cpp
+++ b/src/game/client/shadow/w3dprojectedshadow.cpp
@@ -477,22 +477,20 @@ bool W3DProjectedShadowManager::Re_Acquire_Resources()
     captainslog_dbgassert(dev, "Trying to ReAquireResources on W3DProjectedShadowManager without device");
     captainslog_dbgassert(!g_shadowDecalIndexBufferD3D, "ReAquireResources not released in W3DProjectedShadowManager");
 
-    if (dev->CreateIndexBuffer(2 * g_shadowDecalIndexSize,
+    if (FAILED(dev->CreateIndexBuffer(2 * g_shadowDecalIndexSize,
             D3DUSAGE_WRITEONLY | D3DUSAGE_DYNAMIC,
             D3DFMT_INDEX16,
             D3DPOOL_DEFAULT,
-            &g_shadowDecalIndexBufferD3D)
-        < S_OK) {
+            &g_shadowDecalIndexBufferD3D))) {
         return false;
     }
 
     return g_shadowDecalVertexBufferD3D
-        || dev->CreateVertexBuffer(24 * g_shadowDecalVertexSize,
-               D3DUSAGE_WRITEONLY | D3DUSAGE_DYNAMIC,
-               0,
-               D3DPOOL_DEFAULT,
-               &g_shadowDecalVertexBufferD3D)
-        >= S_OK;
+        || SUCCEEDED(dev->CreateVertexBuffer(24 * g_shadowDecalVertexSize,
+            D3DUSAGE_WRITEONLY | D3DUSAGE_DYNAMIC,
+            0,
+            D3DPOOL_DEFAULT,
+            &g_shadowDecalVertexBufferD3D));
 #else
     return true;
 #endif
@@ -623,7 +621,7 @@ void W3DProjectedShadowManager::Queue_Decal(W3DProjectedShadow *shadow)
     RenderObjClass *robj = shadow->m_robj;
 
     if (g_theTerrainRenderObject) {
-        if (DX8Wrapper::Get_D3D_Device8()) {
+        if (DX8Wrapper::Get_D3D_Device8() != nullptr) {
             WorldHeightMap *hmap = g_theTerrainRenderObject->Get_Map();
             int size = hmap->Border_Size();
 

--- a/src/game/client/water/w3dwater.cpp
+++ b/src/game/client/water/w3dwater.cpp
@@ -306,7 +306,7 @@ HRESULT WaterRenderObjClass::Generate_Vertex_Buffer(int size_x, int size_y, int 
     if (!m_vertexBufferD3D) {
         HRESULT res = m_pDev->CreateVertexBuffer(vertex_size * m_numVertices, usage, fvf, pool, &m_vertexBufferD3D);
 
-        if (res < 0) {
+        if (FAILED(res)) {
             return res;
         }
     }
@@ -320,7 +320,7 @@ HRESULT WaterRenderObjClass::Generate_Vertex_Buffer(int size_x, int size_y, int 
     SEA_PATCH_VERTEX *vertices;
     HRESULT res = m_vertexBufferD3D->Lock(0, m_numVertices * sizeof(SEA_PATCH_VERTEX), (BYTE **)&vertices, 0);
 
-    if (res < 0) {
+    if (FAILED(0)) {
         return res;
     }
 
@@ -338,10 +338,11 @@ HRESULT WaterRenderObjClass::Generate_Vertex_Buffer(int size_x, int size_y, int 
 
     res = m_vertexBufferD3D->Unlock();
 
-    if (res < 0) {
+    if (FAILED(res)) {
         return res;
     }
-    return 0;
+
+    return D3D_OK;
 }
 #endif
 
@@ -352,14 +353,14 @@ HRESULT WaterRenderObjClass::Generate_Index_Buffer(int size_x, int size_y)
     HRESULT res = m_pDev->CreateIndexBuffer(
         2 * m_numIndices + 4, D3DUSAGE_WRITEONLY, D3DFMT_INDEX16, D3DPOOL_MANAGED, &m_indexBufferD3D);
 
-    if (res < 0) {
+    if (FAILED(res)) {
         return res;
     }
 
     unsigned short *indices;
     res = m_indexBufferD3D->Lock(0, 2 * m_numIndices, (BYTE **)&indices, 0);
 
-    if (res < 0) {
+    if (FAILED(res)) {
         return res;
     }
 
@@ -385,10 +386,11 @@ HRESULT WaterRenderObjClass::Generate_Index_Buffer(int size_x, int size_y)
 
     res = m_indexBufferD3D->Unlock();
 
-    if (res < 0) {
+    if (FAILED(res)) {
         return res;
     }
-    return 0;
+
+    return D3D_OK;
 }
 #endif
 
@@ -459,20 +461,20 @@ void WaterRenderObjClass::Re_Acquire_Resources()
     m_pDev = DX8Wrapper::Get_D3D_Device8();
 
     if (m_meshData) {
-        if (Generate_Index_Buffer(m_gridCellsX + 1, m_gridCellsY + 1) < 0
-            || Generate_Vertex_Buffer(m_gridCellsX + 1, m_gridCellsY + 1, 32, 0) < 0) {
+        if (FAILED(Generate_Index_Buffer(m_gridCellsX + 1, m_gridCellsY + 1))
+            || FAILED(Generate_Vertex_Buffer(m_gridCellsX + 1, m_gridCellsY + 1, 32, 0))) {
             return;
         }
     } else if (m_waterType == WATER_TYPE_2_PVSHADER) {
         HRESULT res = Generate_Index_Buffer(15, 15);
 
-        if (res < 0) {
+        if (FAILED(res)) {
             return;
         }
 
         res = Generate_Vertex_Buffer(15, 15, 24, true);
 
-        if (res < 0) {
+        if (FAILED(res)) {
             return;
         }
 
@@ -483,13 +485,13 @@ void WaterRenderObjClass::Re_Acquire_Resources()
             D3DVSD_END() };
         res = W3DShaderManager::Load_And_Create_D3D_Shader("shaders\\wave.pso", decl, 0, false, &m_dwWavePixelShader);
 
-        if (res < 0) {
+        if (FAILED(res)) {
             return;
         }
 
         res = W3DShaderManager::Load_And_Create_D3D_Shader("shaders\\wave.vso", decl, 0, true, &m_dwWaveVertexShader);
 
-        if (res < 0) {
+        if (FAILED(res)) {
             return;
         }
 
@@ -514,7 +516,7 @@ void WaterRenderObjClass::Re_Acquire_Resources()
                           "\t\t\tadd r0.rgb, r0, r1\n";
         HRESULT res = D3DXAssembleShader(ps1, strlen(ps1), 0, nullptr, &shader, nullptr);
 
-        if (res == 0) {
+        if (res == D3D_OK) {
             res = DX8Wrapper::Get_D3D_Device8()->CreatePixelShader(
                 (DWORD *)shader->GetBufferPointer(), &m_riverWaterPixelShader);
             shader->Release();
@@ -529,7 +531,7 @@ void WaterRenderObjClass::Re_Acquire_Resources()
                           "\t\t\tadd r0.rgb, r0, r1";
         res = D3DXAssembleShader(ps2, strlen(ps2), 0, nullptr, &shader, nullptr);
 
-        if (res == 0) {
+        if (res == D3D_OK) {
             res = DX8Wrapper::Get_D3D_Device8()->CreatePixelShader((DWORD *)shader->GetBufferPointer(), &m_waterPixelShader);
             shader->Release();
         }
@@ -545,7 +547,7 @@ void WaterRenderObjClass::Re_Acquire_Resources()
                           "\t\t\t;\n";
         res = D3DXAssembleShader(ps3, strlen(ps3), 0, nullptr, &shader, nullptr);
 
-        if (res == 0) {
+        if (res == D3D_OK) {
             res = DX8Wrapper::Get_D3D_Device8()->CreatePixelShader(
                 (DWORD *)shader->GetBufferPointer(), &m_trapezoidWaterPixelShader);
             shader->Release();
@@ -729,7 +731,7 @@ void WaterRenderObjClass::Enable_Water_Grid(bool state)
             m_indexBufferD3D = nullptr;
         }
 
-        if (Generate_Index_Buffer(m_gridCellsX + 1, m_gridCellsY + 1) >= 0) {
+        if (SUCCEEDED(Generate_Index_Buffer(m_gridCellsX + 1, m_gridCellsY + 1))) {
             Generate_Vertex_Buffer(m_gridCellsX + 1, m_gridCellsY + 1, 32, false);
         }
     }

--- a/src/platform/directx/dinputkeybd.cpp
+++ b/src/platform/directx/dinputkeybd.cpp
@@ -63,14 +63,14 @@ void DirectInputKeyboard::Get_Key(KeyboardIO *io)
     DIDEVICEOBJECTDATA data;
     DWORD data_fetched = 1; // Initial value is how many data objects we are filling.
 
-    if (res == DI_OK || res == DI_NOTATTACHED) {
+    if (res == DI_OK || res == S_FALSE) {
         res = m_inputDevice->GetDeviceData(sizeof(data), &data, &data_fetched, 0);
     }
 
     if (res == DIERR_INPUTLOST || res == DIERR_NOTACQUIRED) {
         res = m_inputDevice->Acquire();
 
-        if (res == DI_OK || res == DI_NOTATTACHED) {
+        if (res == DI_OK || res == S_FALSE) {
             io->key = 0xFF;
         }
     } else if (res == DI_OK && data_fetched != 0) {

--- a/src/platform/w3dengine/client/w3ddisplay.cpp
+++ b/src/platform/w3dengine/client/w3ddisplay.cpp
@@ -403,8 +403,8 @@ void W3DDisplay::Draw()
                 prevTime = now;
             }
 
-            if (DX8Wrapper::Get_D3D_Device8()) {
-                if (!DX8Wrapper::Get_D3D_Device8()->TestCooperativeLevel()) {
+            if (DX8Wrapper::Get_D3D_Device8() != nullptr) {
+                if (DX8Wrapper::Get_D3D_Device8()->TestCooperativeLevel() == D3D_OK) {
                     Update_Views();
                     g_theParticleSystemManager->Update();
 

--- a/src/platform/w3dengine/client/w3dshroud.cpp
+++ b/src/platform/w3dengine/client/w3dshroud.cpp
@@ -121,7 +121,7 @@ void W3DShroud::Init(WorldHeightMap *map, float world_cell_size_x, float world_c
     D3DLOCKED_RECT r;
     HRESULT res = m_pSrcTexture->LockRect(&r, nullptr, D3DLOCK_NO_DIRTY_UPDATE);
     m_pSrcTexture->UnlockRect();
-    captainslog_dbgassert(!res, "Failed to lock shroud src surface");
+    captainslog_dbgassert(res == D3D_OK, "Failed to lock shroud src surface");
     m_srcTextureData = (unsigned char *)r.pBits;
     m_srcTexturePitch = r.Pitch;
     memset(m_srcTextureData, 0, y * m_srcTexturePitch);
@@ -428,7 +428,7 @@ void W3DShroud::Render(CameraClass *cam)
 {
 #ifdef BUILD_WITH_D3D8
     if (m_pSrcTexture != nullptr) {
-        if (!DX8Wrapper::Get_D3D_Device8() || !DX8Wrapper::Get_D3D_Device8()->TestCooperativeLevel()) {
+        if (DX8Wrapper::Get_D3D_Device8() == nullptr || DX8Wrapper::Get_D3D_Device8()->TestCooperativeLevel() == D3D_OK) {
 #ifdef GAME_DEBUG_STRUCTS
             if (g_theWriteableGlobalData && g_theWriteableGlobalData->m_fogOfWarOn != m_drawFogOfWar) {
                 Reset();

--- a/src/w3d/renderer/dx8indexbuffer.cpp
+++ b/src/w3d/renderer/dx8indexbuffer.cpp
@@ -181,7 +181,7 @@ DX8IndexBufferClass::DX8IndexBufferClass(unsigned short index_count_, UsageType 
                      2 * m_indexCount, d3dusage, D3DFMT_INDEX16, (D3DPOOL)(unsigned __int8)(usage & 1 ^ 1), &m_indexBuffer),
         res);
 
-    if (res < 0) {
+    if (FAILED(res)) {
         captainslog_warn("Index buffer creation failed, trying to release assets...");
         TextureBaseClass::Invalidate_Old_Unused_Textures(5000);
         W3D::Invalidate_Mesh_Cache();

--- a/src/w3d/renderer/dx8vertexbuffer.cpp
+++ b/src/w3d/renderer/dx8vertexbuffer.cpp
@@ -224,7 +224,7 @@ void DX8VertexBufferClass::Create_Vertex_Buffer(UsageType usage)
                      &m_vertexBuffer),
         res);
 
-    if (res < 0) {
+    if (FAILED(res)) {
         captainslog_warn("Vertex buffer creation failed, trying to release assets...");
         TextureBaseClass::Invalidate_Old_Unused_Textures(5000);
         W3D::Invalidate_Mesh_Cache();

--- a/src/w3d/renderer/w3d.cpp
+++ b/src/w3d/renderer/w3d.cpp
@@ -252,7 +252,8 @@ W3DErrorType W3D::Begin_Render(bool clear, bool clearz, const Vector3 &color, fl
 
     HRESULT res;
 
-    if (DX8Wrapper::Get_D3D_Device8() && (res = DX8Wrapper::Get_D3D_Device8()->TestCooperativeLevel()) != S_OK) {
+    if (DX8Wrapper::Get_D3D_Device8() != nullptr
+        && (res = DX8Wrapper::Get_D3D_Device8()->TestCooperativeLevel()) != D3D_OK) {
         if (res == D3DERR_DEVICELOST) {
             return W3D_ERROR_GENERIC;
         } else if (res == D3DERR_DEVICENOTRESET) {


### PR DESCRIPTION
This change refactors W3D HRESULT error handling to streamline it better.

`0 and S_OK` has been replaced with D3D_OK
`< 0` has been replaced with FAILED() macro
`>= 0` has been replaced with SUCCEEDED() macro

There are a few placed where HRESULT is compared against D3D_OK with equal or unequal. Technically not super correct, but that is what the original does, so I left it as is for now.

Ideally all checks would just use FAILED and SUCCEEDED.