### PR TITLE
Implement new GameTextFile, GameTextManager classes and gametextcompiler tool

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,6 +96,7 @@ option(BUILD_TESTS "Builds the unit tests." OFF)
 option(USE_SANITIZER "Builds with address sanitizer" OFF)
 option(BUILD_COVERAGE "Instruments the code with coverage." OFF)
 option(BUILD_TOOLS "Builds the developer/debug tools." OFF)
+option(USE_LEGACY_GAMETEXT "Enable the legacy (original) GameTextManager implementation." ON)
 
 include(CMakeDependentOption)
 cmake_dependent_option(USE_STDFS "Use C++ 17 filesystem for crossplatform file handling." ${DEFAULT_STDFS} "STANDALONE" OFF)

--- a/deps/baseconfig/src/typesize.h
+++ b/deps/baseconfig/src/typesize.h
@@ -38,6 +38,9 @@ template<> struct UnsignedIntegerForSize<8>{ typedef uint64_t type; };
 template<class T> struct SignedInteger{ typedef typename SignedIntegerForSize<sizeof(T)>::type type; };
 template<class T> struct UnsignedInteger{ typedef typename UnsignedIntegerForSize<sizeof(T)>::type type; };
 
+template<class T> using SignedIntegerT = typename SignedInteger<T>::type;
+template<class T> using UnsignedIntegerT = typename UnsignedInteger<T>::type;
+
 // clang-format on
 }
 #endif // __cplusplus

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -20,6 +20,7 @@ set(GAMEENGINE_INCLUDES
     game/common/rts
     game/common/system
     game/common/thing
+    #game/common/utility # contains non standard header files
     game/logic/ai
     game/logic/map
     game/logic/object

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -76,6 +76,8 @@ set(GAMEENGINE_SRC
     game/client/fxlist.cpp
     game/client/gameclient.cpp
     game/client/gametext.cpp
+    game/client/gametextcommon.cpp
+    game/client/gametextfile.cpp
     game/client/globallanguage.cpp
     game/client/ingameui.cpp
     game/client/languagefilter.cpp

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -78,6 +78,8 @@ set(GAMEENGINE_SRC
     game/client/gametext.cpp
     game/client/gametextcommon.cpp
     game/client/gametextfile.cpp
+    game/client/gametextinterface.cpp
+    game/client/gametextmanager.cpp
     game/client/globallanguage.cpp
     game/client/ingameui.cpp
     game/client/languagefilter.cpp
@@ -558,6 +560,10 @@ endif()
 if(DINPUT8_FOUND)
     list(APPEND GAME_LINK_LIBRARIES dxguid dinput8)
     list(APPEND GAME_COMPILE_OPTIONS -DBUILD_WITH_DINPUT)
+endif()
+
+if(USE_LEGACY_GAMETEXT)
+    list(APPEND GAME_COMPILE_OPTIONS -DUSE_LEGACY_GAMETEXT)
 endif()
 
 # Static library for standalone builds and linking tools.

--- a/src/game/client/display.cpp
+++ b/src/game/client/display.cpp
@@ -16,7 +16,7 @@
 #include "display.h"
 #include "displaystringmanager.h"
 #include "gamefont.h"
-#include "gametext.h"
+#include "gametextinterface.h"
 #include "mouse.h"
 #include "rtsutils.h"
 #include "videobuffer.h"

--- a/src/game/client/gametext.cpp
+++ b/src/game/client/gametext.cpp
@@ -13,6 +13,7 @@
  *            LICENSE
  */
 #include "gametext.h"
+#include "file.h"
 #include "filesystem.h"
 #include "main.h" // For g_applicationHWnd
 #include "registry.h"
@@ -33,11 +34,9 @@
 #include "hookcrt.h"
 #endif
 
+namespace Legacy
+{
 using rts::FourCC;
-
-#ifndef GAME_DLL
-GameTextInterface *g_theGameText = nullptr;
-#endif
 
 // Comparison function used for sorting and searching StringLookUp arrays.
 int GameTextManager::Compare_LUT(void const *a, void const *b)
@@ -940,3 +939,4 @@ void GameTextManager::Deinit()
     m_noStringList = nullptr;
     m_initialized = false;
 }
+} // namespace Legacy

--- a/src/game/client/gametext.h
+++ b/src/game/client/gametext.h
@@ -15,71 +15,21 @@
 #pragma once
 
 #include "always.h"
-#include "asciistring.h"
-#include "file.h"
-#include "subsysteminterface.h"
-#include "unicodestring.h"
+#include "gametextcommon.h"
+#include "gametextinterface.h"
 
-// This enum applies to RA2/YR and Generals/ZH, BFME ID's are slightly different.
-enum class LanguageID : int32_t
+class File;
+
+namespace Legacy
 {
-    US = 0,
-    UK,
-    GERMAN,
-    FRENCH,
-    SPANISH,
-    ITALIAN,
-    JAPANESE,
-    JABBER,
-    KOREAN,
-    CHINESE,
-    UNK1,
-    BRAZILIAN,
-    POLISH,
-    UNKNOWN,
-};
-
-struct CSFHeader
-{
-    uint32_t id;
-    int32_t version;
-    int32_t num_labels;
-    int32_t num_strings;
-    int32_t skip;
-    LanguageID langid;
-};
-
-struct NoString
-{
-    NoString *next;
-    Utf16String text;
-};
-
-struct StringInfo
-{
-    Utf8String label;
-    Utf16String text;
-    Utf8String speech;
-};
-
 struct StringLookUp
 {
-    Utf8String *label;
-    StringInfo *info;
+    const Utf8String *label;
+    const StringInfo *info;
 };
 
-class GameTextInterface : public SubsystemInterface
-{
-public:
-    virtual ~GameTextInterface() {}
-
-    virtual Utf16String Fetch(const char *args, bool *success = nullptr) = 0;
-    virtual Utf16String Fetch(Utf8String args, bool *success = nullptr) = 0;
-    virtual std::vector<Utf8String> *Get_Strings_With_Prefix(Utf8String label) = 0;
-    virtual void Init_Map_String_File(Utf8String const &filename) = 0;
-    virtual void Deinit() = 0;
-};
-
+// GameTextManager is self contained and will automatically load and read generals.csf,
+// generals.str and map.str files.
 class GameTextManager : public GameTextInterface
 {
 public:
@@ -134,9 +84,4 @@ private:
     int m_mapTextCount;
     std::vector<Utf8String> m_stringVector;
 };
-
-#ifdef GAME_DLL
-extern GameTextInterface *&g_theGameText;
-#else
-extern GameTextInterface *g_theGameText;
-#endif
+} // namespace Legacy

--- a/src/game/client/gametext_impl.h
+++ b/src/game/client/gametext_impl.h
@@ -1,0 +1,23 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief File to be included wherever GameTextManager is used.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#if USE_LEGACY_GAMETEXT
+#include "gametext.h"
+using GameTextManager = Legacy::GameTextManager;
+#else
+#include "gametextmanager.h"
+using GameTextManager = Thyme::GameTextManager;
+#endif

--- a/src/game/client/gametextcommon.cpp
+++ b/src/game/client/gametextcommon.cpp
@@ -1,0 +1,95 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Common structures for Game Localization. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "gametextcommon.h"
+#include "utility/enumerator.h"
+
+namespace Thyme
+{
+
+constexpr const char *const s_localization_us = "English";
+constexpr const char *const s_localization_en = "";
+constexpr const char *const s_localization_de = "German";
+constexpr const char *const s_localization_fr = "French";
+constexpr const char *const s_localization_es = "Spanish";
+constexpr const char *const s_localization_it = "Italian";
+constexpr const char *const s_localization_ja = "Japanese";
+constexpr const char *const s_localization_jb = "";
+constexpr const char *const s_localization_ko = "Korean";
+constexpr const char *const s_localization_zh = "Chinese";
+constexpr const char *const s_localization___ = "";
+constexpr const char *const s_localization_bp = "Brazilian";
+constexpr const char *const s_localization_pl = "Polish";
+constexpr const char *const s_localization_uk = "Unknown";
+constexpr const char *const s_localization_ru = "Russian";
+constexpr const char *const s_localization_ar = "Arabic";
+
+constexpr const char *const s_localizations[] = {
+    s_localization_us,
+    s_localization_en,
+    s_localization_de,
+    s_localization_fr,
+    s_localization_es,
+    s_localization_it,
+    s_localization_ja,
+    s_localization_jb,
+    s_localization_ko,
+    s_localization_zh,
+    s_localization___,
+    s_localization_bp,
+    s_localization_pl,
+    s_localization_uk,
+    s_localization_ru,
+    s_localization_ar,
+};
+
+static_assert(s_localization_us == s_localizations[size_t(LanguageID::US)]);
+static_assert(s_localization_en == s_localizations[size_t(LanguageID::UK)]);
+static_assert(s_localization_de == s_localizations[size_t(LanguageID::GERMAN)]);
+static_assert(s_localization_fr == s_localizations[size_t(LanguageID::FRENCH)]);
+static_assert(s_localization_es == s_localizations[size_t(LanguageID::SPANISH)]);
+static_assert(s_localization_it == s_localizations[size_t(LanguageID::ITALIAN)]);
+static_assert(s_localization_ja == s_localizations[size_t(LanguageID::JAPANESE)]);
+static_assert(s_localization_jb == s_localizations[size_t(LanguageID::JABBER)]);
+static_assert(s_localization_ko == s_localizations[size_t(LanguageID::KOREAN)]);
+static_assert(s_localization_zh == s_localizations[size_t(LanguageID::CHINESE)]);
+static_assert(s_localization___ == s_localizations[size_t(LanguageID::UNUSED_1)]);
+static_assert(s_localization_bp == s_localizations[size_t(LanguageID::BRAZILIAN)]);
+static_assert(s_localization_pl == s_localizations[size_t(LanguageID::POLISH)]);
+static_assert(s_localization_uk == s_localizations[size_t(LanguageID::UNKNOWN)]);
+static_assert(s_localization_ru == s_localizations[size_t(LanguageID::RUSSIAN)]);
+static_assert(s_localization_ar == s_localizations[size_t(LanguageID::ARABIC)]);
+
+static_assert(ARRAY_SIZE(s_localizations) == g_languageCount);
+
+bool Name_To_Language(const char *localization, LanguageID &language)
+{
+    rts::enumerator<LanguageID> it;
+
+    for (const char *name : s_localizations) {
+        if (0 == strcasecmp(localization, name)) {
+            language = it.value();
+            return true;
+        }
+        ++it;
+    }
+    return false;
+}
+
+const char *Get_Language_Name(LanguageID language)
+{
+    return s_localizations[static_cast<size_t>(language)];
+}
+
+} // namespace Thyme

--- a/src/game/client/gametextcommon.h
+++ b/src/game/client/gametextcommon.h
@@ -1,0 +1,94 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Common structures for Game Localization.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "asciistring.h"
+#include "bittype.h"
+#include "unicodestring.h"
+#include "utility/type_traits.h"
+#include <vector>
+
+// This enum applies to RA2/YR and Generals/ZH, BFME ID's are slightly different.
+enum class LanguageID : int32_t
+{
+    // Official game languages.
+    US = 0,
+    UK = 1,
+    GERMAN = 2,
+    FRENCH = 3,
+    SPANISH = 4,
+    ITALIAN = 5,
+    JAPANESE = 6,
+    JABBER = 7,
+    KOREAN = 8,
+    CHINESE = 9,
+    UNUSED_1 = 10,
+    BRAZILIAN = 11,
+    POLISH = 12,
+
+    // Unspecified language. Default in GameTextFile class.
+    UNKNOWN = 13,
+
+    // Community game languages.
+    RUSSIAN = 14,
+    ARABIC = 15,
+
+    COUNT
+};
+
+DEFINE_RTS_UNDERLYING_TYPE(LanguageID, int32_t);
+
+constexpr size_t g_languageCount = static_cast<size_t>(LanguageID::COUNT);
+
+struct CSFHeader
+{
+    uint32_t id;
+    int32_t version;
+    int32_t num_labels;
+    int32_t num_strings;
+    int32_t skip;
+    LanguageID langid;
+};
+
+struct StringInfo
+{
+    Utf8String label;
+    Utf16String text;
+    Utf8String speech;
+};
+
+struct NoString
+{
+    NoString *next;
+    Utf16String text;
+};
+
+namespace Thyme
+{
+
+struct MultiStringInfo
+{
+    Utf8String label;
+    Utf16String text[g_languageCount];
+    Utf8String speech[g_languageCount];
+};
+
+using StringInfos = std::vector<StringInfo>;
+using MultiStringInfos = std::vector<MultiStringInfo>;
+
+bool Name_To_Language(const char *localization, LanguageID &language);
+const char *Get_Language_Name(LanguageID language);
+
+} // namespace Thyme

--- a/src/game/client/gametextfile.cpp
+++ b/src/game/client/gametextfile.cpp
@@ -1,0 +1,1401 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Localization File. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "always.h"
+#include "gametextfile.h"
+#include "filesystem.h"
+#include "gametextlookup.h"
+#include "rtsutils.h"
+#include "utility/arrayutil.h"
+#include "utility/fileutil.h"
+#include "utility/stlutil.h"
+#include "utility/stringutil.h"
+
+#define GAMETEXTLOG_TRACE(fmt, ...) \
+    captainslog_trace(fmt, ##__VA_ARGS__); \
+    GameTextFile::Log_Line("TRACE : ", fmt, ##__VA_ARGS__)
+
+#define GAMETEXTLOG_DEBUG(fmt, ...) \
+    captainslog_debug(fmt, ##__VA_ARGS__); \
+    GameTextFile::Log_Line("DEBUG : ", fmt, ##__VA_ARGS__)
+
+#define GAMETEXTLOG_INFO(fmt, ...) \
+    captainslog_info(fmt, ##__VA_ARGS__); \
+    GameTextFile::Log_Line("", fmt, ##__VA_ARGS__)
+
+#define GAMETEXTLOG_WARN(fmt, ...) \
+    captainslog_warn(fmt, ##__VA_ARGS__); \
+    GameTextFile::Log_Line("WARNING : ", fmt, ##__VA_ARGS__)
+
+#define GAMETEXTLOG_ERROR(fmt, ...) \
+    captainslog_error(fmt, ##__VA_ARGS__); \
+    GameTextFile::Log_Line("ERROR : ", fmt, ##__VA_ARGS__)
+
+#define GAMETEXTLOG_FATAL(fmt, ...) \
+    captainslog_fatal(fmt, ##__VA_ARGS__); \
+    GameTextFile::Log_Line("FATAL : ", fmt, ##__VA_ARGS__)
+
+namespace Thyme
+{
+
+namespace
+{
+template<typename IntegerType> constexpr size_t Bit_To_Index(IntegerType integer)
+{
+    using UnsignedInt = UnsignedIntegerT<IntegerType>;
+    size_t n = 0;
+    for (; n < sizeof(IntegerType) * 8; ++n) {
+        if (UnsignedInt(integer) & (UnsignedInt(1) << n)) {
+            return n;
+        }
+    }
+    return n;
+}
+
+constexpr const char *const s_option_0 = "None";
+constexpr const char *const s_option_1 = "Optimize_Memory_Size";
+constexpr const char *const s_option_2 = "Check_Buffer_Length_On_Load";
+constexpr const char *const s_option_3 = "Check_Buffer_Length_On_Save";
+constexpr const char *const s_option_4 = "Keep_Obsolete_Spaces_On_Load";
+constexpr const char *const s_option_5 = "Write_Extra_LF_On_STR_Save";
+
+constexpr const char *const s_options[] = {
+    s_option_0,
+    s_option_1,
+    s_option_2,
+    s_option_3,
+    s_option_4,
+    s_option_5,
+};
+
+static_assert(s_option_0 == s_options[size_t(GameTextOption::NONE)]);
+static_assert(s_option_1 == s_options[1 + Bit_To_Index(GameTextOption::OPTIMIZE_MEMORY_SIZE)]);
+static_assert(s_option_2 == s_options[1 + Bit_To_Index(GameTextOption::CHECK_BUFFER_LENGTH_ON_LOAD)]);
+static_assert(s_option_3 == s_options[1 + Bit_To_Index(GameTextOption::CHECK_BUFFER_LENGTH_ON_SAVE)]);
+static_assert(s_option_4 == s_options[1 + Bit_To_Index(GameTextOption::KEEP_OBSOLETE_SPACES_ON_LOAD)]);
+static_assert(s_option_5 == s_options[1 + Bit_To_Index(GameTextOption::WRITE_EXTRA_LF_ON_STR_SAVE)]);
+} // namespace
+
+bool Name_To_Game_Text_Option(const char *name, GameTextOption &option)
+{
+    size_t index = 0;
+    for (const char *option_name : s_options) {
+        if (strcasecmp(option_name, name) == 0) {
+            option = (index == 0) ? GameTextOption::NONE : static_cast<GameTextOption>(1 << (index - 1));
+            return true;
+        }
+        ++index;
+    }
+    return false;
+}
+
+namespace
+{
+// ISO 639-1 language codes - sort of.
+
+constexpr const char *const s_langcode_invalid = "__";
+
+constexpr const char *const s_langcode_us = "US";
+constexpr const char *const s_langcode_en = s_langcode_invalid;
+constexpr const char *const s_langcode_de = "DE";
+constexpr const char *const s_langcode_fr = "FR";
+constexpr const char *const s_langcode_es = "ES";
+constexpr const char *const s_langcode_it = "IT";
+constexpr const char *const s_langcode_ja = "JA";
+constexpr const char *const s_langcode_jb = s_langcode_invalid;
+constexpr const char *const s_langcode_ko = "KO";
+constexpr const char *const s_langcode_zh = "ZH";
+constexpr const char *const s_langcode___ = s_langcode_invalid;
+constexpr const char *const s_langcode_bp = "BP";
+constexpr const char *const s_langcode_pl = "PL";
+constexpr const char *const s_langcode_uk = s_langcode_invalid;
+constexpr const char *const s_langcode_ru = "RU";
+constexpr const char *const s_langcode_ar = "AR";
+
+constexpr const char *const s_langcodes[] = {
+    s_langcode_us,
+    s_langcode_en,
+    s_langcode_de,
+    s_langcode_fr,
+    s_langcode_es,
+    s_langcode_it,
+    s_langcode_ja,
+    s_langcode_jb,
+    s_langcode_ko,
+    s_langcode_zh,
+    s_langcode___,
+    s_langcode_bp,
+    s_langcode_pl,
+    s_langcode_uk,
+    s_langcode_ru,
+    s_langcode_ar,
+};
+
+static_assert(s_langcode_us == s_langcodes[size_t(LanguageID::US)]);
+static_assert(s_langcode_en == s_langcodes[size_t(LanguageID::UK)]);
+static_assert(s_langcode_de == s_langcodes[size_t(LanguageID::GERMAN)]);
+static_assert(s_langcode_fr == s_langcodes[size_t(LanguageID::FRENCH)]);
+static_assert(s_langcode_es == s_langcodes[size_t(LanguageID::SPANISH)]);
+static_assert(s_langcode_it == s_langcodes[size_t(LanguageID::ITALIAN)]);
+static_assert(s_langcode_ja == s_langcodes[size_t(LanguageID::JAPANESE)]);
+static_assert(s_langcode_jb == s_langcodes[size_t(LanguageID::JABBER)]);
+static_assert(s_langcode_ko == s_langcodes[size_t(LanguageID::KOREAN)]);
+static_assert(s_langcode_zh == s_langcodes[size_t(LanguageID::CHINESE)]);
+static_assert(s_langcode___ == s_langcodes[size_t(LanguageID::UNUSED_1)]);
+static_assert(s_langcode_bp == s_langcodes[size_t(LanguageID::BRAZILIAN)]);
+static_assert(s_langcode_pl == s_langcodes[size_t(LanguageID::POLISH)]);
+static_assert(s_langcode_uk == s_langcodes[size_t(LanguageID::UNKNOWN)]);
+static_assert(s_langcode_ru == s_langcodes[size_t(LanguageID::RUSSIAN)]);
+static_assert(s_langcode_ar == s_langcodes[size_t(LanguageID::ARABIC)]);
+
+static_assert(ARRAY_SIZE(s_langcodes) == g_languageCount);
+
+constexpr const char *Get_Language_Code(LanguageID language)
+{
+    return s_langcodes[size_t(language)];
+}
+
+constexpr const char s_str_eol[] = { '\r', '\n' };
+constexpr const char s_str_quo[] = { '"' };
+constexpr const char s_str_end[] = { 'E', 'N', 'D' };
+constexpr const char s_str_lng[] = { ':' };
+
+struct CSFLabelHeader
+{
+    uint32_t id;
+    int32_t texts;
+    int32_t length;
+};
+
+struct CSFTextHeader
+{
+    uint32_t id;
+    int32_t length;
+};
+
+struct CSFSpeechHeader
+{
+    int32_t length;
+};
+
+} // namespace
+
+FILE *GameTextFile::s_logfile = nullptr;
+
+GameTextFile::GameTextFile() :
+    m_options(GameTextOption::OPTIMIZE_MEMORY_SIZE), m_language(LanguageID::UNKNOWN), m_stringInfosArray(){};
+
+bool GameTextFile::Is_Loaded() const
+{
+    return !Get_String_Infos().empty();
+}
+
+bool GameTextFile::Is_Loaded(Languages languages) const
+{
+    bool loaded = true;
+    For_Each_Language(languages, [&](LanguageID language) { loaded &= !Get_String_Infos(language).empty(); });
+    return loaded;
+}
+
+bool GameTextFile::Is_Any_Loaded(Languages languages) const
+{
+    bool loaded = true;
+    For_Each_Language(languages, [&](LanguageID language) { loaded |= !Get_String_Infos(language).empty(); });
+    return loaded;
+}
+
+bool GameTextFile::Load(const char *filename)
+{
+    const FileType filetype = Get_File_Type(filename, FileType::AUTO);
+
+    return Load(filename, filetype, ~Languages());
+}
+
+bool GameTextFile::Load_CSF(const char *filename)
+{
+    return Load(filename, FileType::CSF, Languages());
+}
+
+bool GameTextFile::Load_STR(const char *filename)
+{
+    return Load(filename, FileType::STR, Languages());
+}
+
+bool GameTextFile::Load_Multi_STR(const char *filename, Languages languages)
+{
+    return Load(filename, FileType::MULTI_STR, languages);
+}
+
+bool GameTextFile::Save(const char *filename)
+{
+    FileType filetype = Get_File_Type(filename, FileType::AUTO);
+
+    return Save(filename, filetype, ~Languages());
+}
+
+bool GameTextFile::Save_CSF(const char *filename)
+{
+    return Save(filename, FileType::CSF, Languages());
+}
+
+bool GameTextFile::Save_STR(const char *filename)
+{
+    return Save(filename, FileType::STR, Languages());
+}
+
+bool GameTextFile::Save_Multi_STR(const char *filename, Languages languages)
+{
+    return Save(filename, FileType::MULTI_STR, languages);
+}
+
+bool GameTextFile::Load(const char *filename, FileType filetype, Languages languages)
+{
+    captainslog_assert(filetype != FileType::AUTO);
+
+    if (!filename || !filename[0]) {
+        GAMETEXTLOG_ERROR("File without name cannot be loaded");
+        return false;
+    }
+
+    const int filemode = Encode_Buffered_File_Mode(File::READ | File::BINARY, 1024 * 32);
+    FileRef file = g_theFileSystem->Open_File(filename, filemode);
+
+    if (!file.Is_Open()) {
+        GAMETEXTLOG_ERROR("File '%s' cannot be opened for read", filename);
+        return false;
+    }
+
+    bool success = false;
+
+    languages = Filter_Usable_Languages(languages);
+    LanguageID read_language = m_language;
+    StringInfosArray string_infos_array;
+    StringInfos &string_infos = string_infos_array[size_t(read_language)];
+
+    switch (filetype) {
+
+        case FileType::CSF: {
+            success = Read_CSF_File(file, string_infos, read_language, m_options);
+            string_infos_array[size_t(read_language)].swap(string_infos);
+            break;
+        }
+        case FileType::STR: {
+            success = Read_STR_File(file, string_infos, m_options);
+            break;
+        }
+        case FileType::MULTI_STR: {
+            StringInfosPtrArray string_infos_ptrs = Build_String_Infos_Ptrs_Array(string_infos_array, languages);
+            success = Read_Multi_STR_File(file, string_infos_ptrs, languages, m_options);
+            Get_Language_With_String_Infos(read_language, string_infos_ptrs, 0);
+            break;
+        }
+    }
+
+    if (success) {
+        m_language = read_language;
+        const Languages used_languages = Supports_Multi_Language(filetype) ? languages : read_language;
+
+        GAMETEXTLOG_INFO("File '%s' loaded successfully", filename);
+
+        For_Each_Language(used_languages, [&](LanguageID language) {
+            Mutable_String_Infos(language).swap(string_infos_array[size_t(language)]);
+
+            GAMETEXTLOG_INFO("Read language: %s", Get_Language_Name(language));
+            GAMETEXTLOG_INFO("Read line count: %zu", Get_String_Infos(language).size());
+
+            if (m_options.has(Options::Value::CHECK_BUFFER_LENGTH_ON_LOAD)) {
+                Check_Buffer_Lengths(language);
+            }
+        });
+    } else {
+        GAMETEXTLOG_ERROR("File '%s' failed to load", filename);
+    }
+
+    return success;
+}
+
+bool GameTextFile::Save(const char *filename, FileType filetype, Languages languages)
+{
+    captainslog_assert(filetype != FileType::AUTO);
+
+    if (!filename || !filename[0]) {
+        GAMETEXTLOG_ERROR("File without name cannot be saved");
+        return false;
+    }
+
+    languages = Filter_Usable_Languages(languages);
+    const Languages used_languages = Supports_Multi_Language(filetype) ? languages : m_language;
+
+    if (!Is_Any_Loaded(used_languages)) {
+        GAMETEXTLOG_ERROR("File without string data cannot be saved");
+        return false;
+    }
+
+    const int filemode = Encode_Buffered_File_Mode(File::WRITE | File::CREATE | File::BINARY, 1024 * 32);
+    FileRef file = g_theFileSystem->Open_File(filename, filemode);
+
+    if (!file.Is_Open()) {
+        GAMETEXTLOG_ERROR("File '%s' cannot be opened for write", filename);
+        return false;
+    }
+
+    bool success = false;
+
+    switch (filetype) {
+
+        case FileType::CSF: {
+            success = Write_CSF_File(file, Get_String_Infos(), m_language);
+            break;
+        }
+        case FileType::STR: {
+            success = Write_STR_File(file, Get_String_Infos(), m_options);
+            break;
+        }
+        case FileType::MULTI_STR: {
+            ConstStringInfosPtrArray string_infos_ptrs = Build_Const_String_Infos_Ptrs_Array(m_stringInfosArray, languages);
+            success = Write_Multi_STR_File(file, string_infos_ptrs, languages, m_options);
+            break;
+        }
+    }
+
+    if (success) {
+        GAMETEXTLOG_INFO("File '%s' saved successfully", filename);
+
+        For_Each_Language(used_languages, [&](LanguageID language) {
+            GAMETEXTLOG_INFO("Written language: %s", Get_Language_Name(language));
+            GAMETEXTLOG_INFO("Written line count: %zu", Get_String_Infos(language).size());
+
+            if (m_options.has(Options::Value::CHECK_BUFFER_LENGTH_ON_SAVE)) {
+                Check_Buffer_Lengths(language);
+            }
+        });
+    } else {
+        GAMETEXTLOG_ERROR("File '%s' failed to save", filename);
+    }
+
+    return success;
+}
+
+void GameTextFile::Unload()
+{
+    Unload(m_language);
+}
+
+void GameTextFile::Unload(Languages languages)
+{
+    For_Each_Language(languages, [&](LanguageID language) { rts::Free_Container(Mutable_String_Infos(language)); });
+}
+
+void GameTextFile::Reset()
+{
+    for (StringInfos &string_infos : m_stringInfosArray) {
+        rts::Free_Container(string_infos);
+    }
+    m_options = Options::Value::NONE;
+    m_language = LanguageID::UNKNOWN;
+}
+
+void GameTextFile::Merge_And_Overwrite(const GameTextFile &other)
+{
+    Merge_And_Overwrite_Internal(other, m_language);
+}
+
+void GameTextFile::Merge_And_Overwrite(const GameTextFile &other, Languages languages)
+{
+    For_Each_Language(languages, [&](LanguageID language) { Merge_And_Overwrite_Internal(other, language); });
+}
+
+void GameTextFile::Merge_And_Overwrite_Internal(const GameTextFile &other, LanguageID language)
+{
+    const size_t other_size = other.Get_String_Infos(language).size();
+    StringInfos &this_strings = Mutable_String_Infos(language);
+    StringInfos other_new_strings;
+    other_new_strings.reserve(other_size);
+
+    {
+        const MutableGameTextLookup this_lookup(this_strings);
+
+        for (const StringInfo &other_string : other.Get_String_Infos(language)) {
+            const MutableStringLookup *this_string_lookup = this_lookup.Find(other_string.label.Str());
+
+            if (this_string_lookup == nullptr) {
+                // Other string is new. Prepare to add.
+                other_new_strings.push_back(other_string);
+            } else {
+                // Other string already exists. Update this string.
+                this_string_lookup->string_info->text = other_string.text;
+                this_string_lookup->string_info->speech = other_string.speech;
+            }
+        }
+    }
+
+    rts::Append_Container(this_strings, other_new_strings);
+}
+
+void GameTextFile::Check_Buffer_Lengths(LanguageID language)
+{
+    LengthInfo len_info;
+    Collect_Length_Info(len_info, Get_String_Infos(language));
+    Log_Length_Info(len_info);
+    Assert_Length_Info(len_info);
+}
+
+const StringInfos &GameTextFile::Get_String_Infos() const
+{
+    return m_stringInfosArray[size_t(m_language)];
+}
+
+const StringInfos &GameTextFile::Get_String_Infos(LanguageID language) const
+{
+    return m_stringInfosArray[size_t(language)];
+}
+
+StringInfos &GameTextFile::Mutable_String_Infos()
+{
+    return m_stringInfosArray[size_t(m_language)];
+}
+
+StringInfos &GameTextFile::Mutable_String_Infos(LanguageID language)
+{
+    return m_stringInfosArray[size_t(language)];
+}
+
+void GameTextFile::Set_Options(Options options)
+{
+    m_options = options;
+}
+
+GameTextFile::Options GameTextFile::Get_Options() const
+{
+    return m_options;
+}
+
+void GameTextFile::Set_Language(LanguageID language)
+{
+    m_language = language;
+}
+
+LanguageID GameTextFile::Get_Language() const
+{
+    return m_language;
+}
+
+void GameTextFile::Swap_String_Infos(LanguageID left, LanguageID right)
+{
+    if (left != right) {
+        m_stringInfosArray[size_t(left)].swap(m_stringInfosArray[size_t(right)]);
+    }
+}
+
+void GameTextFile::Set_Log_File(FILE *log)
+{
+    s_logfile = log;
+}
+
+template<typename Functor> void GameTextFile::For_Each_Language(Languages languages, Functor functor)
+{
+    for (rts::enumerator<LanguageID> it; it < LanguageID(g_languageCount); ++it) {
+        const LanguageID language = it.value();
+        if (languages.has(language)) {
+            functor(language);
+        }
+    }
+}
+
+GameTextFile::StringInfosPtrArray GameTextFile::Build_String_Infos_Ptrs_Array(
+    StringInfosArray &string_infos_array, Languages languages)
+{
+    StringInfosPtrArray string_infos_ptrs = {};
+
+    For_Each_Language(languages, [&](LanguageID language) {
+        const size_t index = static_cast<size_t>(language);
+        string_infos_ptrs[index] = &string_infos_array[index];
+    });
+    return string_infos_ptrs;
+}
+
+GameTextFile::ConstStringInfosPtrArray GameTextFile::Build_Const_String_Infos_Ptrs_Array(
+    StringInfosArray &string_infos_array, Languages languages)
+{
+    ConstStringInfosPtrArray string_infos_ptrs = {};
+
+    For_Each_Language(languages, [&](LanguageID language) {
+        const size_t index = static_cast<size_t>(language);
+        string_infos_ptrs[index] = &string_infos_array[index];
+    });
+    return string_infos_ptrs;
+}
+
+size_t GameTextFile::Get_Max_Size(const ConstStringInfosPtrArray &string_infos_ptrs)
+{
+    size_t size = 0;
+
+    for (const StringInfos *string_infos : string_infos_ptrs) {
+        if (string_infos != nullptr) {
+            size = std::max(size, string_infos->size());
+        }
+    }
+    return size;
+}
+
+void GameTextFile::Build_Multi_String_Infos(
+    MultiStringInfos &multi_string_infos, const ConstStringInfosPtrArray &string_infos_ptrs, Options options)
+{
+    const size_t estimated_size = Get_Max_Size(string_infos_ptrs);
+    size_t current_size = 0;
+    MultiStringInfos tmp_multi_string_infos;
+    tmp_multi_string_infos.reserve(estimated_size);
+    multi_string_infos.clear();
+    multi_string_infos.reserve(estimated_size);
+    MutableMultiGameTextLookup lookup;
+
+    size_t language_index = 0;
+
+    for (const StringInfos *string_infos : string_infos_ptrs) {
+        if (string_infos != nullptr) {
+            if (current_size != multi_string_infos.size()) {
+                current_size = multi_string_infos.size();
+                lookup.Load(multi_string_infos);
+            }
+
+            for (const StringInfo &string_info : *string_infos) {
+                const MutableMultiStringLookup *multi_string_lookup = lookup.Find(string_info.label.Str());
+
+                if (multi_string_lookup == nullptr) {
+                    MultiStringInfo multi_string_info;
+                    multi_string_info.label = string_info.label;
+                    multi_string_info.text[language_index] = string_info.text;
+                    multi_string_info.speech[language_index] = string_info.speech;
+                    tmp_multi_string_infos.push_back(multi_string_info);
+                } else {
+                    multi_string_lookup->string_info->text[language_index] = string_info.text;
+                    multi_string_lookup->string_info->speech[language_index] = string_info.speech;
+                }
+            }
+            rts::Append_Container(multi_string_infos, tmp_multi_string_infos);
+            tmp_multi_string_infos.clear();
+        }
+        ++language_index;
+    }
+
+    if (options.has(Options::Value::OPTIMIZE_MEMORY_SIZE)) {
+        rts::Shrink_To_Fit(multi_string_infos);
+    }
+}
+
+void GameTextFile::Build_String_Infos(
+    StringInfosPtrArray &string_infos_ptrs, const MultiStringInfos &multi_string_infos, Options options)
+{
+    size_t language_index = 0;
+
+    for (StringInfos *string_infos_ptr : string_infos_ptrs) {
+        if (string_infos_ptr != nullptr) {
+            StringInfos &string_infos = *string_infos_ptr;
+            if (options.has(Options::Value::OPTIMIZE_MEMORY_SIZE)) {
+                rts::Free_Container(string_infos);
+            }
+            string_infos.resize(multi_string_infos.size());
+            size_t string_index = 0;
+
+            for (const MultiStringInfo &multi_string_info : multi_string_infos) {
+                string_infos[string_index].label = multi_string_info.label;
+                string_infos[string_index].text = multi_string_info.text[language_index];
+                string_infos[string_index].speech = multi_string_info.speech[language_index];
+                ++string_index;
+            }
+        }
+        ++language_index;
+    }
+}
+
+bool GameTextFile::Get_Language_With_String_Infos(
+    LanguageID &language, const StringInfosPtrArray &string_infos_ptrs, size_t occurence)
+{
+    size_t num = 0;
+    rts::enumerator<LanguageID> it;
+    for (const StringInfosPtrArray::value_type &string_infos_ptr : string_infos_ptrs) {
+        if (string_infos_ptr != nullptr && !string_infos_ptr->empty()) {
+            if (occurence == num++) {
+                language = it.value();
+                return true;
+            }
+        }
+        ++it;
+    }
+    return false;
+}
+
+GameTextFile::Languages GameTextFile::Filter_Usable_Languages(Languages languages)
+{
+    for (rts::enumerator<LanguageID> it; it < LanguageID::COUNT; ++it) {
+        if (languages.has(it.value())) {
+            const char *langcode = s_langcodes[it.underlying()];
+            if (strcmp(langcode, s_langcode_invalid) == 0) {
+                languages.reset(it.value());
+            }
+        }
+    }
+    return languages;
+}
+
+bool GameTextFile::Supports_Multi_Language(FileType filetype)
+{
+    switch (filetype) {
+        case FileType::MULTI_STR:
+            return true;
+        default:
+            return false;
+    }
+}
+
+GameTextFile::FileType GameTextFile::Get_File_Type(const char *filename, FileType filetype)
+{
+    if (filetype == FileType::AUTO) {
+
+        const char *fileext = rts::Get_File_Extension(rts::Make_Array_View(filename));
+
+        if (strcasecmp(fileext, "csf") == 0) {
+            filetype = FileType::CSF;
+        } else if (strcasecmp(fileext, "str") == 0) {
+            filetype = FileType::STR;
+        } else if (strcasecmp(fileext, "multistr") == 0) {
+            filetype = FileType::MULTI_STR;
+        } else {
+            filetype = FileType::CSF;
+        }
+    }
+    return filetype;
+}
+
+void GameTextFile::Collect_Length_Info(LengthInfo &len_info, const StringInfos &strings)
+{
+    len_info.max_label_len = 0;
+    len_info.max_text8_len = 0;
+    len_info.max_text16_len = 0;
+    len_info.max_speech_len = 0;
+
+    Utf8String utf8text;
+
+    for (const StringInfo &string : strings) {
+        utf8text.Translate(string.text);
+
+        len_info.max_label_len = std::max(len_info.max_label_len, string.label.Get_Length());
+        len_info.max_text8_len = std::max(len_info.max_text8_len, utf8text.Get_Length());
+        len_info.max_text16_len = std::max(len_info.max_text16_len, string.text.Get_Length());
+        len_info.max_speech_len = std::max(len_info.max_speech_len, string.speech.Get_Length());
+    }
+}
+
+void GameTextFile::Log_Length_Info(const LengthInfo &len_info)
+{
+    const int label_len = len_info.max_label_len;
+    const int text8_len = len_info.max_text8_len;
+    const int text16_len = len_info.max_text16_len;
+    const int speech_len = len_info.max_speech_len;
+
+    const bool label_ok = (TEXT_8_SIZE - 1 > label_len);
+    const bool text8_ok = (TEXT_8_SIZE - 1 > text8_len);
+    const bool text16_ok = (TEXT_16_SIZE - 1 > text16_len);
+    const bool speech_ok = (TEXT_8_SIZE - 1 > speech_len);
+
+    if (label_ok) {
+        GAMETEXTLOG_INFO("Checked label len: %d, max: %d", label_len, TEXT_8_SIZE - 1);
+    } else {
+        GAMETEXTLOG_ERROR("Checked label len: %d, max: %d", label_len, TEXT_8_SIZE - 1);
+    }
+
+    if (text8_ok) {
+        GAMETEXTLOG_INFO("Checked utf8 text len: %d, max: %d", text8_len, TEXT_8_SIZE - 1);
+    } else {
+        GAMETEXTLOG_ERROR("Checked utf8 text len: %d, max: %d", text8_len, TEXT_8_SIZE - 1);
+    }
+
+    if (text16_ok) {
+        GAMETEXTLOG_INFO("Checked utf16 text len: %d, max: %d", text16_len, TEXT_16_SIZE - 1);
+    } else {
+        GAMETEXTLOG_ERROR("Checked utf16 text len: %d, max: %d", text16_len, TEXT_16_SIZE - 1);
+    }
+
+    if (speech_ok) {
+        GAMETEXTLOG_INFO("Checked speech len: %d, max: %d", speech_len, TEXT_8_SIZE - 1);
+    } else {
+        GAMETEXTLOG_ERROR("Checked speech len: %d, max: %d", speech_len, TEXT_8_SIZE - 1);
+    }
+}
+
+void GameTextFile::Assert_Length_Info(const LengthInfo &len_info)
+{
+    captainslog_dbgassert(TEXT_8_SIZE - 1 > len_info.max_label_len, "Buffer size must be larger");
+    captainslog_dbgassert(TEXT_8_SIZE - 1 > len_info.max_text8_len, "Buffer size must be larger");
+    captainslog_dbgassert(TEXT_16_SIZE - 1 > len_info.max_text16_len, "Buffer size must be larger");
+    captainslog_dbgassert(TEXT_8_SIZE - 1 > len_info.max_speech_len, "Buffer size must be larger");
+}
+
+Utf16String &GameTextFile::Get_Text(StringInfo &string_info, LanguageID language)
+{
+    (void)language;
+    return string_info.text;
+}
+
+Utf16String &GameTextFile::Get_Text(MultiStringInfo &string_info, LanguageID language)
+{
+    return string_info.text[size_t(language)];
+}
+
+Utf8String &GameTextFile::Get_Speech(StringInfo &string_info, LanguageID language)
+{
+    (void)language;
+    return string_info.speech;
+}
+
+Utf8String &GameTextFile::Get_Speech(MultiStringInfo &string_info, LanguageID language)
+{
+    return string_info.speech[size_t(language)];
+}
+
+bool GameTextFile::Read_Multi_STR_File(
+    FileRef &file, StringInfosPtrArray &string_infos_ptrs, Languages languages, Options options)
+{
+    GAMETEXTLOG_INFO("Reading text file '%s' in Multi STR format", file.Get_File_Name().Str());
+
+    MultiStringInfos multi_string_infos;
+    multi_string_infos.reserve(8192);
+
+    Read_STR_File_T(file, multi_string_infos, languages, options);
+
+    Build_String_Infos(string_infos_ptrs, multi_string_infos, options);
+
+    return !multi_string_infos.empty();
+}
+
+bool GameTextFile::Read_STR_File(FileRef &file, StringInfos &string_infos, Options options)
+{
+    GAMETEXTLOG_INFO("Reading text file '%s' in STR format", file.Get_File_Name().Str());
+
+    // Instead of reading the file once from top to bottom to get the number of the entries, we will allocate a very generous
+    // buffer to begin with and shrink it down afterwards. This will reduce algorithm complexity and file access.
+    string_infos.reserve(8192);
+
+    Read_STR_File_T(file, string_infos, LanguageID::UNKNOWN, options);
+
+    if (options.has(Options::Value::OPTIMIZE_MEMORY_SIZE)) {
+        rts::Shrink_To_Fit(string_infos);
+    }
+
+    return !string_infos.empty();
+}
+
+template<typename StringInfosType>
+void GameTextFile::Read_STR_File_T(FileRef &file, StringInfosType &string_infos, Languages languages, Options options)
+{
+    using StringInfoType = typename StringInfosType::value_type;
+
+    StringInfoType string_info;
+    StrParseResult result;
+    LanguageID read_language = LanguageID::UNKNOWN;
+    Utf8Array buf = {};
+    StrReadStep step = StrReadStep::LABEL;
+    const char *eol_chars = "\n";
+
+    while (rts::Read_Line(file.Get_File(), buf.data(), buf.size(), eol_chars)) {
+
+        switch (step) {
+            case StrReadStep::LABEL:
+                string_info = StringInfoType();
+                result = Parse_STR_Label(buf, string_info.label);
+
+                if (result == StrParseResult::IS_LABEL) {
+                    Change_Step(step, StrReadStep::SEARCH, eol_chars);
+                }
+                break;
+
+            case StrReadStep::SEARCH:
+                read_language = LanguageID::UNKNOWN;
+                result = Parse_STR_Search(buf);
+
+                if (result == StrParseResult::IS_PRETEXT) {
+                    size_t parsed_count;
+                    Parse_STR_Language(buf.data(), read_language, parsed_count);
+                    Change_Step(step, StrReadStep::TEXT, eol_chars);
+
+                } else if (result == StrParseResult::IS_SPEECH) {
+                    size_t parsed_count;
+                    Parse_STR_Language(buf.data(), read_language, parsed_count);
+
+                    if (languages.has(read_language)) {
+                        Utf8View view(buf.data() + parsed_count, buf.size() - parsed_count);
+                        Parse_STR_Speech(view, Get_Speech(string_info, read_language));
+                    }
+
+                } else if (result == StrParseResult::IS_END) {
+                    string_infos.push_back(string_info);
+                    Change_Step(step, StrReadStep::LABEL, eol_chars);
+                }
+                break;
+
+            case StrReadStep::TEXT:
+                if (languages.has(read_language)) {
+                    Parse_STR_Text(buf, Get_Text(string_info, read_language), options);
+                }
+                Change_Step(step, StrReadStep::SEARCH, eol_chars);
+                break;
+        }
+    }
+}
+
+GameTextFile::StrParseResult GameTextFile::Parse_STR_Label(Utf8Array &buf, Utf8String &label)
+{
+    rts::Strip_Characters(buf.data(), "\n\r");
+    const size_t len = rts::Strip_Leading_And_Trailing_Spaces(buf.data());
+
+    if (len == 0) {
+        return StrParseResult::IS_NOTHING;
+    }
+
+    if (Is_STR_Comment(buf.data())) {
+        return StrParseResult::IS_NOTHING;
+    }
+
+    label = buf.data();
+    return StrParseResult::IS_LABEL;
+}
+
+GameTextFile::StrParseResult GameTextFile::Parse_STR_Search(Utf8Array &buf)
+{
+    rts::Strip_Characters(buf.data(), "\n\r");
+    const size_t len = rts::Strip_Leading_And_Trailing_Spaces(buf.data());
+
+    if (len == 0) {
+        return StrParseResult::IS_NOTHING;
+    }
+
+    if (Is_STR_Comment(buf.data())) {
+        return StrParseResult::IS_NOTHING;
+    }
+
+    if (Is_STR_End(buf.data())) {
+        return StrParseResult::IS_END;
+    }
+
+    Utf8View view(buf.begin(), len);
+
+    // #TODO the original appears to have some more checks for the Speech string. Could include them here as well.
+
+    return Is_STR_Pre_Text(view) ? StrParseResult::IS_PRETEXT : StrParseResult::IS_SPEECH;
+}
+
+void GameTextFile::Parse_STR_Text(Utf8Array &buf, Utf16String &text, Options options)
+{
+    // Read string can be empty.
+    rts::Strip_Characters(buf.data(), "\n\r");
+    rts::Replace_Characters(buf.data(), "\t\v\f", ' ');
+
+    // STR does support escaped characters for special control characters. When written out as 2 symbol sequence, it will be
+    // converted into single character here. Convert in place.
+    const char *search[6] = { "\\n", "\\t", "\\\"", "\\?", "\\\'", "\\\\" };
+    const char *replace[6] = { "\n", "\t", "\"", "?", "\'", "\\" };
+    size_t len = rts::Replace_Character_Sequences(buf.data(), buf.size(), buf.data(), search, replace);
+
+    // Read string is expected to close with a quote. Remove it here.
+    if (buf[len - 1] == '\"') {
+        buf[len - 1] = '\0';
+    }
+
+    if (!options.has(GameTextOption::KEEP_OBSOLETE_SPACES_ON_LOAD)) {
+        // Strip any remaining obsolete spaces for cleaner presentation in game.
+        rts::Strip_Obsolete_Spaces(buf.data());
+    }
+
+    // Translate final UTF16 string.
+    text.Translate(buf.data());
+}
+
+void GameTextFile::Parse_STR_Speech(Utf8View &buf, Utf8String &speech)
+{
+    rts::Strip_Characters(buf.data(), "\n\r");
+    rts::Strip_Leading_And_Trailing_Spaces(buf.data());
+    speech = buf.data();
+}
+
+bool GameTextFile::Parse_STR_Language(const char *cstring, LanguageID &language, size_t &parsed_count)
+{
+    const size_t code_len = strlen(s_langcodes[0]);
+    const size_t lng_len = sizeof(s_str_lng);
+
+    for (rts::enumerator<LanguageID> it; it < LanguageID::COUNT; ++it) {
+        const char *code = s_langcodes[it.underlying()];
+        if (strncasecmp(cstring, code, code_len) == 0) {
+            if (strncasecmp(cstring + code_len, s_str_lng, lng_len) == 0) {
+                language = it.value();
+                parsed_count = code_len + lng_len;
+                return true;
+            }
+        }
+    }
+    parsed_count = 0;
+    return false;
+}
+
+bool GameTextFile::Is_STR_Pre_Text(Utf8View buf)
+{
+    return !buf.empty() ? (buf.back() == '"') : false;
+}
+
+bool GameTextFile::Is_STR_Comment(const char *cstring)
+{
+    return (cstring[0] == '/' && cstring[1] == '/') || (cstring[0] == '\\' && cstring[1] == '\\');
+}
+
+bool GameTextFile::Is_STR_End(const char *cstring)
+{
+    return (strcasecmp(cstring, "END") == 0);
+}
+
+void GameTextFile::Change_Step(StrReadStep &step, StrReadStep new_step, const char *&eol_chars)
+{
+    step = new_step;
+
+    switch (new_step) {
+        case StrReadStep::LABEL:
+            eol_chars = "\n";
+            break;
+        case StrReadStep::SEARCH:
+            eol_chars = "\n\"";
+            break;
+        case StrReadStep::TEXT:
+            eol_chars = "\"";
+            break;
+    }
+}
+
+bool GameTextFile::Read_CSF_File(FileRef &file, StringInfos &string_infos, LanguageID &language, Options options)
+{
+    GAMETEXTLOG_INFO("Reading text file '%s' in CSF format", file.Get_File_Name().Str());
+
+    bool success = false;
+    Utf16Array buf = {};
+
+    if (Read_CSF_Header(file, string_infos, language)) {
+        success = true;
+
+        for (StringInfo &string_info : string_infos) {
+            if (!Read_CSF_Entry(file, string_info, options, buf)) {
+                success = false;
+                break;
+            }
+        }
+    }
+    return success;
+}
+
+bool GameTextFile::Read_CSF_Header(FileRef &file, StringInfos &string_infos, LanguageID &language)
+{
+    CSFHeader header;
+
+    if (rts::Read_Any(file.Get_File(), header)) {
+        letoh_ref(header.id);
+        letoh_ref(header.langid);
+        letoh_ref(header.num_labels);
+        letoh_ref(header.num_strings);
+        letoh_ref(header.skip);
+        letoh_ref(header.version);
+
+        if (header.id == rts::FourCC_LE<'C', 'S', 'F', ' '>::value) {
+            language = (header.version > 1) ? static_cast<LanguageID>(header.langid) : LanguageID::US;
+            string_infos.resize(header.num_labels);
+            return true;
+        }
+    }
+
+    return false;
+}
+
+bool GameTextFile::Read_CSF_Entry(FileRef &file, StringInfo &string_info, Options options, Utf16Array &buf)
+{
+    int32_t texts;
+
+    if (Read_CSF_Label(file, string_info, texts)) {
+        if (texts == 0) {
+            return true;
+        }
+        if (Read_CSF_Text(file, string_info, options, buf)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GameTextFile::Read_CSF_Label(FileRef &file, StringInfo &string_info, int32_t &texts)
+{
+    CSFLabelHeader header;
+
+    if (rts::Read_Any(file.Get_File(), header)) {
+        letoh_ref(header.id);
+        letoh_ref(header.texts);
+        letoh_ref(header.length);
+
+        if (header.id == rts::FourCC_LE<'L', 'B', 'L', ' '>::value) {
+            const auto view = rts::Make_Resized_Array_View(string_info.label, header.length);
+
+            if (rts::Read_Str(file.Get_File(), view)) {
+                texts = header.texts;
+                return true;
+            }
+        }
+    }
+
+    return false;
+}
+
+bool GameTextFile::Read_CSF_Text(FileRef &file, StringInfo &string_info, Options options, Utf16Array &buf)
+{
+    bool text_ok = false;
+    bool speech_ok = false;
+    bool read_speech = false;
+
+    {
+        CSFTextHeader header;
+
+        if (rts::Read_Any(file.Get_File(), header)) {
+            letoh_ref(header.id);
+            letoh_ref(header.length);
+
+            const size_t capped_text_len = std::min<size_t>(header.length, buf.size() - 1);
+
+            read_speech = (header.id == rts::FourCC_LE<'S', 'T', 'R', 'W'>::value);
+            const bool read_text = (header.id == rts::FourCC_LE<'S', 'T', 'R', ' '>::value);
+
+            if (read_speech || read_text) {
+                auto bufview = rts::Make_Array_View(buf.data(), capped_text_len);
+
+                if (rts::Read_Str(file.Get_File(), bufview)) {
+                    buf[capped_text_len] = U_CHAR('\0');
+
+                    for (size_t i = 0; i < capped_text_len; ++i) {
+                        letoh_ref(bufview[i]);
+                        // Every char is binary flipped here by design.
+                        bufview[i] = ~bufview[i];
+                    }
+
+                    if (!options.has(GameTextOption::KEEP_OBSOLETE_SPACES_ON_LOAD)) {
+                        // Strip obsolete spaces for cleaner presentation in game.
+                        rts::Strip_Obsolete_Spaces(bufview.data());
+                    }
+
+                    string_info.text = buf.data();
+                    text_ok = true;
+                }
+            }
+        }
+    }
+
+    if (read_speech) {
+        CSFSpeechHeader header;
+
+        if (rts::Read_Any(file.Get_File(), header)) {
+            letoh_ref(header.length);
+            const auto view = rts::Make_Resized_Array_View(string_info.speech, header.length);
+
+            if (rts::Read_Str(file.Get_File(), view)) {
+                speech_ok = true;
+            }
+        }
+    }
+
+    return text_ok && (speech_ok || !read_speech);
+}
+
+bool GameTextFile::Write_Multi_STR_File(
+    FileRef &file, const ConstStringInfosPtrArray &string_infos_ptrs, Languages languages, Options options)
+{
+    GAMETEXTLOG_INFO("Writing text file '%s' in Multi STR format", file.Get_File_Name().Str());
+
+    MultiStringInfos multi_string_infos;
+    Build_Multi_String_Infos(multi_string_infos, string_infos_ptrs, options);
+
+    Utf8Array buf = {};
+    Utf8String str;
+    str.Get_Buffer_For_Read(TEXT_8_SIZE);
+
+    for (const MultiStringInfo &string_info : multi_string_infos) {
+        if (!string_info.label.Is_Empty()) {
+            if (!Write_Multi_STR_Entry(file, string_info, languages, options, buf, str)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool GameTextFile::Write_Multi_STR_Entry(
+    FileRef &file, const MultiStringInfo &string_info, Languages languages, Options options, Utf8Array &buf, Utf8String &str)
+{
+    bool ok = true;
+
+    ok &= Write_STR_Label(file, string_info.label);
+
+    For_Each_Language(languages, [&](LanguageID language) {
+        const size_t index = static_cast<size_t>(language);
+        ok &= Write_STR_Language(file, language);
+        ok &= Write_STR_Text(file, string_info.text[index], options, buf, str);
+    });
+
+    For_Each_Language(languages, [&](LanguageID language) {
+        const size_t index = static_cast<size_t>(language);
+        if (!string_info.speech[index].Is_Empty()) {
+            ok &= Write_STR_Language(file, language);
+            ok &= Write_STR_Speech(file, string_info.speech[index]);
+        }
+    });
+
+    ok &= Write_STR_End(file);
+
+    return ok;
+}
+
+bool GameTextFile::Write_STR_Language(FileRef &file, LanguageID language)
+{
+    const char *code = Get_Language_Code(language);
+
+    bool ok = true;
+    ok &= rts::Write_Str(file.Get_File(), rts::Make_Array_View(code));
+    ok &= rts::Write_Any(file.Get_File(), s_str_lng);
+    ok &= rts::Write_Any(file.Get_File(), ' ');
+    return ok;
+}
+
+bool GameTextFile::Write_STR_File(FileRef &file, const StringInfos &string_infos, Options options)
+{
+    GAMETEXTLOG_INFO("Writing text file '%s' in STR format", file.Get_File_Name().Str());
+
+    Utf8Array buf = {};
+    Utf8String str;
+    str.Get_Buffer_For_Read(TEXT_8_SIZE);
+
+    for (const StringInfo &string_info : string_infos) {
+        if (!string_info.label.Is_Empty()) {
+            if (!Write_STR_Entry(file, string_info, options, buf, str)) {
+                return false;
+            }
+        }
+    }
+    return true;
+}
+
+bool GameTextFile::Write_STR_Entry(
+    FileRef &file, const StringInfo &string_info, Options options, Utf8Array &buf, Utf8String &str)
+{
+    bool ok = true;
+    ok &= Write_STR_Label(file, string_info.label);
+    ok &= Write_STR_Text(file, string_info.text, options, buf, str);
+
+    if (!string_info.speech.Is_Empty()) {
+        ok &= Write_STR_Speech(file, string_info.speech);
+    }
+    ok &= Write_STR_End(file);
+    return ok;
+}
+
+bool GameTextFile::Write_STR_Label(FileRef &file, const Utf8String &label)
+{
+    bool ok = true;
+    ok &= rts::Write_Str(file.Get_File(), rts::Make_Array_View(label));
+    ok &= rts::Write_Any(file.Get_File(), s_str_eol);
+    return ok;
+}
+
+bool GameTextFile::Write_STR_Text(FileRef &file, const Utf16String &text, Options options, Utf8Array &buf, Utf8String &str)
+{
+    // Convert utf16 to utf8.
+    str.Translate(text.Str());
+
+    // STR does support escaped characters for special control characters. Write them out as escaped characters so they
+    // are easily modifiable in text editor.
+    const char *search[4] = { "\n", "\t", "\"", "\\" };
+    const char *replace[4] = { "\\n", "\\t", "\\\"", "\\\\" };
+
+    if (options.has(Options::Value::WRITE_EXTRA_LF_ON_STR_SAVE)) {
+        replace[0] = "\\n\r\n";
+    }
+    size_t len = rts::Replace_Character_Sequences(buf.data(), buf.size(), str.Str(), search, replace);
+
+    bool ok = true;
+    ok &= rts::Write_Any(file.Get_File(), s_str_quo);
+    ok &= rts::Write_Str(file.Get_File(), rts::Make_Array_View(buf.data(), len));
+    ok &= rts::Write_Any(file.Get_File(), s_str_quo);
+    ok &= rts::Write_Any(file.Get_File(), s_str_eol);
+    return ok;
+}
+
+bool GameTextFile::Write_STR_Speech(FileRef &file, const Utf8String &speech)
+{
+    bool ok = true;
+    ok &= rts::Write_Str(file.Get_File(), rts::Make_Array_View(speech));
+    ok &= rts::Write_Any(file.Get_File(), s_str_eol);
+    return ok;
+}
+
+bool GameTextFile::Write_STR_End(FileRef &file)
+{
+    bool ok = true;
+    ok &= rts::Write_Any(file.Get_File(), s_str_end);
+    ok &= rts::Write_Any(file.Get_File(), s_str_eol);
+    ok &= rts::Write_Any(file.Get_File(), s_str_eol);
+    return ok;
+}
+
+bool GameTextFile::Write_CSF_File(FileRef &file, const StringInfos &string_infos, const LanguageID &language)
+{
+    GAMETEXTLOG_INFO("Writing text file '%s' in CSF format", file.Get_File_Name().Str());
+
+    bool success = false;
+
+    if (Write_CSF_Header(file, string_infos, language)) {
+        success = true;
+        Utf16Array buf = {};
+        int string_index = 0;
+
+        for (const StringInfo &string_info : string_infos) {
+            ++string_index;
+
+            if (string_info.label.Is_Empty()) {
+                GAMETEXTLOG_ERROR("String %d has no label", string_index);
+                continue;
+            }
+
+            if (!Write_CSF_Entry(file, string_info, buf)) {
+                success = false;
+                break;
+            }
+        }
+    }
+    return success;
+}
+
+bool GameTextFile::Write_CSF_Header(FileRef &file, const StringInfos &string_infos, const LanguageID &language)
+{
+    CSFHeader header;
+    header.id = rts::FourCC_LE<'C', 'S', 'F', ' '>::value;
+    header.version = 3;
+    header.num_labels = string_infos.size();
+    header.num_strings = string_infos.size();
+    header.skip = rts::FourCC_LE<'T', 'H', 'Y', 'M'>::value;
+    header.langid = language;
+    htole_ref(header.id);
+    htole_ref(header.version);
+    htole_ref(header.num_labels);
+    htole_ref(header.num_strings);
+    htole_ref(header.skip);
+    htole_ref(header.langid);
+
+    return rts::Write_Any(file.Get_File(), header);
+}
+
+bool GameTextFile::Write_CSF_Entry(FileRef &file, const StringInfo &string_info, Utf16Array &buf)
+{
+    if (Write_CSF_Label(file, string_info)) {
+        if (Write_CSF_Text(file, string_info, buf)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GameTextFile::Write_CSF_Label(FileRef &file, const StringInfo &string_info)
+{
+    CSFLabelHeader header;
+    header.id = rts::FourCC_LE<'L', 'B', 'L', ' '>::value;
+    header.texts = string_info.text.Is_Empty() ? 0 : 1;
+    header.length = string_info.label.Get_Length();
+    htole_ref(header.id);
+    htole_ref(header.texts);
+    htole_ref(header.length);
+
+    if (rts::Write_Any(file.Get_File(), header)) {
+        if (rts::Write_Str(file.Get_File(), rts::Make_Array_View(string_info.label))) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool GameTextFile::Write_CSF_Text(FileRef &file, const StringInfo &string_info, Utf16Array &buf)
+{
+    bool text_ok = false;
+    bool speech_ok = false;
+    const size_t text_len = string_info.text.Get_Length();
+    const size_t speech_len = string_info.speech.Get_Length();
+    const bool write_text = (text_len > 0);
+    const bool write_speech = (speech_len > 0);
+
+    if (write_text) {
+        const size_t capped_text_len = std::min<size_t>(text_len, buf.size() - 1);
+
+        CSFTextHeader header;
+        header.id = write_speech ? rts::FourCC_LE<'S', 'T', 'R', 'W'>::value : rts::FourCC_LE<'S', 'T', 'R', ' '>::value;
+        header.length = capped_text_len;
+        htole_ref(header.id);
+        htole_ref(header.length);
+
+        if (rts::Write_Any(file.Get_File(), header)) {
+
+            for (size_t i = 0; i < capped_text_len; ++i) {
+                // Every char is binary flipped here by design.
+                buf[i] = ~string_info.text[i];
+                htole_ref(buf[i]);
+            }
+
+            if (rts::Write(file.Get_File(), buf.data(), capped_text_len * sizeof(Utf16View::value_type))) {
+                text_ok = true;
+            }
+        }
+    }
+
+    if (text_ok && write_speech) {
+        CSFSpeechHeader header;
+        header.length = string_info.speech.Get_Length();
+        htole_ref(header.length);
+
+        if (rts::Write_Any(file.Get_File(), header)) {
+            if (rts::Write_Str(file.Get_File(), rts::Make_Array_View(string_info.speech))) {
+                speech_ok = true;
+            }
+        }
+    }
+    return (text_ok || !write_text) && (speech_ok || !write_speech);
+}
+
+void GameTextFile::Log_Line(const char *prefix, const char *format, ...)
+{
+    FILE *file = s_logfile;
+
+    if (file != nullptr) {
+        va_list args;
+        va_start(args, format);
+        fputs(prefix, file);
+        vfprintf(file, format, args);
+        fputs("\n", file);
+        va_end(args);
+        fflush(file);
+    }
+}
+
+} // namespace Thyme
+
+#undef GAMETEXTLOG_TRACE
+#undef GAMETEXTLOG_DEBUG
+#undef GAMETEXTLOG_INFO
+#undef GAMETEXTLOG_WARN
+#undef GAMETEXTLOG_ERROR
+#undef GAMETEXTLOG_FATAL

--- a/src/game/client/gametextfile.h
+++ b/src/game/client/gametextfile.h
@@ -1,0 +1,252 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Localization File. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "fileref.h"
+#include "gametextcommon.h"
+#include "utility/array.h"
+#include "utility/arrayview.h"
+#include "utility/ebitflags.h"
+#include "utility/enumerator.h"
+#include "utility/enumflags.h"
+
+namespace Thyme
+{
+
+enum class GameTextOption : uint32_t
+{
+    NONE = 0,
+    OPTIMIZE_MEMORY_SIZE = (1 << 0),
+    CHECK_BUFFER_LENGTH_ON_LOAD = (1 << 1),
+    CHECK_BUFFER_LENGTH_ON_SAVE = (1 << 2),
+    KEEP_OBSOLETE_SPACES_ON_LOAD = (1 << 3),
+    WRITE_EXTRA_LF_ON_STR_SAVE = (1 << 4),
+};
+
+bool Name_To_Game_Text_Option(const char *name, GameTextOption &option);
+
+} // namespace Thyme
+
+DEFINE_RTS_UNDERLYING_TYPE(Thyme::GameTextOption, uint32_t);
+
+namespace Thyme
+{
+
+// #TODO Split the multi language functionality from 'GameTextFile' into a new 'MultiGameTextFile' class?
+// #TODO Return error codes for load and save?
+
+// #FEATURE GameTextFile contains the core file handling functionality of original GameTextManager, which allows to use it
+// for more flexible localization file operations.
+class GameTextFile
+{
+public:
+    using Options = rts::ebitflags<GameTextOption>;
+    using Languages = rts::enumflags<LanguageID, g_languageCount>;
+
+public:
+    GameTextFile();
+
+    // Checks whether or not localization is loaded.
+    bool Is_Loaded() const;
+    bool Is_Loaded(Languages languages) const;
+    bool Is_Any_Loaded(Languages languages) const;
+
+    // Loads CSF or STR file from disk. Does not unload previous data on failure.
+    bool Load(const char *filename);
+    bool Load_CSF(const char *filename);
+    bool Load_STR(const char *filename);
+    bool Load_Multi_STR(const char *filename, Languages languages);
+
+    // Saves CSF or STR file to disk. Will write over any existing file.
+    bool Save(const char *filename);
+    bool Save_CSF(const char *filename);
+    bool Save_STR(const char *filename);
+    bool Save_Multi_STR(const char *filename, Languages languages);
+
+    // Unloads language data.
+    void Unload();
+    void Unload(Languages languages);
+
+    // Unloads all data and resets all settings.
+    void Reset();
+
+    // Merges another game text into this one. Identical labels will write their text contents from the other to this.
+    void Merge_And_Overwrite(const GameTextFile &other);
+    void Merge_And_Overwrite(const GameTextFile &other, Languages languages);
+
+    // Retrieves all localization data.
+    const StringInfos &Get_String_Infos() const;
+    const StringInfos &Get_String_Infos(LanguageID language) const;
+
+    // Sets options for loading and saving files.
+    void Set_Options(Options options);
+    Options Get_Options() const;
+
+    // Sets the active language used by this instance. Loading a CSF file will automatically change active language.
+    void Set_Language(LanguageID language);
+    LanguageID Get_Language() const;
+
+    // Swaps strings from one language to another one.
+    void Swap_String_Infos(LanguageID left, LanguageID right);
+
+    // Optional logging stream. Works besides captains log.
+    static void Set_Log_File(FILE *log);
+
+private:
+    enum class FileType
+    {
+        AUTO,
+        CSF,
+        STR,
+        MULTI_STR,
+
+        COUNT,
+    };
+
+    enum class StrReadStep
+    {
+        LABEL,
+        SEARCH,
+        TEXT,
+    };
+
+    enum class StrParseResult
+    {
+        IS_NOTHING,
+        IS_LABEL,
+        IS_PRETEXT,
+        IS_SPEECH,
+        IS_END,
+    };
+
+    struct LengthInfo
+    {
+        int max_label_len;
+        int max_text8_len;
+        int max_text16_len;
+        int max_speech_len;
+    };
+
+    // https://www.rfc-editor.org/rfc/rfc3629
+    // In UTF-8, characters from the U+0000..U+10FFFF range (the UTF-16
+    // accessible range) are encoded using sequences of 1 to 4 octets.
+    enum : size_t
+    {
+        TEXT_16_SIZE = 1024,
+        TEXT_8_SIZE = TEXT_16_SIZE * 4,
+    };
+
+    using StringInfosArray = rts::array<StringInfos, g_languageCount>;
+    using ConstStringInfosPtrArray = rts::array<const StringInfos *, g_languageCount>;
+    using StringInfosPtrArray = rts::array<StringInfos *, g_languageCount>;
+    using Utf8Array = rts::array<char, TEXT_8_SIZE>;
+    using Utf16Array = rts::array<unichar_t, TEXT_16_SIZE>;
+    using Utf8View = rts::array_view<char>;
+    using Utf16View = rts::array_view<unichar_t>;
+
+private:
+    bool Load(const char *filename, FileType filetype, Languages languages);
+    bool Save(const char *filename, FileType filetype, Languages languages);
+
+    void Merge_And_Overwrite_Internal(const GameTextFile &other, LanguageID language);
+    void Check_Buffer_Lengths(LanguageID language);
+
+    StringInfos &Mutable_String_Infos();
+    StringInfos &Mutable_String_Infos(LanguageID language);
+
+    template<typename Functor> static void For_Each_Language(Languages languages, Functor functor);
+    static StringInfosPtrArray Build_String_Infos_Ptrs_Array(StringInfosArray &string_infos_array, Languages languages);
+    static ConstStringInfosPtrArray Build_Const_String_Infos_Ptrs_Array(
+        StringInfosArray &string_infos_array, Languages languages);
+
+    static size_t Get_Max_Size(const ConstStringInfosPtrArray &string_infos_ptrs);
+
+    static void Build_Multi_String_Infos(
+        MultiStringInfos &multi_string_infos, const ConstStringInfosPtrArray &string_infos_ptrs, Options options);
+    static void Build_String_Infos(
+        StringInfosPtrArray &string_infos_ptrs, const MultiStringInfos &multi_string_infos, Options options);
+
+    static bool Get_Language_With_String_Infos(
+        LanguageID &language, const StringInfosPtrArray &string_infos_ptrs, size_t occurence = 0);
+
+    static Languages Filter_Usable_Languages(Languages languages);
+    static bool Supports_Multi_Language(FileType filetype);
+    static FileType Get_File_Type(const char *filename, FileType filetype);
+
+    static void Collect_Length_Info(LengthInfo &len_info, const StringInfos &strings);
+    static void Log_Length_Info(const LengthInfo &len_info);
+    static void Assert_Length_Info(const LengthInfo &len_info);
+
+    static Utf16String &Get_Text(StringInfo &string_info, LanguageID language);
+    static Utf16String &Get_Text(MultiStringInfo &string_info, LanguageID language);
+    static Utf8String &Get_Speech(StringInfo &string_info, LanguageID language);
+    static Utf8String &Get_Speech(MultiStringInfo &string_info, LanguageID language);
+
+    static bool Read_Multi_STR_File(
+        FileRef &file, StringInfosPtrArray &string_infos_ptrs, Languages languages, Options options);
+    static bool Read_STR_File(FileRef &file, StringInfos &string_infos, Options options);
+    template<typename StringInfosType>
+    static void Read_STR_File_T(FileRef &file, StringInfosType &string_infos, Languages languages, Options options);
+    static StrParseResult Parse_STR_Label(Utf8Array &buf, Utf8String &label);
+    static StrParseResult Parse_STR_Search(Utf8Array &buf);
+    static void Parse_STR_Text(Utf8Array &buf, Utf16String &text, Options options);
+    static void Parse_STR_Speech(Utf8View &buf, Utf8String &speech);
+    static bool Parse_STR_Language(const char *cstring, LanguageID &language, size_t &parsed_count);
+    static bool Is_STR_Pre_Text(Utf8View buf);
+    static bool Is_STR_Comment(const char *cstring);
+    static bool Is_STR_End(const char *cstring);
+    static void Change_Step(StrReadStep &step, StrReadStep new_step, const char *&eol_chars);
+
+    static bool Read_CSF_File(FileRef &file, StringInfos &string_infos, LanguageID &language, Options options);
+    static bool Read_CSF_Header(FileRef &file, StringInfos &string_infos, LanguageID &language);
+    static bool Read_CSF_Entry(FileRef &file, StringInfo &string_info, Options options, Utf16Array &buf);
+    static bool Read_CSF_Label(FileRef &file, StringInfo &string_info, int32_t &texts);
+    static bool Read_CSF_Text(FileRef &file, StringInfo &string_info, Options options, Utf16Array &buf);
+
+    static bool Write_Multi_STR_File(
+        FileRef &file, const ConstStringInfosPtrArray &string_infos_ptrs, Languages languages, Options options);
+    static bool Write_Multi_STR_Entry(FileRef &file,
+        const MultiStringInfo &string_info,
+        Languages languages,
+        Options options,
+        Utf8Array &buf,
+        Utf8String &str);
+    static bool Write_STR_Language(FileRef &file, LanguageID language);
+
+    static bool Write_STR_File(FileRef &file, const StringInfos &string_infos, Options options);
+    static bool Write_STR_Entry(
+        FileRef &file, const StringInfo &string_info, Options options, Utf8Array &buf, Utf8String &str);
+    static bool Write_STR_Label(FileRef &file, const Utf8String &label);
+    static bool Write_STR_Text(FileRef &file, const Utf16String &text, Options options, Utf8Array &buf, Utf8String &str);
+    static bool Write_STR_Speech(FileRef &file, const Utf8String &speech);
+    static bool Write_STR_End(FileRef &file);
+
+    static bool Write_CSF_File(FileRef &file, const StringInfos &string_infos, const LanguageID &language);
+    static bool Write_CSF_Header(FileRef &file, const StringInfos &string_infos, const LanguageID &language);
+    static bool Write_CSF_Entry(FileRef &file, const StringInfo &string_info, Utf16Array &buf);
+    static bool Write_CSF_Label(FileRef &file, const StringInfo &string_info);
+    static bool Write_CSF_Text(FileRef &file, const StringInfo &string_info, Utf16Array &buf);
+
+    static void Log_Line(const char *prefix, const char *format, ...);
+
+private:
+    Options m_options;
+    LanguageID m_language;
+    StringInfosArray m_stringInfosArray;
+
+    static FILE *s_logfile;
+};
+
+} // namespace Thyme

--- a/src/game/client/gametextinterface.cpp
+++ b/src/game/client/gametextinterface.cpp
@@ -1,0 +1,19 @@
+/**
+ * @file
+ *
+ * @author OmniBlade
+ *
+ * @brief Interface for Game Localization.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "gametextinterface.h"
+
+#ifndef GAME_DLL
+GameTextInterface *g_theGameText = nullptr;
+#endif

--- a/src/game/client/gametextinterface.h
+++ b/src/game/client/gametextinterface.h
@@ -1,0 +1,37 @@
+/**
+ * @file
+ *
+ * @author OmniBlade
+ *
+ * @brief Interface for Game Localization.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "asciistring.h"
+#include "subsysteminterface.h"
+#include "unicodestring.h"
+
+class GameTextInterface : public SubsystemInterface
+{
+public:
+    virtual ~GameTextInterface() {}
+
+    virtual Utf16String Fetch(const char *args, bool *success = nullptr) = 0;
+    virtual Utf16String Fetch(Utf8String args, bool *success = nullptr) = 0;
+    virtual std::vector<Utf8String> *Get_Strings_With_Prefix(Utf8String label) = 0;
+    virtual void Init_Map_String_File(Utf8String const &filename) = 0;
+    virtual void Deinit() = 0;
+};
+
+#ifdef GAME_DLL
+extern GameTextInterface *&g_theGameText;
+#else
+extern GameTextInterface *g_theGameText;
+#endif

--- a/src/game/client/gametextlookup.h
+++ b/src/game/client/gametextlookup.h
@@ -1,0 +1,118 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Localization Lookup. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "gametextcommon.h"
+#include "utility/stlutil.h"
+#include <cstdlib>
+
+namespace Thyme
+{
+
+struct ConstStringLookup
+{
+    const char *label;
+    const StringInfo *string_info;
+};
+
+struct MutableStringLookup
+{
+    const char *label;
+    StringInfo *string_info;
+};
+
+struct ConstMultiStringLookup
+{
+    const char *label;
+    const MultiStringInfo *string_info;
+};
+
+struct MutableMultiStringLookup
+{
+    const char *label;
+    MultiStringInfo *string_info;
+};
+
+// #FEATURE Template class to build a lookup map to help find strings by their label from a given string info container.
+// Prefer using the type aliases further down below. An instance of this class must not be used after the source string info
+// container has been changed or deleted.
+template<typename StringLookup, typename StringInfos> class GameTextLookup
+{
+    using StringLookups = std::vector<StringLookup>;
+
+public:
+    explicit GameTextLookup() {}
+    explicit GameTextLookup(StringInfos &string_infos) { Load(string_infos); }
+
+    void Load(StringInfos &string_infos)
+    {
+        if (string_infos.empty()) {
+            return;
+        }
+
+        const size_t string_count = string_infos.size();
+        m_stringLookups.resize(string_count);
+
+        for (size_t i = 0; i < string_count; ++i) {
+            m_stringLookups[i].label = string_infos[i].label.Str();
+            m_stringLookups[i].string_info = &string_infos[i];
+        }
+
+        void *base = &m_stringLookups[0];
+        const size_t item_count = m_stringLookups.size();
+        const size_t item_size = sizeof(StringLookup);
+
+        qsort(base, item_count, item_size, Compare_LUT);
+    }
+
+    void Unload() { rts::Free_Container(m_stringLookups); }
+
+    const StringLookup *Find(const char *label) const
+    {
+        if (m_stringLookups.empty()) {
+            return nullptr;
+        }
+
+        StringLookup key;
+        key.label = label;
+        key.string_info = nullptr;
+
+        const void *base = &m_stringLookups[0];
+        const size_t item_count = m_stringLookups.size();
+        const size_t item_size = sizeof(StringLookup);
+
+        return static_cast<const StringLookup *>(bsearch(&key, base, item_count, item_size, Compare_LUT));
+    }
+
+private:
+    static int Compare_LUT(const void *a, const void *b)
+    {
+        const char *ac = static_cast<const StringLookup *>(a)->label;
+        const char *bc = static_cast<const StringLookup *>(b)->label;
+
+        return strcasecmp(ac, bc);
+    }
+
+    StringLookups m_stringLookups;
+};
+
+// Aliases for convenience.
+
+using ConstGameTextLookup = GameTextLookup<ConstStringLookup, const StringInfos>;
+using MutableGameTextLookup = GameTextLookup<MutableStringLookup, StringInfos>;
+using ConstMultiGameTextLookup = GameTextLookup<ConstMultiStringLookup, const MultiStringInfos>;
+using MutableMultiGameTextLookup = GameTextLookup<MutableMultiStringLookup, MultiStringInfos>;
+
+} // namespace Thyme

--- a/src/game/client/gametextmanager.cpp
+++ b/src/game/client/gametextmanager.cpp
@@ -1,0 +1,270 @@
+/**
+ * @file
+ *
+ * @author OmniBlade
+ * @author xezon
+ *
+ * @brief Game Localization Manager. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "gametextmanager.h"
+#include "filesystem.h"
+#include "registry.h"
+#include "rtsutils.h"
+#include <algorithm>
+#include <captainslog.h>
+
+#ifdef PLATFORM_WINDOWS
+#include "main.h"
+#include <winuser.h>
+#endif
+
+namespace Thyme
+{
+
+// #OBSOLETE Kept for ABI compatibility.
+struct StringLookUp
+{
+    const Utf8String *label;
+    const StringInfo *info;
+};
+
+// #OBSOLETE Kept for ABI compatibility.
+// Comparison function used for sorting and searching StringLookUp arrays.
+int GameTextManager::Compare_LUT(void const *a, void const *b)
+{
+    const char *ac = static_cast<StringLookUp const *>(a)->label->Str();
+    const char *bc = static_cast<StringLookUp const *>(b)->label->Str();
+
+    return strcasecmp(ac, bc);
+}
+
+GameTextInterface *GameTextManager::Create_Game_Text_Interface()
+{
+    return new GameTextManager;
+}
+
+GameTextManager::GameTextManager() :
+    m_initialized(false),
+    m_useStringFile(true),
+    m_failed(U_CHAR("***FATAL*** String Manager failed to initialize properly")),
+    m_textFile(),
+    m_textLookup(),
+    m_mapTextFile(),
+    m_mapTextLookup(),
+    m_noStringList(nullptr),
+    m_stringVector()
+{
+}
+
+GameTextManager::~GameTextManager()
+{
+    Reset();
+    Deinit();
+}
+
+void GameTextManager::Init()
+{
+    captainslog_info("Initializing GameTextManager.");
+    if (m_initialized) {
+        return;
+    }
+
+    const Utf8String language_str = Get_Registry_Language();
+    bool loaded = false;
+
+    if (m_useStringFile) {
+        // Standard behavior.
+        m_textFile.Set_Language(LanguageID::UNKNOWN);
+
+        if (m_textFile.Load_STR("data/Generals.str")) {
+            loaded = true;
+        } else {
+            // Non standard behavior. Try loading STR string from different places.
+            LanguageID language;
+            if (Name_To_Language(language_str.Str(), language)) {
+                m_textFile.Set_Language(language);
+
+                if (m_textFile.Load_STR("data/Generals.str")) {
+                    loaded = true;
+                } else {
+                    Utf8String str_file;
+                    str_file.Format("data/%s/Generals.str", language_str.Str());
+                    m_textFile.Set_Language(LanguageID::UNKNOWN);
+
+                    if (m_textFile.Load_STR(str_file.Str())) {
+                        m_textFile.Swap_String_Infos(LanguageID::UNKNOWN, language);
+                        m_textFile.Set_Language(language);
+                        loaded = true;
+                    } else {
+                        m_textFile.Set_Language(language);
+
+                        if (m_textFile.Load_STR(str_file.Str())) {
+                            loaded = true;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if (!loaded) {
+        Utf8String csf_file;
+        csf_file.Format("data/%s/Generals.csf", language_str.Str());
+        if (m_textFile.Load_CSF(csf_file.Str())) {
+            loaded = true;
+        }
+    }
+
+    if (!loaded) {
+        Deinit();
+        return;
+    }
+
+    m_textLookup.Load(m_textFile.Get_String_Infos());
+
+    // Fetch the GUI window title string and set it here.
+    Utf8String ntitle;
+    Utf16String wtitle;
+    // #FEATURE Add Thyme text to window name.
+    wtitle = U_CHAR("Thyme - ");
+    wtitle += Fetch("GUI:Command&ConquerGenerals");
+
+    ntitle.Translate(wtitle);
+
+#ifdef PLATFORM_WINDOWS
+    if (g_applicationHWnd != 0) {
+        SetWindowTextA(g_applicationHWnd, ntitle.Str());
+        SetWindowTextW(g_applicationHWnd, (const wchar_t *)wtitle.Str());
+    }
+#endif
+}
+
+// Resets the map strings, main string file is left loaded.
+void GameTextManager::Reset()
+{
+    m_mapTextLookup.Unload();
+    m_mapTextFile.Unload();
+}
+
+// Find and return the unicode string corresponding to the label provided.
+// Optionally can pass a bool pointer to determine if a string was found.
+Utf16String GameTextManager::Fetch(Utf8String args, bool *success)
+{
+    return Fetch(args.Str(), success);
+}
+
+// Find and return the unicode string corresponding to the label provided.
+// Optionally can pass a bool pointer to determine if a string was found.
+Utf16String GameTextManager::Fetch(const char *args, bool *success)
+{
+    if (!m_textFile.Is_Loaded()) {
+        if (success != nullptr) {
+            *success = false;
+        }
+        return m_failed;
+    }
+
+    const ConstStringLookup *found = m_textLookup.Find(args);
+
+    if (found != nullptr) {
+        if (success != nullptr) {
+            *success = true;
+        }
+        return found->string_info->text;
+    }
+
+    found = m_textLookup.Find(args);
+
+    if (found != nullptr) {
+        if (success != nullptr) {
+            *success = true;
+        }
+        return found->string_info->text;
+    }
+
+    if (success != nullptr) {
+        *success = false;
+    }
+
+    // If we reached here, we didn't find a string from our string file.
+    Utf16String missing;
+    NoString *no_string;
+
+    missing.Format(U_CHAR("MISSING: '%hs'"), args);
+
+    // Find missing string in NoString list if it already exists.
+    for (no_string = m_noStringList; no_string != nullptr; no_string = no_string->next) {
+        if (missing == no_string->text) {
+            break;
+        }
+    }
+
+    // If it was not found or the list was empty, add a new one.
+    if (no_string == nullptr) {
+        no_string = new NoString;
+        no_string->text = missing;
+        no_string->next = m_noStringList;
+        m_noStringList = no_string;
+    }
+
+    return no_string->text;
+}
+
+// List all string labels that start with the prefix passed to the function.
+std::vector<Utf8String> *GameTextManager::Get_Strings_With_Prefix(Utf8String label)
+{
+    m_stringVector.clear();
+    const char *other_label = label.Str();
+
+    Collect_Labels_With_Prefix(m_stringVector, label, m_textFile.Get_String_Infos());
+    Collect_Labels_With_Prefix(m_stringVector, label, m_mapTextFile.Get_String_Infos());
+
+    return &m_stringVector;
+}
+
+void GameTextManager::Collect_Labels_With_Prefix(
+    Utf8Strings &found_labels, const Utf8String &search_label, const StringInfos &string_infos)
+{
+    const char *search_label_str = search_label.Str();
+
+    for (const StringInfo &string_info : string_infos) {
+        const char *found_label = string_info.label.Str();
+
+        if (strstr(found_label, search_label_str) == found_label) {
+            found_labels.push_back(string_info.label);
+        }
+    }
+}
+
+// Initializes a string file associated with a specific map. Resources
+// allocated here are freed by GameTextManager::Reset()
+void GameTextManager::Init_Map_String_File(Utf8String const &filename)
+{
+    if (m_mapTextFile.Load_STR(filename.Str())) {
+        m_mapTextLookup.Load(m_mapTextFile.Get_String_Infos());
+    }
+}
+
+// Destroys the main string file, doesn't affect loaded map strings.
+void GameTextManager::Deinit()
+{
+    m_textLookup.Unload();
+    m_textFile.Unload();
+
+    for (NoString *ns = m_noStringList; ns != nullptr;) {
+        NoString *tmp = ns;
+        ns = tmp->next;
+        delete tmp;
+    }
+
+    m_noStringList = nullptr;
+    m_initialized = false;
+}
+} // namespace Thyme

--- a/src/game/client/gametextmanager.h
+++ b/src/game/client/gametextmanager.h
@@ -1,0 +1,68 @@
+/**
+ * @file
+ *
+ * @author OmniBlade
+ * @author xezon
+ *
+ * @brief Game Localization Manager. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "always.h"
+#include "gametextcommon.h"
+#include "gametextfile.h"
+#include "gametextinterface.h"
+#include "gametextlookup.h"
+
+namespace Thyme
+{
+// #FEATURE New GameTextManager with new features. Can read UTF-8 STR Files. GameTextManager is self contained and will
+// automatically load and read generals.csf, generals.str and map.str files.
+class GameTextManager : public GameTextInterface
+{
+    using Utf8Strings = std::vector<Utf8String>;
+
+public:
+    GameTextManager();
+    virtual ~GameTextManager();
+
+    virtual void Init() override;
+    virtual void Reset() override;
+    virtual void Update() override {}
+
+    virtual Utf16String Fetch(const char *args, bool *success = nullptr) override;
+    virtual Utf16String Fetch(Utf8String args, bool *success = nullptr) override;
+    virtual std::vector<Utf8String> *Get_Strings_With_Prefix(Utf8String label) override;
+    virtual void Init_Map_String_File(Utf8String const &filename) override;
+    virtual void Deinit() override;
+
+    static int Compare_LUT(void const *a, void const *b);
+    static GameTextInterface *Create_Game_Text_Interface();
+
+private:
+    static void Collect_Labels_With_Prefix(
+        Utf8Strings &found_labels, const Utf8String &search_label, const StringInfos &string_infos);
+
+    bool m_initialized;
+    bool m_useStringFile;
+    Utf16String m_failed;
+
+    // Main localization
+    GameTextFile m_textFile;
+    ConstGameTextLookup m_textLookup;
+
+    // Map localization
+    GameTextFile m_mapTextFile;
+    ConstGameTextLookup m_mapTextLookup;
+
+    NoString *m_noStringList;
+    Utf8Strings m_stringVector;
+};
+} // namespace Thyme

--- a/src/game/client/input/mouse.cpp
+++ b/src/game/client/input/mouse.cpp
@@ -16,7 +16,7 @@
 #include "mouse.h"
 #include "colorspace.h"
 #include "displaystringmanager.h"
-#include "gametext.h"
+#include "gametextinterface.h"
 #include "globaldata.h"
 #include "ini.h"
 #include "keyboard.h"

--- a/src/game/common/gameengine.cpp
+++ b/src/game/common/gameengine.cpp
@@ -21,7 +21,7 @@
 #include "filesystem.h"
 #include "functionlexicon.h"
 #include "gamelod.h"
-#include "gametext.h"
+#include "gametext_impl.h"
 #include "globaldata.h"
 #include "globallanguage.h"
 #include "ini.h"

--- a/src/game/common/ini/ini.cpp
+++ b/src/game/common/ini/ini.cpp
@@ -26,7 +26,7 @@
 #include "fxlist.h"
 #include "gamelod.h"
 #include "gamemath.h"
-#include "gametext.h"
+#include "gametextinterface.h"
 #include "gametype.h"
 #include "globaldata.h"
 #include "globallanguage.h"

--- a/src/game/common/system/file.h
+++ b/src/game/common/system/file.h
@@ -29,6 +29,7 @@ struct FileInfo
 namespace Thyme
 {
 // Thyme specific
+template<typename> class FileRefT;
 
 // Returns integer of given mode and BUFFERED flag and encoded buffer size.
 // Buffer size min: 0, max: 4194240, in 64 byte increments.
@@ -38,8 +39,12 @@ int Encode_Buffered_File_Mode(int mode, int buffer_size);
 bool Decode_Buffered_File_Mode(int mode, int &buffer_size);
 } // namespace Thyme
 
+// Game file class. Can read and write file data. When using File*, then call Close() function when done with it. Prefer
+// wrapping File* in FileRef when writing new feature code to avoid misuse.
 class File : public MemoryPoolObject
 {
+    template<typename> friend class Thyme::FileRefT;
+
     IMPLEMENT_ABSTRACT_POOL(File);
 
 public:
@@ -89,10 +94,14 @@ public:
 
     bool Eof();
 
-    const char *Get_Name() { return m_name.Str(); }
+    const char *Get_Name() const { return m_name.Str(); }
     void Set_Name(const char *name) { m_name = name; }
-    int Get_Access() { return m_access; }
+    int Get_Access() const { return m_access; }
     void Delete_On_Close() { m_deleteOnClose = true; }
+
+    // Thyme specific
+    void Delete_On_Close(bool del) { m_deleteOnClose = del; }
+    const Utf8String &Get_File_Name() { return m_name; }
 
 protected:
     File() : m_access(0), m_open(false), m_deleteOnClose(false) { Set_Name("<no file>"); }

--- a/src/game/common/system/fileref.h
+++ b/src/game/common/system/fileref.h
@@ -1,0 +1,149 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief File Reference class to use with File class. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "file.h"
+#include "utility/shared_ptr.h"
+
+class File;
+
+namespace Thyme
+{
+
+// #FEATURE Reference counted file class that automatically closes the assigned file when all references are destroyed.
+template<typename Counter> class FileRefT
+{
+private:
+    struct FileWrapper
+    {
+        File *file = nullptr;
+    };
+
+    struct FileWrapperDeleter
+    {
+        void operator()(FileWrapper *instance) const
+        {
+            if (instance->file != nullptr) {
+                instance->file->Delete_On_Close(true);
+                instance->file->Close();
+            }
+            delete instance;
+        }
+    };
+
+public:
+    FileRefT() : m_wrapper(nullptr) {}
+
+    ~FileRefT() {}
+
+    FileRefT(File *file) { Assign(file); }
+
+    FileRefT(const FileRefT &other) { *this = other; }
+
+    FileRefT &operator=(File *file)
+    {
+        Assign(file);
+        return *this;
+    }
+
+    FileRefT &operator=(const FileRefT &other)
+    {
+        m_wrapper = other.m_wrapper;
+        return *this;
+    }
+
+    File *Get_File() { return m_wrapper ? m_wrapper->file : nullptr; }
+
+    const File *Get_File() const { return m_wrapper ? m_wrapper->file : nullptr; }
+
+    // Returns whether or not file is open. Unopened file must not be used.
+    bool Is_Open() const { return m_wrapper && m_wrapper->file && m_wrapper->file->m_access; }
+
+    void Close()
+    {
+        m_wrapper->file->Delete_On_Close(true);
+        m_wrapper->file->Close();
+        m_wrapper->file = nullptr;
+        m_wrapper.reset();
+    }
+
+    int Read(void *dst, int bytes) { return m_wrapper->file->Read(dst, bytes); }
+
+    int Write(void const *src, int bytes) { return m_wrapper->file->Write(src, bytes); }
+
+    int Seek(int offset, File::SeekMode mode) { return m_wrapper->file->Seek(offset, mode); }
+
+    void Next_Line(char *dst, int bytes) { m_wrapper->file->Next_Line(dst, bytes); }
+
+    bool Scan_Int(int &integer) { return m_wrapper->file->Scan_Int(integer); }
+
+    bool Scan_Real(float &real) { return m_wrapper->file->Scan_Real(real); }
+
+    bool Scan_String(Utf8String &string) { return m_wrapper->file->Scan_String(string); }
+
+    template<typename... Args> void Print(const char *format, Args... args) { m_wrapper->file->Print(format, args...); }
+
+    int Size() { return m_wrapper->file->Size(); }
+
+    int Position() { return m_wrapper->file->Position(); }
+
+    void *Read_All_And_Close()
+    {
+        m_wrapper->file->Delete_On_Close(true);
+        void *data = m_wrapper->file->Read_All_And_Close();
+        m_wrapper->file = nullptr;
+        m_wrapper.reset();
+        return data;
+    }
+
+    bool To_RAM_File()
+    {
+        bool converted = false;
+
+        m_wrapper->file->Delete_On_Close(true);
+        File *old_file = m_wrapper->file;
+        File *new_file = m_wrapper->file->Convert_To_RAM_File();
+        converted = (old_file != new_file);
+        m_wrapper->file = new_file;
+        m_wrapper->file->Delete_On_Close(false);
+
+        return converted;
+    }
+
+    const Utf8String &Get_File_Name() const { return m_wrapper->file->Get_File_Name(); }
+
+    int Get_File_Mode() const { return m_wrapper->file->Get_Access(); }
+
+private:
+    void Assign(File *file)
+    {
+        if (m_wrapper.get() == nullptr || m_wrapper->file != file) {
+            if (file == nullptr) {
+                m_wrapper.reset();
+            } else {
+                m_wrapper.reset(new FileWrapper);
+                m_wrapper->file = file;
+                m_wrapper->file->Delete_On_Close(false);
+            }
+        }
+    }
+
+    rts::shared_ptr_t<FileWrapper, FileWrapperDeleter, Counter> m_wrapper;
+};
+
+using FileRef = FileRefT<rts::shared_counter>;
+using FileRefAtomic = FileRefT<rts::atomic_shared_counter>;
+
+} // namespace Thyme

--- a/src/game/common/utility/array.h
+++ b/src/game/common/utility/array.h
@@ -1,0 +1,108 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Simple array class with static storage size. (Thyme Feature)
+ *        Can be removed and replaced with std::array if STL Port is abandoned.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+
+namespace rts
+{
+
+// #TODO Add a constexpr reverse_iterator.
+// #TODO Remove Array class?
+
+template<typename T, std::size_t Size> class array
+{
+public:
+    using value_type = T;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = value_type &;
+    using const_reference = const value_type &;
+    using pointer = value_type *;
+    using const_pointer = const value_type *;
+    using iterator = pointer;
+    using const_iterator = const_pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+    using const_reverse_iterator = std::reverse_iterator<const_iterator>;
+
+public:
+    // Aggregate type. Constructors are implicitly declared.
+
+    constexpr reference at(size_type pos)
+    {
+        assert(pos < size());
+        return m_array[pos];
+    }
+    constexpr const_reference at(size_type pos) const
+    {
+        assert(pos < size());
+        return m_array[pos];
+    }
+    constexpr reference operator[](size_type pos)
+    {
+        assert(pos < size());
+        return m_array[pos];
+    }
+    constexpr const_reference operator[](size_type pos) const
+    {
+        assert(pos < size());
+        return m_array[pos];
+    }
+
+    constexpr reference front() noexcept { return m_array[0]; }
+    constexpr const_reference front() const noexcept { return m_array[0]; }
+    constexpr reference back() noexcept { return m_array[size() - 1]; }
+    constexpr const_reference back() const noexcept { return m_array[size() - 1]; }
+
+    constexpr pointer data() noexcept { return m_array; }
+    constexpr const_pointer data() const noexcept { return m_array; }
+
+    constexpr iterator begin() noexcept { return iterator(data()); }
+    constexpr const_iterator begin() const noexcept { return const_iterator(data()); }
+    constexpr const_iterator cbegin() const noexcept { return const_iterator(data()); }
+
+    constexpr iterator end() noexcept { return iterator(data() + size()); }
+    constexpr const_iterator end() const noexcept { return const_iterator(data() + size()); }
+    constexpr const_iterator cend() const noexcept { return const_iterator(data() + size()); }
+
+    reverse_iterator rbegin() noexcept { return std::reverse_iterator(begin()); }
+    const_reverse_iterator rbegin() const noexcept { return std::reverse_iterator(begin()); }
+    const_reverse_iterator crbegin() const noexcept { return std::reverse_iterator(cbegin()); }
+
+    reverse_iterator rend() noexcept { return std::reverse_iterator(end()); }
+    const_reverse_iterator rend() const noexcept { return std::reverse_iterator(end()); }
+    const_reverse_iterator crend() const noexcept { return std::reverse_iterator(cend()); }
+
+    constexpr bool empty() const noexcept { return size() == 0; }
+    constexpr size_type size() const noexcept { return sizeof(m_array) / sizeof(value_type); }
+    constexpr size_type max_size() const noexcept { return size(); }
+
+    void fill(const T &value) { std::fill_n(begin(), size(), value); }
+
+    void swap(array &other) noexcept
+    {
+        for (std::size_t i = 0; i < size(); ++i) {
+            std::swap(m_array[i], other.m_array[i]);
+        }
+    }
+
+    value_type m_array[Size ? Size : 1];
+};
+
+} // namespace rts

--- a/src/game/common/utility/arrayutil.h
+++ b/src/game/common/utility/arrayutil.h
@@ -1,0 +1,115 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Array utility functions. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "arrayview.h"
+#include "asciistring.h"
+#include "stringutil.h"
+#include "unicodestring.h"
+#include <captainslog.h>
+
+namespace rts
+{
+
+template<typename ValueType> inline constexpr array_view<ValueType> Make_Array_View(ValueType *begin, std::size_t size)
+{
+    return array_view<ValueType>(begin, size);
+}
+
+template<typename ValueType> inline constexpr array_view<ValueType> Make_Array_View(ValueType *begin, ValueType *end)
+{
+    return array_view<ValueType>(begin, end);
+}
+
+inline CHAR_TRAITS_CONSTEXPR array_view<char> Make_Array_View(char *cstring)
+{
+    return array_view<char>(cstring, String_Length(cstring));
+}
+
+inline CHAR_TRAITS_CONSTEXPR array_view<const char> Make_Array_View(const char *cstring)
+{
+    return array_view<const char>(cstring, String_Length(cstring));
+}
+
+inline CHAR_TRAITS_CONSTEXPR array_view<unichar_t> Make_Array_View(unichar_t *cstring)
+{
+    return array_view<unichar_t>(cstring, String_Length(cstring));
+}
+
+inline CHAR_TRAITS_CONSTEXPR array_view<const unichar_t> Make_Array_View(const unichar_t *cstring)
+{
+    return array_view<const unichar_t>(cstring, String_Length(cstring));
+}
+
+// There is no Make_Array_View for mutable Utf8String and Utf16String. This is intentional.
+// Writing to string buffer directly is not good practice, due the reference counted nature of this string.
+// All modifications must take place on unique instance only. Use Make_Resized_Array_View function instead.
+
+inline array_view<const typename Utf8String::value_type> Make_Array_View(const Utf8String &instance)
+{
+    return array_view<const typename Utf8String::value_type>(instance.Str(), instance.Get_Length());
+}
+
+inline array_view<const typename Utf16String::value_type> Make_Array_View(const Utf16String &instance)
+{
+    return array_view<const typename Utf16String::value_type>(instance.Str(), instance.Get_Length());
+}
+
+namespace detail
+{
+template<typename CharType, typename ObjectType, typename SizeType>
+inline array_view<CharType> Utf_String_Resized_Array_View(ObjectType &object, SizeType size)
+{
+    using object_type = ObjectType;
+    using char_type = CharType;
+    using size_type = SizeType;
+
+    captainslog_assert(size >= 0);
+    if (size == 0) {
+        return array_view<char_type>();
+    }
+    CHAR_TRAITS_CONSTEXPR char_type null_char = Get_Char<char_type>('\0');
+    object_type copy = object;
+    char_type *peek = object.Get_Buffer_For_Read(size); // Allocates + 1
+    const char_type *reader = copy.Str();
+    const char_type *end = peek + size;
+    char_type *inserter = peek;
+    // Copy original string as far as it goes.
+    while (*reader != null_char && inserter != end) {
+        *inserter++ = *reader++;
+    }
+    // Fill the rest with null.
+    while (inserter != end + 1) {
+        *inserter++ = null_char;
+    }
+    return array_view<char_type>(peek, size);
+}
+} // namespace detail
+
+// Create array_view<> from Utf8String and resize the string with the given size.
+inline array_view<typename Utf8String::value_type> Make_Resized_Array_View(
+    Utf8String &utfstring, typename Utf8String::size_type size)
+{
+    return detail::Utf_String_Resized_Array_View<typename Utf8String::value_type>(utfstring, size);
+}
+
+// Create array_view<> from Utf16String and resize the string with the given size.
+inline array_view<typename Utf16String::value_type> Make_Resized_Array_View(
+    Utf16String &utfstring, typename Utf16String::size_type size)
+{
+    return detail::Utf_String_Resized_Array_View<typename Utf16String::value_type>(utfstring, size);
+}
+
+} // namespace rts

--- a/src/game/common/utility/arrayview.h
+++ b/src/game/common/utility/arrayview.h
@@ -1,0 +1,103 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Lightweight custom array view. (Thyme Feature)
+ *        Can be removed and replaced with std::span (c++20) if STL Port is abandoned.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "type_traits.h"
+#include <cassert>
+#include <cstddef>
+#include <iterator>
+
+namespace rts
+{
+
+// #TODO Add a constexpr reverse_iterator.
+
+template<typename ValueType> class array_view
+{
+public:
+    using element_type = ValueType;
+    using value_type = remove_cv_t<ValueType>;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = element_type &;
+    using const_reference = const element_type &;
+    using pointer = element_type *;
+    using const_pointer = const element_type *;
+    using iterator = pointer;
+    using reverse_iterator = std::reverse_iterator<iterator>;
+
+public:
+    ~array_view() noexcept = default;
+
+    constexpr array_view() noexcept : m_begin(nullptr), m_size(0) {}
+    constexpr array_view(pointer begin, size_type size) noexcept : m_begin(begin), m_size(size) {}
+    constexpr array_view(pointer begin, pointer end) : m_begin(begin), m_size(static_cast<size_t>(end - begin))
+    {
+        assert(begin <= end);
+    }
+
+    template<size_type Size> constexpr array_view(element_type (&arr)[Size]) noexcept : m_begin(arr), m_size(Size) {}
+
+    constexpr array_view(const array_view &) noexcept = default;
+    constexpr array_view &operator=(const array_view &) noexcept = default;
+
+    constexpr reference operator[](size_type index) const
+    {
+        assert(index < size());
+        return m_begin[index];
+    }
+    constexpr reference operator*() const
+    {
+        assert(m_begin != nullptr);
+        assert(0 < size());
+        return *m_begin;
+    }
+    constexpr pointer operator->() const noexcept { return m_begin; }
+
+    constexpr operator bool() const noexcept { return m_begin != nullptr; }
+
+    constexpr iterator begin() const noexcept { return m_begin; }
+    constexpr iterator end() const noexcept { return m_begin + m_size; }
+
+    reverse_iterator rbegin() { return reverse_iterator(end()); }
+    reverse_iterator rend() { return reverse_iterator(begin()); }
+
+    constexpr reference front() const
+    {
+        assert(m_begin != nullptr);
+        assert(0 < size());
+        return *m_begin;
+    }
+    constexpr reference back() const
+    {
+        assert(m_begin != nullptr);
+        assert(0 < size());
+        return *(m_begin + m_size - 1);
+    }
+
+    constexpr pointer data() const noexcept { return m_begin; }
+
+    constexpr size_type size() const noexcept { return m_size; }
+    constexpr size_type size_bytes() const noexcept { return m_size * sizeof(element_type); }
+
+    constexpr bool empty() const noexcept { return m_size == 0; }
+
+private:
+    pointer m_begin;
+    size_type m_size;
+};
+
+} // namespace rts

--- a/src/game/common/utility/atomicop.h
+++ b/src/game/common/utility/atomicop.h
@@ -1,0 +1,114 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Simple atomic integer operations. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+// Usefulness of atomic operations is limited cross platform. Be aware that integer types can be either signed or unsigned,
+// so conversion must take place manually. Prefer using 32 bit type for best compatibility or std::atomic<> when available.
+
+// clang-format off
+
+#if defined(__linux__)
+using AtomicType16 = int16_t;
+using AtomicType32 = int32_t;
+using AtomicType64 = int64_t;
+
+inline AtomicType16 Atomic_Increment_16(volatile AtomicType16 *addend) { return __sync_fetch_and_add(addend, AtomicType16{ 1 }); }
+inline AtomicType32 Atomic_Increment_32(volatile AtomicType32 *addend) { return __sync_fetch_and_add(addend, AtomicType32{ 1 }); }
+inline AtomicType64 Atomic_Increment_64(volatile AtomicType64 *addend) { return __sync_fetch_and_add(addend, AtomicType64{ 1 }); }
+
+inline AtomicType16 Atomic_Decrement_16(volatile AtomicType16 *addend) { return __sync_fetch_and_sub(addend, AtomicType16{ 1 }); }
+inline AtomicType32 Atomic_Decrement_32(volatile AtomicType32 *addend) { return __sync_fetch_and_sub(addend, AtomicType32{ 1 }); }
+inline AtomicType64 Atomic_Decrement_64(volatile AtomicType64 *addend) { return __sync_fetch_and_sub(addend, AtomicType64{ 1 }); }
+
+#elif defined(__APPLE__) && defined(__MACH__)
+#include <OSAtomic.h>
+using AtomicType16 = SInt16;
+using AtomicType32 = SInt32;
+using AtomicType64 = SInt64;
+
+inline AtomicType16 Atomic_Increment_16(volatile AtomicType16 *addend) { return OSIncrementAtomic16(addend); }
+inline AtomicType32 Atomic_Increment_32(volatile AtomicType32 *addend) { return OSIncrementAtomic(addend); }
+inline AtomicType64 Atomic_Increment_64(volatile AtomicType64 *addend) { return OSIncrementAtomic64(addend); }
+
+inline AtomicType16 Atomic_Increment_16(volatile AtomicType16 *addend) { return OSDecrementAtomic16(addend); }
+inline AtomicType32 Atomic_Increment_32(volatile AtomicType32 *addend) { return OSDecrementAtomic(addend); }
+inline AtomicType64 Atomic_Increment_64(volatile AtomicType64 *addend) { return OSDecrementAtomic64(addend); }
+
+#elif defined(__OpenBSD__)
+#include <sys/atomic.h>
+// Appears to have no native atomic operations for 16 bit integers.
+using AtomicType16 = unsigned short;
+using AtomicType32 = unsigned int;
+using AtomicType64 = unsigned long; // is 64 bit on 64 bit architecture
+
+inline AtomicType32 Atomic_Increment_32(volatile AtomicType32 *addend) { return atomic_inc_int_nv(addend); }
+inline AtomicType64 Atomic_Increment_64(volatile AtomicType64 *addend) { return atomic_inc_long_nv(addend); }
+
+inline AtomicType32 Atomic_Increment_32(volatile AtomicType32 *addend) { return atomic_dec_int_nv(addend); }
+inline AtomicType64 Atomic_Increment_64(volatile AtomicType64 *addend) { return atomic_dec_long_nv(addend); }
+
+#elif defined(__FreeBSD__) || defined(__DragonFly__)
+#include <machine/atomic.h>
+// Appears to have no native atomic operations for 16, 64 bit integers.
+using AtomicType16 = uint16_t;
+using AtomicType32 = uint32_t;
+using AtomicType64 = uint64_t;
+
+inline AtomicType32 Atomic_Increment_32(volatile AtomicType32 *addend) { return atomic_fetchadd_32(addend, AtomicType32{ 1 }); }
+
+inline AtomicType32 Atomic_Decrement_32(volatile AtomicType32 *addend) { return atomic_fetchadd_32(addend, ~AtomicType32{ 0 }); }
+
+#elif defined(__NetBSD__)
+#include <sys/atomic.h>
+// Appears to have no native atomic operations for 16 bit integers.
+using AtomicType16 = uint16_t;
+using AtomicType32 = uint32_t;
+using AtomicType64 = uint64_t;
+
+inline AtomicType32 Atomic_Increment_32(volatile AtomicType32 *addend) { return atomic_inc_32_nv(addend); }
+inline AtomicType64 Atomic_Increment_64(volatile AtomicType64 *addend) { return atomic_inc_64_nv(addend); }
+
+inline AtomicType32 Atomic_Decrement_32(volatile AtomicType32 *addend) { return atomic_dec_32_nv(addend); }
+inline AtomicType32 Atomic_Decrement_64(volatile AtomicType64 *addend) { return atomic_dec_64_nv(addend); }
+
+#elif defined(_WIN32)
+#include <windows.h>
+using AtomicType16 = short;
+using AtomicType32 = long;
+using AtomicType64 = __int64;
+
+inline AtomicType16 Atomic_Increment_16(volatile AtomicType16 *addend) { return InterlockedIncrement16(addend); }
+inline AtomicType32 Atomic_Increment_32(volatile AtomicType32 *addend) { return InterlockedIncrement(addend); }
+inline AtomicType64 Atomic_Increment_64(volatile AtomicType64 *addend) { return InterlockedIncrement64(addend); }
+
+inline AtomicType16 Atomic_Decrement_16(volatile AtomicType16 *addend) { return InterlockedDecrement16(addend); }
+inline AtomicType32 Atomic_Decrement_32(volatile AtomicType32 *addend) { return InterlockedDecrement(addend); }
+inline AtomicType64 Atomic_Decrement_64(volatile AtomicType64 *addend) { return InterlockedDecrement64(addend); }
+
+#else
+#error platform not supported
+#endif
+
+template<typename Type> inline Type Atomic_Increment(volatile Type *addend);
+template<> inline AtomicType16 Atomic_Increment<AtomicType16>(volatile AtomicType16 *addend) { return Atomic_Increment_16(addend); }
+template<> inline AtomicType32 Atomic_Increment<AtomicType32>(volatile AtomicType32 *addend) { return Atomic_Increment_32(addend); }
+template<> inline AtomicType64 Atomic_Increment<AtomicType64>(volatile AtomicType64 *addend) { return Atomic_Increment_64(addend); }
+
+template<typename Type> inline Type Atomic_Decrement(volatile Type *addend);
+template<> inline AtomicType16 Atomic_Decrement<AtomicType16>(volatile AtomicType16 *addend) { return Atomic_Decrement_16(addend); }
+template<> inline AtomicType32 Atomic_Decrement<AtomicType32>(volatile AtomicType32 *addend) { return Atomic_Decrement_32(addend); }
+template<> inline AtomicType64 Atomic_Decrement<AtomicType64>(volatile AtomicType64 *addend) { return Atomic_Decrement_64(addend); }
+
+// clang-format on

--- a/src/game/common/utility/deleter.h
+++ b/src/game/common/utility/deleter.h
@@ -1,0 +1,45 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief General purpose template deleter. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+// Deleter for objects created by 'new'.
+template<typename Type> struct NewDeleter
+{
+    void operator()(Type *instance) const { delete instance; }
+};
+
+// Deleter for objects created by 'new[]'.
+template<typename Type> struct NewArrayDeleter
+{
+    void operator()(Type *instance) const { delete[] instance; }
+};
+
+// Deleter for objects created by 'malloc()'.
+template<typename Type> struct AllocDeleter
+{
+    void operator()(Type *instance) const { free(instance); }
+};
+
+// Deleter for objects using a game memory pool.
+template<typename Type> struct MemoryPoolObjectDeleter
+{
+    void operator()(Type *instance) const { instance->Delete_Instance(); }
+};
+
+template<typename Deleter, typename DeleteType> inline void Invoke_Deleter(DeleteType *instance)
+{
+    Deleter deleter;
+    deleter(instance);
+}

--- a/src/game/common/utility/ebitflags.h
+++ b/src/game/common/utility/ebitflags.h
@@ -1,0 +1,167 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief General purpose bit flags utility class. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "utility/type_traits.h"
+#include <cstddef>
+#include <typesize.h>
+
+namespace rts
+{
+
+template<typename ValueType, typename UnderlyingType = underlying_type_t<ValueType>> class ebitflags
+{
+public:
+    using Value = ValueType;
+    using value_type = ValueType;
+    using size_type = std::size_t;
+
+private:
+    using underlying_type = UnderlyingType;
+
+public:
+    inline constexpr ebitflags() noexcept : m_value(0) {}
+
+    inline constexpr ebitflags(value_type value) noexcept : m_value(0) { set(value); }
+
+    inline constexpr ebitflags(const ebitflags &other) noexcept : m_value(other.m_value) {}
+
+    constexpr ebitflags &operator=(ebitflags other) noexcept
+    {
+        m_value = other.m_value;
+        return *this;
+    }
+    constexpr ebitflags &operator|=(ebitflags other) noexcept
+    {
+        m_value |= other.m_value;
+        return *this;
+    }
+    constexpr ebitflags &operator&=(ebitflags other) noexcept
+    {
+        m_value &= other.m_value;
+        return *this;
+    }
+    constexpr ebitflags &operator^=(ebitflags other) noexcept
+    {
+        m_value ^= other.m_value;
+        return *this;
+    }
+    constexpr ebitflags &operator<<=(size_type pos) noexcept
+    {
+        m_value <<= pos;
+        return *this;
+    }
+    constexpr ebitflags &operator>>=(size_type pos) noexcept
+    {
+        m_value >>= pos;
+        return *this;
+    }
+
+    constexpr bool operator==(ebitflags other) const noexcept { return m_value == other.m_value; }
+
+    constexpr bool operator!=(ebitflags other) const noexcept { return m_value != other.m_value; }
+
+    constexpr operator bool() const noexcept { return m_value != underlying_type(0); }
+
+    constexpr ebitflags operator~() const noexcept { return ebitflags(static_cast<value_type>(~m_value)); }
+
+    constexpr ebitflags operator|(ebitflags other) const noexcept
+    {
+        return ebitflags(static_cast<value_type>(m_value | other.m_value));
+    }
+
+    constexpr ebitflags operator&(ebitflags other) const noexcept
+    {
+        return ebitflags(static_cast<value_type>(m_value & other.m_value));
+    }
+
+    constexpr ebitflags operator^(ebitflags other) const noexcept
+    {
+        return ebitflags(static_cast<value_type>(m_value ^ other.m_value));
+    }
+
+    constexpr ebitflags operator<<(size_type pos) const noexcept
+    {
+        return ebitflags(static_cast<value_type>(m_value << pos));
+    }
+
+    constexpr ebitflags operator>>(size_type pos) const noexcept
+    {
+        return ebitflags(static_cast<value_type>(m_value >> pos));
+    }
+
+    constexpr void set(value_type value) noexcept { m_value |= static_cast<underlying_type>(value); }
+
+    constexpr void set(ebitflags flags) noexcept { m_value |= flags.m_value; }
+
+    constexpr void reset(value_type value) noexcept { m_value &= ~static_cast<underlying_type>(value); }
+
+    constexpr void reset(ebitflags flags) noexcept { m_value &= ~flags.m_value; }
+
+    constexpr void reset() noexcept { m_value = underlying_type(0); }
+
+    constexpr size_type size() const noexcept { return static_cast<size_type>(sizeof(m_value) * 8); }
+
+    constexpr size_type count() const noexcept
+    {
+        size_type count = 0;
+        for (size_type i = 0; i < size(); ++i) {
+            value_type value = static_cast<value_type>(underlying_type(1) << underlying_type(i));
+            if (has(value)) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    constexpr bool none() const noexcept { return (m_value == underlying_type(0)); }
+
+    constexpr bool any() const noexcept { return (m_value != underlying_type(0)); }
+
+    constexpr bool all() const noexcept { return (m_value == ~underlying_type(0)); }
+
+    constexpr bool has(value_type value) const noexcept
+    {
+        return ((m_value & static_cast<underlying_type>(value)) != underlying_type(0));
+    }
+
+    constexpr bool has_only(value_type value) const noexcept
+    {
+        return ((m_value & static_cast<underlying_type>(value)) == m_value);
+    }
+
+    constexpr bool has_any_of(ebitflags flags) const noexcept { return ((m_value & flags.m_value) != underlying_type(0)); }
+
+    constexpr bool has_all_of(ebitflags flags) const noexcept { return ((m_value & flags.m_value) == flags.m_value); }
+
+    constexpr bool get(value_type &value, size_type occurence = 0) const noexcept
+    {
+        size_type num = 0;
+        for (size_type i = 0; i < count(); ++i) {
+            if (has(static_cast<value_type>(i))) {
+                if (occurence == num++) {
+                    value = static_cast<value_type>(i);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+private:
+    underlying_type m_value;
+};
+
+} // namespace rts

--- a/src/game/common/utility/enumerator.h
+++ b/src/game/common/utility/enumerator.h
@@ -1,0 +1,118 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief General purpose enumerator utility class. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "type_traits.h"
+#include <cstddef>
+#include <typesize.h>
+
+namespace rts
+{
+
+template<typename ValueType, typename UnderlyingType = underlying_type_t<ValueType>> class enumerator
+{
+public:
+    using Value = ValueType;
+    using value_type = ValueType;
+    using underlying_type = UnderlyingType;
+
+public:
+    constexpr enumerator() noexcept : m_value(0) {}
+    constexpr enumerator(value_type value) noexcept : m_value(static_cast<underlying_type>(value)) {}
+    constexpr enumerator(const enumerator &other) noexcept : m_value(other.m_value) {}
+
+    constexpr enumerator &operator=(enumerator other) noexcept
+    {
+        m_value = other.m_value;
+        return *this;
+    }
+    constexpr enumerator &operator+=(enumerator other) noexcept
+    {
+        m_value += other.m_value;
+        return *this;
+    }
+    constexpr enumerator &operator-=(enumerator other) noexcept
+    {
+        m_value -= other.m_value;
+        return *this;
+    }
+    constexpr enumerator &operator*=(enumerator other) noexcept
+    {
+        m_value *= other.m_value;
+        return *this;
+    }
+    constexpr enumerator &operator/=(enumerator other) noexcept
+    {
+        m_value /= other.m_value;
+        return *this;
+    }
+    constexpr enumerator &operator%=(enumerator other) noexcept
+    {
+        m_value %= other.m_value;
+        return *this;
+    }
+    constexpr enumerator &operator++() noexcept
+    {
+        ++m_value;
+        return *this;
+    }
+    constexpr enumerator &operator--() noexcept
+    {
+        --m_value;
+        return *this;
+    }
+
+    constexpr enumerator operator+(enumerator other) noexcept
+    {
+        return enumerator(static_cast<value_type>(m_value + other.m_value));
+    }
+    constexpr enumerator operator-(enumerator other) noexcept
+    {
+        return enumerator(static_cast<value_type>(m_value - other.m_value));
+    }
+    constexpr enumerator operator*(enumerator other) noexcept
+    {
+        return enumerator(static_cast<value_type>(m_value * other.m_value));
+    }
+    constexpr enumerator operator/(enumerator other) noexcept
+    {
+        return enumerator(static_cast<value_type>(m_value / other.m_value));
+    }
+    constexpr enumerator operator%(enumerator other) noexcept
+    {
+        return enumerator(static_cast<value_type>(m_value % other.m_value));
+    }
+    constexpr enumerator operator++(int) noexcept { return enumerator(static_cast<value_type>(m_value++)); }
+    constexpr enumerator operator--(int) noexcept { return enumerator(static_cast<value_type>(m_value--)); }
+
+    constexpr bool operator==(enumerator other) const noexcept { return m_value == other.m_value; }
+    constexpr bool operator!=(enumerator other) const noexcept { return m_value != other.m_value; }
+    constexpr bool operator<(enumerator other) const noexcept { return m_value < other.m_value; }
+    constexpr bool operator>(enumerator other) const noexcept { return m_value > other.m_value; }
+    constexpr bool operator<=(enumerator other) const noexcept { return m_value <= other.m_value; }
+    constexpr bool operator>=(enumerator other) const noexcept { return m_value >= other.m_value; }
+
+    constexpr operator bool() const noexcept { return m_value != underlying_type(0); }
+
+    constexpr void reset() noexcept { m_value = underlying_type(0); }
+
+    constexpr value_type value() const noexcept { return static_cast<value_type>(m_value); }
+    constexpr underlying_type underlying() const noexcept { return m_value; }
+
+private:
+    underlying_type m_value;
+};
+
+} // namespace rts

--- a/src/game/common/utility/enumflags.h
+++ b/src/game/common/utility/enumflags.h
@@ -1,0 +1,398 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief General purpose number flags utility class. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "bittype.h"
+#include <cassert>
+#include <cstddef>
+
+namespace rts
+{
+
+namespace detail
+{
+
+// clang-format off
+
+template<typename IntegerType, std::size_t Bytes> struct BitBucketShiftStruct;
+template<typename IntegerType, std::size_t Bytes> struct BitBucketMaskStruct;
+
+template<typename IntegerType> struct BitBucketShiftStruct<IntegerType, 1>{ static constexpr IntegerType Get() { return IntegerType(3); } };
+template<typename IntegerType> struct BitBucketShiftStruct<IntegerType, 2>{ static constexpr IntegerType Get() { return IntegerType(4); } };
+template<typename IntegerType> struct BitBucketShiftStruct<IntegerType, 4>{ static constexpr IntegerType Get() { return IntegerType(5); } };
+template<typename IntegerType> struct BitBucketShiftStruct<IntegerType, 8>{ static constexpr IntegerType Get() { return IntegerType(6); } };
+
+template<typename IntegerType> struct BitBucketMaskStruct<IntegerType, 1>{ static constexpr IntegerType Get() { return IntegerType(0xfff); } };
+template<typename IntegerType> struct BitBucketMaskStruct<IntegerType, 2>{ static constexpr IntegerType Get() { return IntegerType(0xffff); } };
+template<typename IntegerType> struct BitBucketMaskStruct<IntegerType, 4>{ static constexpr IntegerType Get() { return IntegerType(0xfffff); } };
+template<typename IntegerType> struct BitBucketMaskStruct<IntegerType, 8>{ static constexpr IntegerType Get() { return IntegerType(0xffffff); } };
+
+template<typename IntegerType, std::size_t Bytes> constexpr IntegerType Bit_Bucket_Shift() { return BitBucketShiftStruct<IntegerType, Bytes>::Get(); }
+template<typename IntegerType, std::size_t Bytes> constexpr IntegerType Bit_Bucket_Mask() { return BitBucketMaskStruct<IntegerType, Bytes>::Get(); }
+
+// clang-format on
+
+} // namespace detail
+
+template<typename ValueType, std::size_t ValueCount> class enumflags
+{
+public:
+    using Value = ValueType;
+    using value_type = ValueType;
+    using size_type = std::size_t;
+
+private:
+    template<typename, size_type> friend class enumflags;
+    using storage_type = uint32_t;
+
+public:
+    constexpr enumflags() { reset(); }
+
+    constexpr enumflags(value_type value)
+    {
+        reset();
+        set(value);
+    }
+
+    constexpr enumflags(const enumflags &other) noexcept { copy(m_values, other.m_values, bucket_size()); }
+
+    template<size_type OtherValueCount> constexpr enumflags(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        const size_type shared_bucket_size = min(bucket_size(), other.bucket_size());
+        copy(m_values, other.m_values, shared_bucket_size);
+        zero(m_values + shared_bucket_size, bucket_size() - shared_bucket_size);
+    }
+
+    constexpr enumflags &operator=(const enumflags &other) noexcept
+    {
+        copy(m_values, other.m_values, bucket_size());
+        return *this;
+    }
+
+    template<size_type OtherValueCount>
+    constexpr enumflags &operator=(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        const size_type shared_bucket_size = min(bucket_size(), other.bucket_size());
+        copy(m_values, other.m_values, shared_bucket_size);
+        return *this;
+    }
+
+    constexpr enumflags &operator|=(const enumflags &other) noexcept
+    {
+        for (size_type i = 0; i < bucket_size(); ++i) {
+            m_values[i] |= other.m_values[i];
+        }
+        return *this;
+    }
+
+    template<size_type OtherValueCount>
+    constexpr enumflags &operator|=(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        const size_type shared_bucket_size = min(bucket_size(), other.bucket_size());
+        for (size_type i = 0; i < shared_bucket_size; ++i) {
+            m_values[i] |= other.m_values[i];
+        }
+        return *this;
+    }
+
+    constexpr enumflags &operator&=(const enumflags &other) noexcept
+    {
+        for (size_type i = 0; i < bucket_size(); ++i) {
+            m_values[i] &= other.m_values[i];
+        }
+        return *this;
+    }
+
+    template<size_type OtherValueCount>
+    constexpr enumflags &operator&=(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        const size_type shared_bucket_size = min(bucket_size(), other.bucket_size());
+        for (size_type i = 0; i < shared_bucket_size; ++i) {
+            m_values[i] &= other.m_values[i];
+        }
+        return *this;
+    }
+
+    constexpr enumflags &operator^=(const enumflags &other) noexcept
+    {
+        for (size_type i = 0; i < bucket_size(); ++i) {
+            m_values[i] ^= other.m_values[i];
+        }
+        return *this;
+    }
+
+    template<size_type OtherValueCount>
+    constexpr enumflags &operator^=(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        const size_type shared_bucket_size = min(bucket_size(), other.bucket_size());
+        for (size_type i = 0; i < shared_bucket_size; ++i) {
+            m_values[i] ^= other.m_values[i];
+        }
+        return *this;
+    }
+
+    // #TODO implement
+    constexpr enumflags &operator<<=(size_type pos);
+    constexpr enumflags &operator>>=(size_type pos);
+
+    constexpr bool operator==(const enumflags &other) const noexcept
+    {
+        return 0 == compare(m_values, other.m_values, sizeof(m_values));
+    }
+
+    template<size_type OtherValueCount>
+    constexpr bool operator==(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        const size_type shared_bucket_bytes = min(bucket_bytes(), other.bucket_bytes());
+        return 0 == compare(m_values, other.m_values, shared_bucket_bytes);
+    }
+
+    constexpr bool operator!=(const enumflags &other) const noexcept { return !operator==(other); }
+
+    template<size_type OtherValueCount>
+    constexpr bool operator!=(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        return !operator==(other);
+    }
+
+    constexpr operator bool() const noexcept { return any(); }
+
+    constexpr enumflags operator~() const noexcept
+    {
+        enumflags inst;
+        for (size_type i = 0; i < bucket_size(); ++i) {
+            inst.m_values[i] = ~m_values[i];
+        }
+        return inst;
+    }
+
+    constexpr enumflags operator|(const enumflags &other) const noexcept
+    {
+        enumflags inst(*this);
+        inst |= other;
+        return inst;
+    }
+
+    template<size_type OtherValueCount>
+    constexpr enumflags operator|(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        enumflags inst(*this);
+        inst |= other;
+        return inst;
+    }
+
+    constexpr enumflags operator&(const enumflags &other) const noexcept
+    {
+        enumflags inst(*this);
+        inst &= other;
+        return inst;
+    }
+
+    template<size_type OtherValueCount>
+    constexpr enumflags operator&(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        enumflags inst(*this);
+        inst &= other;
+        return inst;
+    }
+
+    constexpr enumflags operator^(const enumflags &other) const noexcept
+    {
+        enumflags inst(*this);
+        inst ^= other;
+        return inst;
+    }
+
+    template<size_type OtherValueCount>
+    constexpr enumflags operator^(const enumflags<value_type, OtherValueCount> &other) noexcept
+    {
+        enumflags inst(*this);
+        inst ^= other;
+        return inst;
+    }
+
+    // #TODO implement
+    constexpr enumflags operator<<(size_type pos) const;
+    constexpr enumflags operator>>(size_type pos) const;
+
+    constexpr void set(value_type value) { access(value) |= bit(value); }
+
+    constexpr void set(const enumflags &flags) noexcept
+    {
+        for (size_type i = 0; i < bucket_size(); ++i) {
+            m_values[i] |= flags.m_values[i];
+        }
+    }
+    constexpr void reset(value_type value) { access(value) &= ~bit(value); }
+
+    constexpr void reset(const enumflags &flags) noexcept
+    {
+        for (size_type i = 0; i < bucket_size(); ++i) {
+            m_values[i] &= ~flags.m_values[i];
+        }
+    }
+
+    constexpr void reset() noexcept { zero(m_values, bucket_size()); }
+
+    constexpr size_type size() const noexcept { return static_cast<size_type>(ValueCount); }
+
+    constexpr size_type count() const noexcept
+    {
+        size_type count = 0;
+        for (size_type i = 0; i < size(); ++i) {
+            if (has(static_cast<value_type>(i))) {
+                ++count;
+            }
+        }
+        return count;
+    }
+
+    constexpr bool none() const noexcept
+    {
+        storage_type bits = 0;
+        for (const storage_type value : m_values) {
+            bits |= value;
+        }
+        return bits == storage_type(0);
+    }
+
+    constexpr bool any() const noexcept { return !none(); }
+
+    constexpr bool all() const noexcept
+    {
+        for (size_type i = 0; i < size(); ++i) {
+            if (!has(static_cast<value_type>(i))) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    constexpr bool has(value_type value) const { return ((access(value) & bit(value)) != storage_type(0)); }
+
+    constexpr bool has_only(value_type value) const
+    {
+        const size_type value_bucket = bucket(value);
+
+        if ((m_values[value_bucket] & bit(value)) != m_values[value_bucket]) {
+            return false;
+        }
+        storage_type other_bits = 0;
+        size_type i = 0;
+
+        for (; i < value_bucket; ++i) {
+            other_bits |= m_values[i];
+        }
+        for (++i; i < bucket_size(); ++i) {
+            other_bits |= m_values[i];
+        }
+        return other_bits == storage_type(0);
+    }
+
+    constexpr bool has_any_of(enumflags flags) const noexcept
+    {
+        bool test = false;
+        for (size_type i = 0; i < bucket_size(); ++i) {
+            test |= ((m_values[i] & flags.m_values[i]) != storage_type(0));
+        }
+        return test;
+    }
+
+    constexpr bool has_all_of(enumflags flags) const noexcept
+    {
+        bool test = true;
+        for (size_type i = 0; i < bucket_size(); ++i) {
+            test &= ((m_values[i] & flags.m_values[i]) == flags.m_values[i]);
+        }
+        return test;
+    }
+
+    constexpr bool get(value_type &value, size_type occurence = 0) const noexcept
+    {
+        size_type num = 0;
+        for (size_type i = 0; i < size(); ++i) {
+            if (has(static_cast<value_type>(i))) {
+                if (occurence == num++) {
+                    value = static_cast<value_type>(i);
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+private:
+    static constexpr size_type min(const size_type a, const size_type b) { return a < b ? a : b; }
+
+    static constexpr void copy(storage_type *dst, const storage_type *src, size_type count)
+    {
+        while (count-- > 0) {
+            dst[count] = src[count];
+        }
+    }
+
+    static constexpr void zero(storage_type *dst, size_type count)
+    {
+        while (count-- > 0) {
+            dst[count] = storage_type(0);
+        }
+    }
+
+    static constexpr int compare(const storage_type *left, const storage_type *right, size_type count)
+    {
+        while (count-- > 0) {
+            if (*left++ != *right++)
+                return left[-1] < right[-1] ? -1 : 1;
+        }
+        return 0;
+    }
+
+    static constexpr size_type bucket_size() noexcept { return sizeof(m_values) / sizeof(storage_type); }
+
+    static constexpr size_type bucket_bytes() noexcept { return sizeof(m_values); }
+
+    static constexpr storage_type bit(value_type value) noexcept
+    {
+        // Mask value to max storage bit count and shift to single storage bit. Example with 1 byte storage:
+        // value   0101 1111 = 95
+        // masked  0000 0111 = 7
+        // shifted 1000 0000 = 128
+        constexpr storage_type mask = detail::Bit_Bucket_Mask<storage_type, sizeof(storage_type)>();
+        storage_type masked = static_cast<storage_type>(value) & mask;
+        storage_type shifted = 1 << masked;
+        return shifted;
+    }
+
+    static constexpr size_type bucket(value_type value)
+    {
+        assert(static_cast<size_type>(value) < ValueCount);
+
+        // Get bucket index with given value. Example with 1 byte storage:
+        // value 0101 1111 = 95
+        // index 0000 1011 = 11
+        constexpr size_type shift = detail::Bit_Bucket_Shift<size_type, sizeof(storage_type)>();
+        size_type index = static_cast<size_type>(value) >> shift;
+        return index;
+    }
+
+    constexpr storage_type &access(value_type value) { return m_values[bucket(value)]; }
+
+    constexpr storage_type access(value_type value) const { return m_values[bucket(value)]; }
+
+private:
+    storage_type m_values[1 + (bucket(value_type(ValueCount - 1)))];
+};
+
+} // namespace rts

--- a/src/game/common/utility/fileutil.h
+++ b/src/game/common/utility/fileutil.h
@@ -1,0 +1,121 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief File utility functions. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "common/system/file.h"
+#include "stringutil.h"
+
+namespace rts
+{
+
+// Read from a file until the specified end character is reached. Will not stop reading at escaped end character. Writes to
+// destination string until size minus 1. Destination string does include the read end character. Always writes null
+// terminator. Returns true, unless no line was read and the end of the file was reached.
+template<typename CharType>
+bool Read_Line(File *file, CharType *dest, std::size_t size, const CharType *eol_chars, std::size_t *num_copied = nullptr)
+{
+    const CharType *writer_end = dest + size - 1;
+    CharType *writer = dest;
+
+    int total_bytes_read = 0;
+    bool escaped = false;
+
+    while (writer != writer_end) {
+        const int bytes_read = file->Read(writer, sizeof(CharType));
+        total_bytes_read += bytes_read;
+
+        if (bytes_read != sizeof(CharType)) {
+            break;
+        }
+
+        // Stop at end character.
+        if (!escaped) {
+            if (Is_Search_Character(*writer, eol_chars)) {
+                ++writer;
+                break;
+            }
+        }
+
+        // End escaping.
+        escaped = false;
+
+        // Begin escaping.
+        if (*writer == Get_Char<CharType>('\\')) {
+            escaped = !escaped;
+        }
+
+        ++writer;
+    }
+
+    *writer = Get_Char<CharType>('\0');
+
+    if (num_copied != nullptr) {
+        *num_copied = (writer - dest);
+    }
+
+    return total_bytes_read != 0;
+}
+
+// Read any type from file.
+template<typename T> bool Read_Any(File *file, T &value)
+{
+    return file->Read(&value, sizeof(T)) == sizeof(T);
+}
+
+// Write any type to file.
+template<typename T> bool Write_Any(File *file, const T &value)
+{
+    return file->Write(&value, sizeof(T)) == sizeof(T);
+}
+
+// Read string buffer with given size from file.
+template<typename StringType> bool Read_Str(File *file, StringType &string)
+{
+    using CharType = typename StringType::value_type;
+    using SizeType = typename StringType::size_type;
+
+    const SizeType size = string.size();
+    void *data = string.data();
+    const int bytes = static_cast<int>(size) * sizeof(CharType);
+
+    return file->Read(data, bytes) == bytes;
+}
+
+// Write string buffer with given size to file.
+template<typename StringType> bool Write_Str(File *file, const StringType &string)
+{
+    using CharType = typename StringType::value_type;
+    using SizeType = typename StringType::size_type;
+
+    const SizeType size = string.size();
+    const void *data = string.data();
+    const int bytes = static_cast<int>(size) * sizeof(CharType);
+
+    return file->Write(data, bytes) == bytes;
+}
+
+// Read Bytes from file.
+inline bool Read(File *file, void *data, int len)
+{
+    return file->Read(data, len) == len;
+}
+
+// Write Bytes to file.
+inline bool Write(File *file, const void *data, int len)
+{
+    return file->Write(data, len) == len;
+}
+
+} // namespace rts

--- a/src/game/common/utility/intrusive_ptr.h
+++ b/src/game/common/utility/intrusive_ptr.h
@@ -1,0 +1,175 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief General purpose intrusive smart pointer to wrap any type with. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "refcounter.h"
+#include <algorithm>
+
+namespace rts
+{
+
+// Intrusive reference counted smart pointer.
+// Works similar to std::shared_ptr<>, but does not hold reference counter by itself.
+// Can be assigned a raw pointer at any time without worrying about colliding with another reference counter.
+// Adapter type needs to be set according to the Counter type used.
+// Default adapter is set for Counter types using rts::atomic_intrusive_counter<> or rts::intrusive_counter<>.
+template<class Counter, class Adapter = intrusive_counter_adapter<Counter>> class intrusive_ptr
+{
+public:
+    using element_type = Counter;
+    using value_type = Counter;
+    using reference = value_type &;
+    using const_reference = const value_type &;
+    using pointer = value_type *;
+    using const_pointer = const value_type *;
+    using integer_type = typename Adapter::integer_type;
+    using adapter_type = typename Adapter;
+
+private:
+    value_type *m_ptr;
+
+public:
+    intrusive_ptr() noexcept : m_ptr(nullptr) {}
+
+    intrusive_ptr(value_type *ptr)
+    {
+        if (ptr != nullptr)
+            adapter_type::Add_Ref(ptr);
+        m_ptr = ptr;
+    }
+
+    intrusive_ptr(const intrusive_ptr &other)
+    {
+        if (other.m_ptr != nullptr)
+            adapter_type::Add_Ref(other.m_ptr);
+        m_ptr = other.m_ptr;
+    }
+
+    intrusive_ptr(intrusive_ptr &&other) noexcept
+    {
+        m_ptr = other.m_ptr;
+        other.m_ptr = nullptr;
+    }
+
+    template<typename RelatedType> intrusive_ptr(const intrusive_ptr<RelatedType> &other)
+    {
+        if (other.m_ptr != nullptr)
+            adapter_type::Add_Ref(other.m_ptr);
+        m_ptr = other.m_ptr;
+    }
+
+    ~intrusive_ptr()
+    {
+        if (m_ptr != nullptr)
+            adapter_type::Remove_Ref(m_ptr);
+    }
+
+    intrusive_ptr &operator=(const intrusive_ptr &other)
+    {
+        reset(other.m_ptr);
+        return *this;
+    }
+
+    intrusive_ptr &operator=(intrusive_ptr &&other)
+    {
+        if (this != &other) {
+            if (m_ptr != nullptr)
+                adapter_type::Remove_Ref(m_ptr);
+            m_ptr = other.m_ptr;
+            other.m_ptr = nullptr;
+        }
+        return *this;
+    }
+
+    template<typename RelatedType> intrusive_ptr &operator=(const intrusive_ptr<RelatedType> &other)
+    {
+        reset(other.m_ptr);
+        return *this;
+    }
+
+    intrusive_ptr &operator=(value_type *ptr)
+    {
+        reset(ptr);
+        return *this;
+    }
+
+    reference operator*() noexcept { return *m_ptr; }
+    pointer operator->() noexcept { return m_ptr; }
+    pointer get() noexcept { return m_ptr; }
+
+    const_reference operator*() const noexcept { return *m_ptr; }
+    const_pointer operator->() const noexcept { return m_ptr; }
+    const_pointer get() const noexcept { return m_ptr; }
+
+    operator bool() const noexcept { return m_ptr != nullptr; }
+
+    // Reset smart pointer to null.
+    void reset()
+    {
+        if (m_ptr != nullptr)
+            adapter_type::Remove_Ref(m_ptr);
+        m_ptr = nullptr;
+    }
+
+    // Reset smart pointer with new pointer.
+    void reset(value_type *ptr)
+    {
+        if (ptr != m_ptr) {
+            if (ptr != nullptr)
+                adapter_type::Add_Ref(ptr);
+            if (m_ptr != nullptr)
+                adapter_type::Remove_Ref(m_ptr);
+            m_ptr = ptr;
+        }
+    }
+
+    // Swap smart pointer with other smart pointer.
+    void swap(intrusive_ptr &other) noexcept { std::swap(m_ptr, other.m_ptr); }
+
+    // Assign pointer without raising its reference count.
+    // Used for example if the reference target already has a reference count on creation.
+    void assign_without_add_ref(value_type *ptr)
+    {
+        if (m_ptr != nullptr)
+            adapter_type::Remove_Ref(m_ptr);
+        m_ptr = ptr;
+    }
+
+    // Release ownership of the pointer and do not change reference count.
+    value_type *release() noexcept
+    {
+        value_type *ptr = m_ptr;
+        m_ptr = nullptr;
+        return ptr;
+    }
+
+    // Get the count of how many times the pointer is referenced.
+    integer_type use_count() const { return adapter_type::Use_Count(m_ptr); }
+};
+
+// Adapter for DirectX and COM reference counted objects.
+template<class Counter> class dx_intrusive_ptr_adapter
+{
+public:
+    using integer_type = ULONG;
+
+    static integer_type Add_Ref(Counter *counter) { return counter->AddRef(); }
+    static integer_type Remove_Ref(Counter *counter) { return counter->Release(); }
+    static integer_type Use_Count(const Counter *counter) { return integer_type{ ~0u }; }
+};
+
+template<class Counter> using dx_intrusive_ptr = intrusive_ptr<Counter, dx_intrusive_ptr_adapter<Counter>>;
+
+} // namespace rts

--- a/src/game/common/utility/refcounter.h
+++ b/src/game/common/utility/refcounter.h
@@ -1,0 +1,267 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief General purpose reference counter to inherit from. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "atomicop.h"
+#include "bittype.h"
+#include "captainslog.h"
+#include "deleter.h"
+#include <typesize.h>
+
+#if GAME_DEBUG
+#ifndef REFCOUNTER_CHECK
+#define REFCOUNTER_CHECK 1
+#endif
+#endif
+
+#if !THYME_USE_STLPORT
+#ifndef REFCOUNTER_USE_STD_ATOMIC
+#define REFCOUNTER_USE_STD_ATOMIC 1 // #TODO implement relevant functionality
+#endif
+#endif
+
+namespace rts
+{
+namespace detail
+{
+
+template<typename Integer> inline void Destructor_Ref_Check(Integer counter, Integer expected_counter = Integer{ 0 })
+{
+#if REFCOUNTER_CHECK
+    using SignedInt = SignedInteger<Integer>::type;
+    if (static_cast<SignedInt>(counter) < static_cast<SignedInt>(expected_counter))
+        captainslog_dbgassert(false,
+            "REFCOUNTER_CHECK Deleting reference counted object more than once. Counter %d is not equal %d.",
+            static_cast<SignedInt>(counter),
+            static_cast<SignedInt>(expected_counter));
+
+    if (static_cast<SignedInt>(counter) > static_cast<SignedInt>(expected_counter))
+        captainslog_dbgassert(false,
+            "REFCOUNTER_CHECK Deleting reference counted object without releasing all owners. Counter %d is not equal %d.",
+            static_cast<SignedInt>(counter),
+            static_cast<SignedInt>(expected_counter));
+#endif
+}
+
+template<typename Integer> inline void Add_Ref_Check(Integer counter, Integer min_counter = Integer{ 1 })
+{
+#if REFCOUNTER_CHECK
+    using SignedInt = SignedInteger<Integer>::type;
+    captainslog_dbgassert(static_cast<SignedInt>(counter) >= static_cast<SignedInt>(min_counter),
+        "REFCOUNTER_CHECK Unexpected reference add. Counter %d is smaller than %d.",
+        static_cast<SignedInt>(counter),
+        static_cast<SignedInt>(min_counter));
+#endif
+}
+
+template<typename Integer> inline void Remove_Ref_Check(Integer counter, Integer min_counter = Integer{ 0 })
+{
+#if REFCOUNTER_CHECK
+    using SignedInt = SignedInteger<Integer>::type;
+    captainslog_dbgassert(static_cast<SignedInt>(counter) >= static_cast<SignedInt>(min_counter),
+        "REFCOUNTER_CHECK Unexpected reference removal. Counter %d is smaller than %d.",
+        static_cast<SignedInt>(counter),
+        static_cast<SignedInt>(min_counter));
+#endif
+}
+
+template<typename Integer> inline Integer Add_Ref(Integer &counter)
+{
+    ++counter;
+    Add_Ref_Check(counter);
+    return counter;
+}
+
+template<typename Integer> inline Integer Remove_Ref(Integer &counter)
+{
+    --counter;
+    Remove_Ref_Check(counter);
+    return counter;
+}
+
+template<typename Integer> inline Integer Add_Ref_Atomic(volatile Integer &counter)
+{
+    const Integer new_count = Atomic_Increment(&counter);
+    Add_Ref_Check(new_count);
+    return new_count;
+}
+
+template<typename Integer> inline Integer Remove_Ref_Atomic(volatile Integer &counter)
+{
+    const Integer new_counter = Atomic_Decrement(&counter);
+    Remove_Ref_Check(new_counter);
+    return new_counter;
+}
+
+} // namespace detail
+
+// Adapter for intrusive counters below.
+template<class Counter> class intrusive_counter_adapter
+{
+public:
+    using integer_type = typename Counter::integer_type;
+
+    static integer_type Add_Ref(Counter *counter) { return counter->Add_Ref(); }
+    static integer_type Remove_Ref(Counter *counter) { return counter->Remove_Ref(); }
+    static integer_type Use_Count(const Counter *counter) { return counter->Use_Count(); }
+};
+
+// Intrusive atomic counter for multi threaded use. Can be used with rts::intrusive_ptr<>.
+template<typename Integer, typename Derived, typename Deleter = NewDeleter<Derived>> class atomic_intrusive_counter_i
+{
+public:
+    using integer_type = Integer;
+    using derived_type = Derived;
+    using deleter_type = Deleter;
+
+    atomic_intrusive_counter_i() = default;
+    atomic_intrusive_counter_i(const atomic_intrusive_counter_i &) {}
+    atomic_intrusive_counter_i &operator=(const atomic_intrusive_counter_i &) { return *this; }
+
+#if REFCOUNTER_CHECK
+    // Virtual Destructor to make sure this is called always on any deletion attempt.
+    virtual ~atomic_intrusive_counter_i() { detail::Destructor_Ref_Check(m_counter); }
+#else
+    // Non virtual destructor to avoid forcing virtual table on derived type.
+    // Destructor could also be deleted in this class, but we keep it for good measure.
+    ~atomic_intrusive_counter_i() {}
+#endif
+
+    integer_type Add_Ref() const { return detail::Add_Ref_Atomic<integer_type>(m_counter); }
+    integer_type Remove_Ref() const
+    {
+        const integer_type new_counter = Atomic_Decrement(&m_counter);
+        if (new_counter == integer_type{ 0 }) {
+#if !REFCOUNTER_CHECK
+            this->~atomic_intrusive_counter_i();
+#endif
+            Invoke_Deleter<deleter_type>(const_cast<derived_type *>(static_cast<const derived_type *>(this)));
+        } else {
+            detail::Remove_Ref_Check(new_counter);
+        }
+        return new_counter;
+    }
+    integer_type Use_Count() const
+    {
+        captainslog_dbgassert(false, "Use count cannot be used in multi threaded context");
+        return integer_type{ -1 };
+    }
+
+private:
+    mutable volatile integer_type m_counter = integer_type{ 0 };
+};
+
+// Non-intrusive atomic counter for multi threaded use. Can be used with rts::shared_ptr_t<>.
+template<typename Integer> class atomic_shared_counter_i
+{
+public:
+    using integer_type = Integer;
+
+    atomic_shared_counter_i() = default;
+    atomic_shared_counter_i(const atomic_shared_counter_i &) = delete;
+    atomic_shared_counter_i &operator=(const atomic_shared_counter_i &) = delete;
+    ~atomic_shared_counter_i() { detail::Destructor_Ref_Check(m_counter); }
+
+    integer_type Add_Ref() const { return detail::Add_Ref_Atomic<integer_type>(m_counter); }
+    integer_type Remove_Ref() const { return detail::Remove_Ref_Atomic<integer_type>(m_counter); }
+    integer_type Use_Count() const
+    {
+        captainslog_dbgassert(false, "Use count cannot be used in multi threaded context");
+        return integer_type{ -1 };
+    }
+
+private:
+    mutable volatile integer_type m_counter = integer_type{ 0 };
+};
+
+// #TODO Add debug feature to verify counter is not touched from 2 different threads.
+
+// Intrusive counter for single threaded use. Can be used with rts::intrusive_ptr<>.
+template<typename Integer, typename Derived, typename Deleter = NewDeleter<Derived>> class intrusive_counter_i
+{
+public:
+    using integer_type = Integer;
+    using derived_type = Derived;
+    using deleter_type = Deleter;
+
+    intrusive_counter_i() = default;
+    intrusive_counter_i(const intrusive_counter_i &) {}
+    intrusive_counter_i &operator=(const intrusive_counter_i &) { return *this; }
+
+#if REFCOUNTER_CHECK
+    // Virtual Destructor to make sure this is called always on any deletion attempt.
+    virtual ~intrusive_counter_i() { detail::Destructor_Ref_Check(m_counter); }
+#else
+    // Non virtual destructor to avoid forcing virtual table on derived type.
+    // Destructor could also be deleted in this class, but we keep it for good measure.
+    ~intrusive_counter_i() {}
+#endif
+
+    integer_type Add_Ref() const { return detail::Add_Ref<integer_type>(m_counter); }
+    integer_type Remove_Ref() const
+    {
+        integer_type counter = --m_counter;
+        if (counter == integer_type{ 0 }) {
+#if !REFCOUNTER_CHECK
+            this->~intrusive_counter_i();
+#endif
+            Invoke_Deleter<deleter_type>(const_cast<derived_type *>(static_cast<const derived_type *>(this)));
+        } else {
+            detail::Remove_Ref_Check(counter);
+        }
+        return counter;
+    }
+    integer_type Use_Count() const { return m_counter; }
+
+private:
+    mutable integer_type m_counter = integer_type{ 0 };
+};
+
+// #TODO Add debug feature to verify counter is not touched from 2 different threads.
+
+// Non-intrusive counter for single threaded use. Can be used with rts::shared_ptr_t<>.
+template<typename Integer> class shared_counter_i
+{
+public:
+    using integer_type = Integer;
+
+    shared_counter_i() = default;
+    shared_counter_i(const shared_counter_i &) = delete;
+    shared_counter_i &operator=(const shared_counter_i &) = delete;
+    ~shared_counter_i() { detail::Destructor_Ref_Check(m_counter); }
+
+    integer_type Add_Ref() const { return detail::Add_Ref<integer_type>(m_counter); }
+    integer_type Remove_Ref() const { return detail::Remove_Ref<integer_type>(m_counter); }
+    integer_type Use_Count() const { return m_counter; }
+
+private:
+    mutable integer_type m_counter = integer_type{ 0 };
+};
+
+// Additional aliases for convenience.
+
+using RefCounterInteger = AtomicType32;
+
+template<typename Derived, typename Deleter = NewDeleter<Derived>>
+using atomic_intrusive_counter = atomic_intrusive_counter_i<RefCounterInteger, Derived, Deleter>;
+
+template<typename Derived, typename Deleter = NewDeleter<Derived>>
+using intrusive_counter = intrusive_counter_i<RefCounterInteger, Derived, Deleter>;
+
+using atomic_shared_counter = atomic_shared_counter_i<RefCounterInteger>;
+
+using shared_counter = shared_counter_i<RefCounterInteger>;
+
+} // namespace rts

--- a/src/game/common/utility/shared_ptr.h
+++ b/src/game/common/utility/shared_ptr.h
@@ -1,0 +1,182 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Lightweight shared pointer. (Thyme Feature)
+ *        Could be removed and replaced with std::shared_ptr (c++11) if STL Port is abandoned.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "refcounter.h"
+#include <algorithm>
+
+namespace rts
+{
+// Non-intrusive reference counted smart pointer.
+// Works similar to std::shared_ptr<>. Prefer using intrusive_ptr<> over shared_ptr_t<>.
+// Provide a custom deleter when not using new & delete. Uses thread unsafe counter by default.
+// If multiple threads are involved, then atomic_shared_counter can be used.
+// Must not assign a raw pointer that has already been assigned to another shared_ptr_t<>.
+template<class Value, typename Deleter = NewDeleter<Value>, typename Counter = shared_counter> class shared_ptr_t
+{
+public:
+    using element_type = Value;
+    using value_type = Value;
+    using reference = value_type &;
+    using const_reference = const value_type &;
+    using pointer = value_type *;
+    using const_pointer = const value_type *;
+    using counter_type = Counter;
+    using integer_type = typename Counter::integer_type;
+
+private:
+    value_type *m_ptr;
+    mutable counter_type *m_counter;
+
+public:
+    shared_ptr_t() noexcept : m_ptr(nullptr), m_counter(nullptr) {}
+
+    shared_ptr_t(value_type *ptr)
+    {
+        m_ptr = ptr;
+        m_counter = nullptr;
+        if (m_ptr != nullptr) {
+            add_ref_for(m_counter);
+        }
+    }
+
+    shared_ptr_t(const shared_ptr_t &other)
+    {
+        m_ptr = other.m_ptr;
+        m_counter = other.m_counter;
+        add_ref_for(m_counter);
+    }
+
+    shared_ptr_t(shared_ptr_t &&other) noexcept
+    {
+        m_ptr = other.m_ptr;
+        m_counter = other.m_counter;
+        other.m_ptr = nullptr;
+        other.m_counter = nullptr;
+    }
+
+    template<typename RelatedType> shared_ptr_t(const shared_ptr_t<RelatedType, counter_type> &other)
+    {
+        m_ptr = other.m_ptr;
+        m_counter = other.m_counter;
+        add_ref_for(m_counter);
+    }
+
+    ~shared_ptr_t() { remove_ref_for(m_counter, m_ptr); }
+
+    shared_ptr_t &operator=(const shared_ptr_t &other)
+    {
+        if (this != &other) {
+            add_ref_for(other.m_counter);
+            remove_ref_for(m_counter, m_ptr);
+            m_ptr = other.m_ptr;
+            m_counter = other.m_counter;
+        }
+        return *this;
+    }
+
+    shared_ptr_t &operator=(shared_ptr_t &&other)
+    {
+        if (this != &other) {
+            remove_ref_for(m_counter, m_ptr);
+            m_ptr = other.m_ptr;
+            m_counter = other.m_counter;
+            other.m_ptr = nullptr;
+            other.m_counter = nullptr;
+        }
+        return *this;
+    }
+
+    template<typename RelatedType> shared_ptr_t &operator=(const shared_ptr_t<RelatedType, counter_type> &other)
+    {
+        add_ref_for(other.m_counter);
+        remove_ref_for(m_counter, m_ptr);
+        m_ptr = other.m_ptr;
+        m_counter = other.m_counter;
+        return *this;
+    }
+
+    shared_ptr_t &operator=(value_type *ptr)
+    {
+        reset(ptr);
+        return *this;
+    }
+
+    reference operator*() noexcept { return *m_ptr; }
+    pointer operator->() noexcept { return m_ptr; }
+    pointer get() noexcept { return m_ptr; }
+
+    const_reference operator*() const noexcept { return *m_ptr; }
+    const_pointer operator->() const noexcept { return m_ptr; }
+    const_pointer get() const noexcept { return m_ptr; }
+
+    operator bool() const noexcept { return m_ptr != nullptr; }
+
+    // Reset smart pointer to null.
+    void reset() { shared_ptr_t().swap(*this); }
+
+    // Reset smart pointer with new pointer.
+    void reset(value_type *ptr)
+    {
+        if (ptr != m_ptr) {
+            shared_ptr_t(ptr).swap(*this);
+        }
+    }
+
+    // Swap smart pointer with other smart pointer.
+    void swap(shared_ptr_t &other) noexcept
+    {
+        std::swap(m_ptr, other.m_ptr);
+        std::swap(m_counter, other.m_counter);
+    }
+
+    // Get the count of how many times the pointer is referenced.
+    integer_type use_count() const { m_counter->UseCount(); }
+
+private:
+    // #TODO Maybe allocate reference counter in game memory pool for better locality, if it makes any difference.
+
+    static void add_ref_for(counter_type *&counter)
+    {
+        if (counter == nullptr) {
+            counter = new Counter;
+            counter->Add_Ref();
+        } else {
+            counter->Add_Ref();
+        }
+    }
+
+    static void remove_ref_for(counter_type *counter, value_type *ptr)
+    {
+        if (counter != nullptr) {
+            const integer_type ref = counter->Remove_Ref();
+            if (ref == integer_type{ 0 }) {
+                Invoke_Deleter<Deleter>(ptr);
+                delete counter;
+            }
+        }
+    }
+};
+
+// Additional aliases for convenience.
+
+template<typename Value, typename Deleter = NewDeleter<Value>>
+using shared_ptr = shared_ptr_t<Value, Deleter, shared_counter>;
+
+template<typename Value, typename Deleter = NewDeleter<Value>>
+using atomic_shared_ptr = shared_ptr_t<Value, Deleter, atomic_shared_counter>;
+
+} // namespace rts

--- a/src/game/common/utility/stlutil.h
+++ b/src/game/common/utility/stlutil.h
@@ -1,0 +1,44 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Utilities for Standard Template Library classes. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+namespace rts
+{
+
+template<class ContainerType> void Free_Container(ContainerType &container)
+{
+    ContainerType().swap(container);
+}
+
+template<class ContainerType> void Append_Container(ContainerType &dest, const ContainerType &src)
+{
+    dest.insert(dest.end(), src.begin(), src.end());
+}
+
+template<class ContainerType> void Shrink_To_Fit(ContainerType &container)
+{
+#if THYME_USE_STLPORT
+    if (container.capacity() > container.size()) {
+        ContainerType tmp;
+        container.swap(tmp);
+        container.swap(ContainerType());
+        container.assign(tmp.begin(), tmp.end());
+    }
+#else
+    container.shrink_to_fit();
+#endif
+}
+
+} // namespace rts

--- a/src/game/common/utility/stringutil.h
+++ b/src/game/common/utility/stringutil.h
@@ -1,0 +1,349 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief String utility functions. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "arrayview.h"
+#include <string>
+#include <typesize.h>
+#include <unichar.h>
+
+#if defined(THYME_USE_STLPORT)
+#define CHAR_TRAITS_CONSTEXPR
+#else
+#define CHAR_TRAITS_CONSTEXPR constexpr
+#endif
+
+namespace rts
+{
+
+// Get a single character. For use in templates.
+template<typename CharType> inline CHAR_TRAITS_CONSTEXPR CharType Get_Char(const char ch);
+
+template<> inline CHAR_TRAITS_CONSTEXPR char Get_Char<char>(const char ch)
+{
+    return ch;
+}
+
+template<> inline CHAR_TRAITS_CONSTEXPR unichar_t Get_Char<unichar_t>(const char ch)
+{
+    const int i_ch = std::char_traits<char>::to_int_type(ch);
+    const unichar_t u_ch = std::char_traits<unichar_t>::to_char_type(i_ch);
+    return u_ch;
+}
+
+// Get an empty null terminated c string. For use in templates.
+template<typename CharType> inline constexpr const CharType *Get_Null_Str();
+
+template<> inline constexpr const char *Get_Null_Str<char>()
+{
+    return "";
+}
+
+template<> inline constexpr const unichar_t *Get_Null_Str<unichar_t>()
+{
+    return U_CHAR("");
+}
+
+// Ascii whitespace is any of these
+// ' ' (0x20)(SPC)space
+// '\t'(0x09)(TAB)horizontal tab
+// '\n'(0x0a)(LF)newline
+// '\v'(0x0b)(VT)vertical tab
+// '\f'(0x0c)(FF)feed
+// '\r'(0x0d)(CR)carriage return
+template<typename CharType> CHAR_TRAITS_CONSTEXPR bool Is_Ascii_Whitespace(CharType ch)
+{
+    return ch == Get_Char<CharType>(' ') || ch == Get_Char<CharType>('\t') || ch == Get_Char<CharType>('\n')
+        || ch == Get_Char<CharType>('\v') || ch == Get_Char<CharType>('\f') || ch == Get_Char<CharType>('\r');
+}
+
+template<typename CharType> CHAR_TRAITS_CONSTEXPR bool Is_Null(CharType ch)
+{
+    return ch == Get_Char<CharType>('\0');
+}
+
+template<typename CharType> CHAR_TRAITS_CONSTEXPR bool Is_Space(CharType ch)
+{
+    return ch == Get_Char<CharType>(' ');
+}
+
+template<typename CharType> CHAR_TRAITS_CONSTEXPR bool Is_Null_Or_Ascii_Whitespace(CharType ch)
+{
+    return Is_Null(ch) || Is_Ascii_Whitespace(ch);
+}
+
+template<typename CharType> CHAR_TRAITS_CONSTEXPR std::size_t String_Length(const CharType *src)
+{
+    const CharType null_char = Get_Char<CharType>('\0');
+    const CharType *end = src;
+    while (*end != null_char) {
+        ++end;
+    }
+    return (end - src);
+}
+
+template<typename CharType> CHAR_TRAITS_CONSTEXPR int String_Compare(const CharType *s1, const CharType *s2)
+{
+    using UnsignedType = typename UnsignedIntegerForSize<sizeof(CharType)>::type;
+    const CharType null_char = Get_Char<CharType>('\0');
+
+    while (*s1 != null_char && *s1 == *s2) {
+        ++s1;
+        ++s2;
+    }
+    const auto i1 = *reinterpret_cast<const UnsignedType *>(s1);
+    const auto i2 = *reinterpret_cast<const UnsignedType *>(s2);
+    return (i1 > i2) - (i2 > i1);
+}
+
+template<typename CharType>
+CHAR_TRAITS_CONSTEXPR int String_N_Compare(const CharType *s1, const CharType *s2, std::size_t count)
+{
+    using UnsignedType = typename UnsignedIntegerForSize<sizeof(CharType)>::type;
+    const CharType null_char = Get_Char<CharType>('\0');
+
+    while (count != 0 && *s1 != null_char && *s1 == *s2) {
+        ++s1;
+        ++s2;
+        --count;
+    }
+    if (count == 0) {
+        return 0;
+    } else {
+        const auto i1 = *reinterpret_cast<const UnsignedType *>(s1);
+        const auto i2 = *reinterpret_cast<const UnsignedType *>(s2);
+        return (i1 > i2) - (i2 > i1);
+    }
+}
+
+// Strips leading and trailing spaces. Returns length of new string after strip. Writes null over all stripped characters at
+// the end. Compatible with UTF-8 and UTF-16.
+template<typename CharType> std::size_t Strip_Leading_And_Trailing_Spaces(CharType *dest)
+{
+    const CharType null_char = Get_Char<CharType>('\0');
+    const CharType *reader = dest;
+    const CharType *reader_end = dest + String_Length(dest);
+    CharType *writer = dest;
+    const CharType *writer_end = reader_end;
+
+    for (; reader != reader_end && Is_Space(*reader); ++reader) {
+    }
+
+    for (; reader != reader_end && Is_Space(*(reader_end - 1)); --reader_end) {
+    }
+
+    while (reader != reader_end) {
+        *writer++ = *reader++;
+    }
+
+    const std::size_t len = writer - dest;
+
+    while (writer != writer_end) {
+        *writer++ = null_char;
+    }
+
+    return len;
+}
+
+// Strips leading, trailing and duplicate spaces. Preserves other whitespace characters such as LF and strips surrounding
+// spaces. Returns length of new string after strip. Writes null over all stripped characters at the end. Compatible with
+// UTF-8 and UTF-16.
+template<typename CharType> std::size_t Strip_Obsolete_Spaces(CharType *dest)
+{
+    const CharType null_char = Get_Char<CharType>('\0');
+    CharType prev_char = Get_Char<CharType>(' ');
+    const CharType *reader = dest;
+    CharType *writer = dest;
+
+    for (; !Is_Null(*reader) && Is_Space(*reader); ++reader) {
+    }
+
+    while (!Is_Null(*reader)) {
+        CharType curr_char = *reader;
+        CharType next_char = *++reader;
+
+        if (Is_Space(curr_char) && (Is_Null_Or_Ascii_Whitespace(next_char) || Is_Ascii_Whitespace(prev_char))) {
+            continue;
+        }
+
+        *writer++ = curr_char;
+        prev_char = curr_char;
+    }
+
+    const std::size_t len = (writer - dest);
+
+    while (writer != reader) {
+        *writer++ = null_char;
+    }
+
+    return len;
+}
+
+// Replaces any search character with replacement character. Compatible with UTF-16. Compatible with UTF-8 if search and
+// replace are ASCII characters.
+template<typename CharType> void Replace_Characters(CharType *dest, const CharType *search, CharType replace)
+{
+    CharType *writer = dest;
+
+    for (; !Is_Null(*writer); ++writer) {
+        const CharType *searcher = search;
+
+        for (; !Is_Null(*searcher); ++searcher) {
+            if (*writer == *searcher) {
+                *writer = replace;
+                break;
+            }
+        }
+    }
+}
+
+// Replaces search character sequence with replacement character sequence. Returns count of characters copied to destination
+// string, not including null terminator. Compatible with UTF-16. Compatible with UTF-8 if search and replace are ASCII
+// characters.
+template<typename CharType>
+std::size_t Replace_Character_Sequence(
+    CharType *dest, std::size_t size, const CharType *src, const CharType *search, const CharType *replace)
+{
+    const CharType null_char = Get_Char<CharType>('\0');
+    const std::size_t search_len = String_Length(search);
+    const std::size_t replace_len = String_Length(replace);
+    const CharType *reader = src;
+    const CharType *writer_end = dest + size - 1;
+    CharType *writer = dest;
+    std::size_t replace_count = 0;
+
+    while (*reader != null_char && writer != writer_end) {
+        if (replace_count > 0) {
+            *writer++ = *(replace + replace_len - replace_count);
+            if (--replace_count == 0) {
+                reader += search_len;
+            }
+        } else if (String_N_Compare(reader, search, search_len) == 0) {
+            replace_count = replace_len;
+        } else {
+            *writer++ = *reader++;
+        }
+    }
+
+    *writer = null_char;
+
+    return (writer - dest);
+}
+
+// Replaces search character sequence(s) with replacement character sequence(s). Returns count of characters copied to
+// destination string, not including null terminator. Compatible with UTF-16. Compatible with UTF-8 if search and replace are
+// ASCII characters.
+template<typename CharType, std::size_t Count>
+std::size_t Replace_Character_Sequences(CharType *dest,
+    std::size_t size,
+    const CharType *src,
+    const CharType *(&search)[Count],
+    const CharType *(&replace)[Count])
+{
+    const CharType null_char = Get_Char<CharType>('\0');
+    std::size_t i;
+    std::size_t search_len[Count];
+    std::size_t replace_len[Count];
+    for (i = 0; i < Count; ++i) {
+        search_len[i] = String_Length(search[i]);
+        replace_len[i] = String_Length(replace[i]);
+    }
+    const CharType *reader = src;
+    const CharType *writer_end = dest + size - 1;
+    CharType *writer = dest;
+    std::size_t replace_count = 0;
+
+    while (*reader != null_char && writer != writer_end) {
+        if (replace_count > 0) {
+            *writer++ = *(replace[i] + replace_len[i] - replace_count);
+            if (--replace_count == 0) {
+                reader += search_len[i];
+            }
+        } else {
+            for (i = 0; i < Count; ++i) {
+                if (String_N_Compare(reader, search[i], search_len[i]) == 0) {
+                    replace_count = replace_len[i];
+                    break;
+                }
+            }
+            if (replace_count == 0) {
+                *writer++ = *reader++;
+            }
+        }
+    }
+
+    *writer = null_char;
+
+    return (writer - dest);
+}
+
+template<typename CharType> bool Is_Search_Character(CharType ch, const CharType *search)
+{
+    for (; !Is_Null(*search); ++search) {
+        if (ch == *search) {
+            return true;
+        }
+    }
+    return false;
+}
+
+// Strips string characters by given search characters. Compatible with UTF-16. Compatible with UTF-8 if search and replace
+// are ASCII characters.
+template<typename CharType> void Strip_Characters(CharType *dest, const CharType *search)
+{
+    const CharType null_char = Get_Char<CharType>('\0');
+    const CharType *reader = dest;
+    CharType *writer = dest;
+
+    for (; !Is_Null(*reader); ++reader) {
+        if (Is_Search_Character(*reader, search)) {
+            continue;
+        }
+
+        *writer++ = *reader;
+    }
+
+    while (writer != reader) {
+        *writer++ = null_char;
+    }
+}
+
+// Return the file extension of a given string.
+template<typename StringType> const typename StringType::value_type *Get_File_Extension(const StringType &filename)
+{
+    using CharType = typename StringType::value_type;
+
+    const char *begin = filename.begin();
+    const char *end = filename.end() - 1;
+
+    CharType ext_char = Get_Char<CharType>('.');
+    CharType dir1_char = Get_Char<CharType>(':');
+    CharType dir2_char = Get_Char<CharType>('/');
+    CharType dir3_char = Get_Char<CharType>('\\');
+
+    while (end != begin) {
+        CharType curr_char = *end;
+        if (curr_char == ext_char) {
+            return end + 1;
+        }
+        if (curr_char == dir1_char || curr_char == dir2_char || curr_char == dir3_char) {
+            return Get_Null_Str<CharType>();
+        }
+        --end;
+    }
+    return Get_Null_Str<CharType>();
+}
+
+} // namespace rts

--- a/src/game/common/utility/type_traits.h
+++ b/src/game/common/utility/type_traits.h
@@ -1,0 +1,118 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Type traits, equivalent to std type traits (c++11, 14) (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+namespace rts
+{
+template<typename T> struct remove_cv
+{
+    using type = T;
+};
+template<typename T> struct remove_cv<const T>
+{
+    using type = T;
+};
+template<typename T> struct remove_cv<volatile T>
+{
+    using type = T;
+};
+template<typename T> struct remove_cv<const volatile T>
+{
+    using type = T;
+};
+template<typename T> struct remove_const
+{
+    using type = T;
+};
+template<typename T> struct remove_const<const T>
+{
+    using type = T;
+};
+template<typename T> struct remove_volatile
+{
+    using type = T;
+};
+template<typename T> struct remove_volatile<volatile T>
+{
+    using type = T;
+};
+template<typename T> struct remove_reference
+{
+    using type = T;
+};
+template<typename T> struct remove_reference<T &>
+{
+    using type = T;
+};
+template<typename T> struct remove_reference<T &&>
+{
+    using type = T;
+};
+
+template<typename T> using remove_cv_t = typename remove_cv<T>::type;
+template<typename T> using remove_const_t = typename remove_const<T>::type;
+template<typename T> using remove_volatile_t = typename remove_volatile<T>::type;
+template<typename T> using remove_reference_t = typename remove_reference<T>::type;
+
+// std::underlying_type uses compiler intrinsics to deduce the enum type.
+// rts::underlying_type cannot do that automatically and instead relies on specializated template.
+// Example:
+//
+// namespace MyNamespace
+// {
+//     enum class MyEnum : unsigned int
+//     {
+//          MyValue1,
+//          MyValue2,
+//     }
+// }
+//
+// DEFINE_RTS_UNDERLYING_TYPE(MyNamespace::MyEnum, unsigned int);
+
+template<typename EnumType> struct underlying_type;
+template<typename EnumType> using underlying_type_t = typename underlying_type<EnumType>::type;
+} // namespace rts
+
+#define DEFINE_RTS_UNDERLYING_TYPE(EnumType, UnderlyingType) \
+    namespace rts \
+    { \
+    template<> struct underlying_type<EnumType> \
+    { \
+        using type = UnderlyingType; \
+    }; \
+    }
+
+namespace rts
+{
+
+// clang-format off
+// Fundamental types cannot be used with std::underlying_type. Apply same principle to rts::underlying_type.
+
+template<> struct underlying_type<signed char>{};
+template<> struct underlying_type<unsigned char>{};
+template<> struct underlying_type<signed short>{};
+template<> struct underlying_type<unsigned short>{};
+template<> struct underlying_type<signed int>{};
+template<> struct underlying_type<unsigned int>{};
+template<> struct underlying_type<signed long>{};
+template<> struct underlying_type<unsigned long>{};
+template<> struct underlying_type<signed long long>{};
+template<> struct underlying_type<unsigned long long>{};
+template<> struct underlying_type<float>{};
+template<> struct underlying_type<double>{};
+
+// clang-format on
+
+} // namespace rts

--- a/src/game/common/utility/utility.h
+++ b/src/game/common/utility/utility.h
@@ -1,0 +1,31 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Utilities, equivalent to std utility. (Thyme Feature)
+          Can be removed if STL Port is abandoned.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+namespace rts
+{
+
+template<class T> T &&forward(typename remove_reference<T>::type &t) noexcept
+{
+    return static_cast<T &&>(t);
+}
+
+template<class T> T &&forward(typename remove_reference<T>::type &&t) noexcept
+{
+    return static_cast<T &&>(t);
+}
+
+} // namespace rts

--- a/src/game/common/version.cpp
+++ b/src/game/common/version.cpp
@@ -13,7 +13,7 @@
  *            LICENSE
  */
 #include "version.h"
-#include "gametext.h"
+#include "gametextinterface.h"
 
 #ifndef GAME_DLL
 Version *g_theVersion = nullptr;

--- a/src/game/network/lanapi.cpp
+++ b/src/game/network/lanapi.cpp
@@ -13,7 +13,7 @@
  *            LICENSE
  */
 #include "lanapi.h"
-#include "gametext.h"
+#include "gametextinterface.h"
 #include "rtsutils.h"
 #include "transport.h"
 #include <cctype>

--- a/src/game/rtsutils.h
+++ b/src/game/rtsutils.h
@@ -89,6 +89,12 @@ template<int a, int b, int c, int d> struct FourCC
 #endif
 };
 
+// FourCC with big endian input (standard)
+template<int a, int b, int c, int d> using FourCC_BE = struct FourCC<a, b, c, d>;
+
+// FourCC with little endian input (reversed)
+template<int a, int b, int c, int d> using FourCC_LE = struct FourCC<d, c, b, a>;
+
 inline unsigned Get_Time()
 {
 #ifdef PLATFORM_WINDOWS

--- a/src/hooker/setuphooks_zh.cpp
+++ b/src/hooker/setuphooks_zh.cpp
@@ -68,7 +68,7 @@
 #include "gamemessage.h"
 #include "gamemessageparser.h"
 #include "gamestate.h"
-#include "gametext.h"
+#include "gametext_impl.h"
 #include "geometry.h"
 #include "globaldata.h"
 #include "hanimmgr.h"

--- a/src/tools/CMakeLists.txt
+++ b/src/tools/CMakeLists.txt
@@ -10,3 +10,5 @@ if(WIN32 OR CMAKE_SYSTEM_NAME STREQUAL "Windows")
     add_subdirectory(wdump)
     add_subdirectory(wndedit)
 endif()
+
+add_subdirectory(gametextcompiler)

--- a/src/tools/gametextcompiler/CMakeLists.txt
+++ b/src/tools/gametextcompiler/CMakeLists.txt
@@ -1,0 +1,17 @@
+set(CMAKE_CXX_STANDARD 17)
+
+set(GAMETEXTCOMPILER_SOURCES
+    src/commands.cpp
+    src/commands.h
+    src/log.cpp
+    src/log.h
+    src/main.cpp
+    src/processor.cpp
+    src/processor.h
+)
+
+set(GAMETEXTCOMPILER_INCLUDES src)
+
+add_executable(gametextcompiler ${GAMETEXTCOMPILER_SOURCES})
+target_include_directories(gametextcompiler PRIVATE ${GAMETEXTCOMPILER_INCLUDES})
+target_link_libraries(gametextcompiler PRIVATE thyme_lib)

--- a/src/tools/gametextcompiler/src/commands.cpp
+++ b/src/tools/gametextcompiler/src/commands.cpp
@@ -1,0 +1,171 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Text Compiler Commands. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "commands.h"
+
+namespace Thyme
+{
+namespace
+{
+const char *const s_command_action_names[] = {
+    "LOAD_CSF",
+    "LOAD_STR",
+    "LOAD_MULTI_STR",
+    "SAVE_CSF",
+    "SAVE_STR",
+    "SAVE_MULTI_STR",
+    "UNLOAD",
+    "RESET",
+    "MERGE_AND_OVERWRITE",
+    "SET_OPTIONS",
+    "SET_LANGUAGE",
+    "SWAP_LANGUAGE_STRINGS",
+    "SWAP_AND_SET_LANGUAGE",
+};
+
+const char *const s_command_argument_names[] = {
+    "FILE_ID",
+    "FILE_PATH",
+    "LANGUAGE",
+    "OPTION",
+};
+
+const char *const s_simple_action_names[] = {
+    "OPTIONS",
+    "LOAD_CSF",
+    "LOAD_STR",
+    "LOAD_STR_LANGUAGES",
+    "SWAP_AND_SET_LANGUAGE",
+    "SAVE_CSF",
+    "SAVE_STR",
+    "SAVE_STR_LANGUAGES",
+};
+
+static_assert(ARRAY_SIZE(s_command_action_names) == g_commandActionCount);
+static_assert(ARRAY_SIZE(s_command_argument_names) == g_commandArgumentCount);
+static_assert(ARRAY_SIZE(s_simple_action_names) == g_simpleActionCount);
+
+template<typename EnumType, size_t Size>
+bool String_To_Enum_Id(const char *str, EnumType &id, const char *const (&search_names)[Size])
+{
+    for (size_t index = 0; index < ARRAY_SIZE(search_names); ++index) {
+        if (strcasecmp(str, search_names[index]) == 0) {
+            id = static_cast<EnumType>(index);
+            return true;
+        }
+    }
+    return false;
+}
+} // namespace
+
+bool String_To_Command_Action_Id(const char *str, CommandActionId &action_id)
+{
+    return String_To_Enum_Id(str, action_id, s_command_action_names);
+}
+
+bool String_To_Command_Argument_Id(const char *str, CommandArgumentId &argument_id)
+{
+    return String_To_Enum_Id(str, argument_id, s_command_argument_names);
+}
+
+bool String_To_Simple_Action_Id(const char *str, SimpleActionId &action_id)
+{
+    return String_To_Enum_Id(str, action_id, s_simple_action_names);
+}
+
+CommandId Command::s_id = 1000000000;
+
+bool LoadCsfCommand::Execute() const
+{
+    return m_filePtr->Load_CSF(m_filePath.c_str());
+}
+
+bool LoadStrCommand::Execute() const
+{
+    return m_filePtr->Load_STR(m_filePath.c_str());
+}
+
+bool LoadMultiStrCommand::Execute() const
+{
+    return m_filePtr->Load_Multi_STR(m_filePath.c_str(), m_languages);
+}
+
+bool SaveCsfCommand::Execute() const
+{
+    return m_filePtr->Save_CSF(m_filePath.c_str());
+}
+
+bool SaveStrCommand::Execute() const
+{
+    return m_filePtr->Save_STR(m_filePath.c_str());
+}
+
+bool SaveMultiStrCommand::Execute() const
+{
+    return m_filePtr->Save_Multi_STR(m_filePath.c_str(), m_languages);
+}
+
+bool UnloadCommand::Execute() const
+{
+    if (m_languages.any()) {
+        m_filePtr->Unload(m_languages);
+    } else {
+        m_filePtr->Unload();
+    }
+    return true;
+}
+
+bool ResetCommand::Execute() const
+{
+    m_filePtr->Reset();
+    return true;
+}
+
+bool MergeAndOverwriteCommand::Execute() const
+{
+    if (m_languages.any()) {
+        m_filePtrA->Merge_And_Overwrite(*m_filePtrB, m_languages);
+    } else {
+        m_filePtrA->Merge_And_Overwrite(*m_filePtrB);
+    }
+    return true;
+}
+
+bool SetOptionsCommand::Execute() const
+{
+    m_filePtr->Set_Options(m_options);
+    return true;
+}
+
+bool SetLanguageCommand::Execute() const
+{
+    m_filePtr->Set_Language(m_language);
+    return true;
+}
+
+bool SwapLanguageStringsCommand::Execute() const
+{
+    m_filePtr->Swap_String_Infos(m_languageA, m_languageB);
+    return true;
+}
+
+bool SwapAndSetLanguageCommand::Execute() const
+{
+    const LanguageID current_language = m_filePtr->Get_Language();
+    m_filePtr->Swap_String_Infos(current_language, m_language);
+    m_filePtr->Set_Language(m_language);
+    return true;
+}
+
+} // namespace Thyme

--- a/src/tools/gametextcompiler/src/commands.h
+++ b/src/tools/gametextcompiler/src/commands.h
@@ -1,0 +1,280 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Text Compiler Commands. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include <gametextfile.h>
+#include <memory>
+#include <string>
+
+namespace Thyme
+{
+using CommandId = size_t;
+using GameTextOption = GameTextOption;
+using GameTextOptions = GameTextFile::Options;
+using GameTextFile = GameTextFile;
+using GameTextFilePtr = std::shared_ptr<GameTextFile>;
+using Languages = GameTextFile::Languages;
+
+enum class CommandActionId
+{
+    INVALID = -1,
+    LOAD_CSF,
+    LOAD_STR,
+    LOAD_MULTI_STR,
+    SAVE_CSF,
+    SAVE_STR,
+    SAVE_MULTI_STR,
+    UNLOAD,
+    RESET,
+    MERGE_AND_OVERWRITE,
+    SET_OPTIONS,
+    SET_LANGUAGE,
+    SWAP_LANGUAGE_STRINGS,
+    SWAP_AND_SET_LANGUAGE,
+
+    COUNT
+};
+
+enum class CommandArgumentId
+{
+    INVALID = -1,
+    FILE_ID,
+    FILE_PATH,
+    LANGUAGES,
+    OPTIONS,
+
+    COUNT
+};
+
+enum class SimpleActionId
+{
+    OPTIONS,
+    LOAD_CSF_FILE,
+    LOAD_STR_FILE,
+    LOAD_STR_LANGUAGES,
+    SWAP_AND_SET_LANGUAGE,
+    SAVE_CSF,
+    SAVE_STR,
+    SAVE_STR_LANGUAGES,
+
+    COUNT
+};
+
+constexpr size_t g_commandActionCount = size_t(CommandActionId::COUNT);
+constexpr size_t g_commandArgumentCount = size_t(CommandArgumentId::COUNT);
+constexpr size_t g_simpleActionCount = size_t(SimpleActionId::COUNT);
+
+bool String_To_Command_Action_Id(const char *str, CommandActionId &action_id);
+bool String_To_Command_Argument_Id(const char *str, CommandArgumentId &argument_id);
+bool String_To_Simple_Action_Id(const char *str, SimpleActionId &action_id);
+
+class Command
+{
+public:
+    Command() : m_id(s_id++) {}
+    virtual ~Command() {}
+
+    CommandId Id() const { return m_id; }
+    void Set_Id(CommandId id) { m_id = id; }
+
+    virtual CommandActionId Type() const = 0;
+    virtual bool Execute() const = 0;
+
+private:
+    CommandId m_id;
+    static CommandId s_id;
+};
+
+class LoadCsfCommand : public Command
+{
+public:
+    LoadCsfCommand(const GameTextFilePtr &file_ptr, const char *path) : m_filePtr(file_ptr), m_filePath(path) {}
+
+    virtual CommandActionId Type() const override { return CommandActionId::LOAD_CSF; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    std::string m_filePath;
+};
+
+class LoadStrCommand : public Command
+{
+public:
+    LoadStrCommand(const GameTextFilePtr &file_ptr, const char *path) : m_filePtr(file_ptr), m_filePath(path) {}
+    virtual CommandActionId Type() const override { return CommandActionId::LOAD_STR; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    std::string m_filePath;
+};
+
+class LoadMultiStrCommand : public Command
+{
+public:
+    LoadMultiStrCommand(const GameTextFilePtr &file_ptr, const char *path, Languages languages) :
+        m_filePtr(file_ptr), m_filePath(path), m_languages(languages)
+    {
+    }
+    virtual CommandActionId Type() const override { return CommandActionId::LOAD_MULTI_STR; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    std::string m_filePath;
+    Languages m_languages;
+};
+
+class SaveCsfCommand : public Command
+{
+public:
+    SaveCsfCommand(const GameTextFilePtr &file_ptr, const char *path) : m_filePtr(file_ptr), m_filePath(path) {}
+
+    virtual CommandActionId Type() const override { return CommandActionId::SAVE_CSF; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    std::string m_filePath;
+};
+
+class SaveStrCommand : public Command
+{
+public:
+    SaveStrCommand(const GameTextFilePtr &file_ptr, const char *path) : m_filePtr(file_ptr), m_filePath(path) {}
+    virtual CommandActionId Type() const override { return CommandActionId::SAVE_STR; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    std::string m_filePath;
+};
+
+class SaveMultiStrCommand : public Command
+{
+public:
+    SaveMultiStrCommand(const GameTextFilePtr &file_ptr, const char *path, Languages languages) :
+        m_filePtr(file_ptr), m_filePath(path), m_languages(languages)
+    {
+    }
+    virtual CommandActionId Type() const override { return CommandActionId::SAVE_MULTI_STR; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    std::string m_filePath;
+    Languages m_languages;
+};
+
+class UnloadCommand : public Command
+{
+public:
+    UnloadCommand(const GameTextFilePtr &file_ptr, Languages languages) : m_filePtr(file_ptr), m_languages(languages) {}
+
+    virtual CommandActionId Type() const override { return CommandActionId::UNLOAD; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    Languages m_languages;
+};
+
+class ResetCommand : public Command
+{
+public:
+    ResetCommand(const GameTextFilePtr &file_ptr) : m_filePtr(file_ptr) {}
+
+    virtual CommandActionId Type() const override { return CommandActionId::RESET; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+};
+
+class MergeAndOverwriteCommand : public Command
+{
+public:
+    MergeAndOverwriteCommand(const GameTextFilePtr &file_ptr_a, const GameTextFilePtr &file_ptr_b, Languages languages) :
+        m_filePtrA(file_ptr_a), m_filePtrB(file_ptr_b), m_languages(languages)
+    {
+    }
+    virtual CommandActionId Type() const override { return CommandActionId::MERGE_AND_OVERWRITE; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtrA;
+    GameTextFilePtr m_filePtrB;
+    Languages m_languages;
+};
+
+class SetOptionsCommand : public Command
+{
+public:
+    SetOptionsCommand(const GameTextFilePtr &file_ptr, GameTextOptions options) : m_filePtr(file_ptr), m_options(options) {}
+
+    virtual CommandActionId Type() const override { return CommandActionId::SET_OPTIONS; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    GameTextOptions m_options;
+};
+
+class SetLanguageCommand : public Command
+{
+public:
+    SetLanguageCommand(const GameTextFilePtr &file_ptr, LanguageID language) : m_filePtr(file_ptr), m_language(language) {}
+
+    virtual CommandActionId Type() const override { return CommandActionId::SET_LANGUAGE; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    LanguageID m_language;
+};
+
+class SwapLanguageStringsCommand : public Command
+{
+public:
+    SwapLanguageStringsCommand(const GameTextFilePtr &file_ptr, LanguageID language_a, LanguageID language_b) :
+        m_filePtr(file_ptr), m_languageA(language_a), m_languageB(language_b)
+    {
+    }
+    virtual CommandActionId Type() const override { return CommandActionId::SWAP_LANGUAGE_STRINGS; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    LanguageID m_languageA;
+    LanguageID m_languageB;
+};
+
+class SwapAndSetLanguageCommand : public Command
+{
+public:
+    SwapAndSetLanguageCommand(const GameTextFilePtr &file_ptr, LanguageID language) :
+        m_filePtr(file_ptr), m_language(language)
+    {
+    }
+    virtual CommandActionId Type() const override { return CommandActionId::SWAP_AND_SET_LANGUAGE; }
+    virtual bool Execute() const override;
+
+private:
+    GameTextFilePtr m_filePtr;
+    LanguageID m_language;
+};
+
+} // namespace Thyme

--- a/src/tools/gametextcompiler/src/log.cpp
+++ b/src/tools/gametextcompiler/src/log.cpp
@@ -1,0 +1,27 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Text Compiler Log. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "log.h"
+#include <cstdarg>
+#include <cstdio>
+
+void Print_Line(const char *message, ...)
+{
+    va_list args;
+    va_start(args, message);
+    vfprintf(stderr, message, args);
+    fprintf(stderr, "\n");
+    va_end(args);
+    fflush(stderr);
+}

--- a/src/tools/gametextcompiler/src/log.h
+++ b/src/tools/gametextcompiler/src/log.h
@@ -1,0 +1,17 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Text Compiler Log. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+void Print_Line(const char *message, ...);

--- a/src/tools/gametextcompiler/src/main.cpp
+++ b/src/tools/gametextcompiler/src/main.cpp
@@ -1,0 +1,252 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Text Compiler. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "log.h"
+#include "processor.h"
+#include <archivefilesystem.h>
+#include <filesystem.h>
+#include <localfilesystem.h>
+#include <string>
+#include <subsysteminterface.h>
+#include <utility/arrayutil.h>
+#include <win32bigfilesystem.h>
+#include <win32localfilesystem.h>
+
+#if defined PLATFORM_WINDOWS
+HWND g_applicationHWnd;
+#endif
+
+using namespace Thyme;
+
+// clang-format off
+void Print_Help()
+{
+//       1         2         3         4         5         6         7         8         9        10        11        12
+//3456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+Print_Line(
+R"#(Function Command List ...
+
+Syntax: COMMAND_NAME(ARGUMENT_NAME_A:value,ARGUMENT_NAME_B:value)
+All capital words are interpreted keywords and must not be omitted.
+All symbols of ( : , ) are part of the syntax and must not be omitted.
+'mandatory' and 'optional' words show whether or not argument is mandatory.
+[1] and [n] words show that argument takes one or multiple values.
+Commands and command arguments are not case sensitive.
+Space character will end current Command and begin new Command in command line.
+Commands are executed in the order they are written in the command line.
+
+LOAD_CSF(FILE_ID:optional,FILE_PATH:mandatory)
+  > Loads a CSF file from FILE_PATH into FILE_ID slot.
+    File language is set to the one stored in CSF file.
+
+LOAD_STR(FILE_ID:optional,FILE_PATH:mandatory)
+  > Loads a STR file from FILE_PATH into FILE_ID slot. File language is not changed.
+
+LOAD_MULTI_STR(FILE_ID:optional,FILE_PATH:mandatory,LANGUAGE:[n]mandatory)
+   > Loads a Multi STR file from FILE_PATH with LANGUAGE into FILE_ID slot.
+     File language is set to the first loaded language.
+
+SAVE_CSF(FILE_ID:optional,FILE_PATH:mandatory)
+  > Saves a CSF file to FILE_PATH from FILE_ID slot.
+
+SAVE_STR(FILE_ID:optional,FILE_PATH:mandatory)
+  > Saves a STR file to FILE_PATH from FILE_ID slot.
+
+SAVE_MULTI_STR(FILE_ID:optional,FILE_PATH:mandatory,LANGUAGE:[n]mandatory)
+  > Saves a Multi STR file to FILE_PATH with LANGUAGE from FILE_ID slot.
+
+UNLOAD(FILE_ID:optional,LANGUAGE:[n]optional)
+  > Unloads string data from FILE_ID slot.
+    Uses the optionally specified language(s), otherwise the current selected file language.
+
+RESET(FILE_ID:optional)
+  > Resets all string data.
+
+MERGE_AND_OVERWRITE(FILE_ID:mandatory,FILE_ID:mandatory,LANGUAGE:[n]optional)
+  > Merges and overwrites string data in 1st FILE_ID from 2nd FILE_ID.
+    Uses the optionally specified language(s), otherwise the current selected file language.
+
+SET_OPTIONS(FILE_ID:optional,OPTION:[n]optional)
+  > Sets options of OPTION in FILE_ID.
+
+SET_LANGUAGE(FILE_ID:optional,LANGUAGE:[1]mandatory)
+  > Sets language of LANGUAGE in FILE_ID.
+
+SWAP_LANGUAGE_STRINGS(FILE_ID:optional,LANGUAGE:[1]mandatory,LANGUAGE:[1]mandatory)
+  > Swaps string data in FILE_ID between 1st LANGUAGE and 2nd LANGUAGE.
+
+SWAP_AND_SET_LANGUAGE(FILE_ID:optional,LANGUAGE:[1]mandatory)
+  > Swaps string data in FILE_ID between current selected file language and LANGUAGE.
+)#");
+//       1         2         3         4         5         6         7         8         9        10        11        12
+//3456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+Print_Line(
+R"#(Command Argument List ...
+
+FILE_ID:number
+FILE_ID takes number and allows to manage multiple files in compiler. Default is 0.
+
+FILE_PATH:path
+FILE_PATH takes any relative or absolute path.
+
+LANGUAGE:enum
+LANGUAGE takes one [1] or multiple [n] languages, separated by pipe:
+All|English|German|French|Spanish|Italian|Japanese|Korean|Chinese|Brazilian|Polish|Unknown|Russian|Arabic
+
+OPTION:enum
+OPTION takes one [1] or multiple [n] options, separated by pipe:
+None|Check_Buffer_Length_On_Load|Check_Buffer_Length_On_Save|
+Keep_Obsolete_Spaces_On_Load|Write_Extra_LF_On_STR_Save|Optimize_Memory_Size
+)#");
+//       1         2         3         4         5         6         7         8         9        10        11        12
+//3456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890
+Print_Line(
+R"#(Simplified Command List ...
+
+Commands are executed in the order they are listed here.
+All capital words are NOT interpreted keywords and are substituted by the command argument(s) of choice.
+[1] and [n] words show that argument takes one or multiple values.
+Commands and command arguments are not case sensitive.
+
+-options OPTION[n]
+  > Sets option(s) for loaded and saved file.
+
+-load_csf filepath.csf
+  > Loads a CSF file from given file path. File language is set to the one stored in CSF file.
+
+-load_str filepath.str
+  > Loads a STR file from given file path. File language is not changed.
+
+-load_str_languages LANGUAGE[n]
+  > Sets language(s) to load Multi STR file with. File language is set to the first loaded language.
+
+-swap_and_set_languages LANGUAGE[1]
+  > Swaps language strings and sets file language from current file language to the given language.
+
+-save_csf filepath.csf
+  > Saves a CSF file to the given file path.
+
+-save_str filepath.str
+  > Saves a STR file to the given file path.
+
+-save_str_languages LANGUAGE[n]
+  > Sets language(s) to save Multi STR file with.
+)#");
+}
+// clang-format on
+
+void Print_Error(const Processor::Result &result, const Processor::CommandTexts &command_texts)
+{
+    const size_t command_index = result.error_command_index;
+    const char *result_name = Processor::Get_Result_Name(result.id);
+    const char *command_name = (command_index < command_texts.size()) ? command_texts[command_index] : "";
+    const std::string error_str(result.error_text.begin(), result.error_text.end());
+
+    Print_Line("Execution stopped with error '%s' at command '%s' (%zu) and error string '%s'",
+        result_name,
+        command_name,
+        command_index,
+        error_str.c_str());
+}
+
+namespace
+{
+constexpr int NoError = 0;
+constexpr int MissingArgumentsError = 1;
+constexpr int ProcessorParseError = 2;
+constexpr int ProcessorExecuteError = 3;
+} // namespace
+
+LocalFileSystem *Create_Local_File_System()
+{
+    return new Win32LocalFileSystem;
+}
+
+ArchiveFileSystem *Create_Archive_File_System()
+{
+    return new Win32BIGFileSystem;
+}
+
+struct CaptainsLogCreator
+{
+    CaptainsLogCreator()
+    {
+        captains_settings_t captains_settings = { 0 };
+        captains_settings.level = LOGLEVEL_DEBUG;
+        captains_settings.console = true;
+        captains_settings.print_file = true;
+        captainslog_init(&captains_settings);
+    };
+    ~CaptainsLogCreator() { captainslog_deinit(); }
+};
+
+struct EngineSystemsCreator
+{
+    EngineSystemsCreator()
+    {
+        g_theSubsystemList = new SubsystemInterfaceList;
+        g_theFileSystem = new FileSystem;
+        Init_Subsystem(g_theLocalFileSystem, "TheLocalFileSystem", Create_Local_File_System());
+        g_theLocalFileSystem->Init();
+#if 0
+        Init_Subsystem(g_theArchiveFileSystem, "TheArchiveFileSystem", Create_Archive_File_System());
+        g_theArchiveFileSystem->Init();
+#endif
+    }
+    ~EngineSystemsCreator()
+    {
+        delete g_theArchiveFileSystem;
+        delete g_theLocalFileSystem;
+        delete g_theFileSystem;
+        delete g_theSubsystemList;
+        g_theArchiveFileSystem = nullptr;
+        g_theLocalFileSystem = nullptr;
+        g_theFileSystem = nullptr;
+        g_theSubsystemList = nullptr;
+    }
+};
+
+int main(int argc, const char *argv[])
+{
+    Print_Line("Game Text Compiler 1.1 by The Assembly Armada");
+
+    if (argc < 2) {
+        Print_Help();
+        return MissingArgumentsError;
+    }
+    GameTextFile::Set_Log_File(stderr);
+    CaptainsLogCreator captains_log_creator;
+    EngineSystemsCreator engine_systems_creator;
+
+    const auto command_texts = rts::Make_Array_View(argv + 1, argc - 1);
+    Processor processor;
+    Processor::Result result = processor.Parse_Commands(command_texts);
+
+    if (result.id != Processor::ResultId::SUCCESS) {
+        Print_Line("ERROR : Game Text Compiler failed to parse commands");
+        Print_Error(result, command_texts);
+        return ProcessorParseError;
+    }
+
+    result = processor.Execute_Commands();
+
+    if (result.id != Processor::ResultId::SUCCESS) {
+        Print_Line("ERROR : Game Text Compiler failed to execute commands");
+        Print_Error(result, command_texts);
+        return ProcessorExecuteError;
+    }
+
+    Print_Line("Game Text Compiler completed successfully");
+    return NoError;
+}

--- a/src/tools/gametextcompiler/src/processor.cpp
+++ b/src/tools/gametextcompiler/src/processor.cpp
@@ -1,0 +1,713 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Text Compiler Processor. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "processor.h"
+#include "commands.h"
+#include <algorithm>
+#include <utility/stringutil.h>
+
+namespace Thyme
+{
+namespace
+{
+constexpr const char *const s_result_names[] = {
+    "SUCCESS",
+    "INVALID_COMMAND_ACTION",
+    "INVALID_COMMAND_ARGUMENT",
+    "INVALID_LANGUAGE_VALUE",
+    "INVALID_OPTION_VALUE",
+    "INVALID_FILE_ID_ARGUMENT",
+    "MISSING_FILE_PATH_ARGUMENT",
+    "MISSING_LANGUAGE_ARGUMENT",
+    "EXECUTION_ERROR",
+};
+
+static_assert(ARRAY_SIZE(s_result_names) == size_t(Processor::ResultId::COUNT));
+} // namespace
+
+const char *Processor::Get_Result_Name(ResultId id)
+{
+    return s_result_names[size_t(id)];
+}
+
+const Processor::FileId Processor::s_defaultFileId = { 0 };
+
+Processor::Processor() : m_fileMap(), m_commands() {}
+
+Processor::Result Processor::Parse_Commands(const CommandTexts &command_texts)
+{
+    if (Has_Simple_Command(command_texts)) {
+        return Parse_Simple_Commands(command_texts);
+    } else {
+        return Parse_Function_Commands(command_texts);
+    }
+}
+
+Processor::Result Processor::Execute_Commands() const
+{
+    Result result(ResultId::SUCCESS);
+
+    for (const CommandPtr &command : m_commands) {
+        if (!command->Execute()) {
+            result.id = ResultId::EXECUTION_ERROR;
+            result.error_command_index = command->Id();
+            break;
+        }
+    }
+    return result;
+}
+
+Processor::Result Processor::Parse_Function_Commands(const CommandTexts &command_texts)
+{
+    Result result(ResultId::SUCCESS);
+    CommandPtrs commands;
+
+    for (size_t index = 0; index < command_texts.size(); ++index) {
+
+        CommandAction action;
+        result = Parse_Function_Command(action, command_texts[index], index);
+
+        if (result.id != ResultId::SUCCESS) {
+            result.error_command_index = index;
+            break;
+        }
+
+        result = Add_New_Command(commands, m_fileMap, action);
+
+        if (result.id != ResultId::SUCCESS) {
+            result.error_command_index = index;
+            break;
+        }
+    }
+
+    if (result.id == ResultId::SUCCESS) {
+        m_commands.swap(commands);
+    }
+
+    return result;
+}
+
+Processor::Result Processor::Parse_Simple_Commands(const CommandTexts &command_texts)
+{
+    Result result(ResultId::SUCCESS);
+    CommandActionSequence actions;
+    CommandPtrs commands;
+
+    if (!command_texts.empty()) {
+
+        const size_t size = command_texts.size();
+
+        for (size_t index = 0; index < size - 1; ++index) {
+
+            if (!Is_Simple_Command(command_texts[index])) {
+                continue;
+            }
+
+            const char *command_name = command_texts[index] + 1;
+            const char *command_value = command_texts[index + 1];
+
+            result = Parse_Simple_Command(actions, command_name, command_value, index);
+
+            if (result.id != ResultId::SUCCESS) {
+                result.error_command_index = index;
+                break;
+            }
+
+            ++index;
+        }
+    }
+
+    if (result.id == ResultId::SUCCESS) {
+
+        for (const CommandAction &action : actions) {
+            if (action.action_id != CommandActionId::INVALID) {
+                result = Add_New_Command(commands, m_fileMap, action);
+
+                if (result.id != ResultId::SUCCESS) {
+                    result.error_command_index = action.command_index;
+                    break;
+                }
+            }
+        }
+    }
+
+    if (result.id == ResultId::SUCCESS) {
+        m_commands.swap(commands);
+    }
+
+    return result;
+}
+
+bool Processor::Has_Simple_Command(const CommandTexts &command_texts)
+{
+    for (const char *command_text : command_texts) {
+        if (Is_Simple_Command(command_text)) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool Processor::Is_Simple_Command(const char *command_text)
+{
+    return command_text != nullptr && *command_text == '-';
+}
+
+template<size_t Size> bool Processor::Parse_Next_Word(std::string &word, const char *&str, const char (&separators)[Size])
+{
+    const char *reader = str;
+
+    do {
+        for (const char separator : separators) {
+            if (*reader == separator && reader > str) {
+                word.assign(str, reader);
+                str = reader;
+                if (*str != '\0') {
+                    str += 1;
+                }
+                return true;
+            }
+        }
+    } while (*reader++ != '\0');
+
+    return false;
+}
+
+Processor::Result Processor::Parse_Function_Command(CommandAction &action, const char *command_text, size_t command_index)
+{
+    Result result(ResultId::SUCCESS);
+    CommandActionId action_id = CommandActionId::INVALID;
+    CommandArgumentId argument_id = CommandArgumentId::INVALID;
+    CommandArguments arguments;
+    const char *reader = command_text;
+    std::string word;
+
+    while (true) {
+        const char *word_begin = reader;
+
+        if (reader == command_text && Parse_Next_Word(word, reader, { '(' })) {
+            if (!String_To_Command_Action_Id(word.c_str(), action_id)) {
+                result.id = ResultId::INVALID_COMMAND_ACTION;
+                result.error_text = ErrorText(word_begin, reader);
+                break;
+            }
+
+        } else if (argument_id == CommandArgumentId::INVALID && Parse_Next_Word(word, reader, { ':' })) {
+            if (!String_To_Command_Argument_Id(word.c_str(), argument_id)) {
+                result.id = ResultId::INVALID_COMMAND_ARGUMENT;
+                result.error_text = ErrorText(word_begin, reader);
+                break;
+            }
+            arguments.emplace_back();
+
+        } else if (argument_id != CommandArgumentId::INVALID && Parse_Next_Word(word, reader, { ',', '|', ')' })) {
+            result = Parse_Command_Argument(arguments.back(), word, argument_id);
+            if (result.id != ResultId::SUCCESS) {
+                result.error_text = ErrorText(word_begin, reader);
+                break;
+            }
+            if (*(reader - 1) == ',') {
+                argument_id = CommandArgumentId::INVALID;
+            }
+
+        } else {
+            break;
+        }
+    }
+
+    if (action_id == CommandActionId::INVALID) {
+        result.id = ResultId::INVALID_COMMAND_ACTION;
+    }
+
+    if (result.id == ResultId::SUCCESS) {
+        action.action_id = action_id;
+        action.arguments.swap(arguments);
+        action.command_index = command_index;
+    }
+
+    return result;
+}
+
+Processor::Result Processor::Parse_Simple_Command(
+    CommandActionSequence &actions, const char *command_name, const char *command_value, size_t command_index)
+{
+    Result result(ResultId::SUCCESS);
+    SimpleActionId simple_action_id;
+
+    if (!String_To_Simple_Action_Id(command_name, simple_action_id)) {
+        result.id = ResultId::INVALID_COMMAND_ACTION;
+        result.error_text = ErrorText(command_name, command_name + strlen(command_name));
+        return result;
+    }
+
+    bool overwrite_action_id = false;
+    SequenceId sequence_id = SequenceId::INVALID;
+    CommandActionId action_id = CommandActionId::INVALID;
+    CommandArgumentId argument_id = CommandArgumentId::INVALID;
+
+    switch (simple_action_id) {
+        case SimpleActionId::OPTIONS:
+            sequence_id = SequenceId::SET_OPTIONS;
+            action_id = CommandActionId::SET_OPTIONS;
+            argument_id = CommandArgumentId::OPTIONS;
+            break;
+        case SimpleActionId::LOAD_CSF_FILE:
+            sequence_id = SequenceId::LOAD;
+            action_id = CommandActionId::LOAD_CSF;
+            argument_id = CommandArgumentId::FILE_PATH;
+            break;
+        case SimpleActionId::LOAD_STR_FILE:
+            sequence_id = SequenceId::LOAD;
+            action_id = CommandActionId::LOAD_STR;
+            argument_id = CommandArgumentId::FILE_PATH;
+            break;
+        case SimpleActionId::LOAD_STR_LANGUAGES:
+            sequence_id = SequenceId::LOAD;
+            action_id = CommandActionId::LOAD_MULTI_STR;
+            argument_id = CommandArgumentId::LANGUAGES;
+            overwrite_action_id = true;
+            break;
+        case SimpleActionId::SWAP_AND_SET_LANGUAGE:
+            sequence_id = SequenceId::SWAP_AND_SET_LANGUAGE;
+            action_id = CommandActionId::SWAP_AND_SET_LANGUAGE;
+            argument_id = CommandArgumentId::LANGUAGES;
+            break;
+        case SimpleActionId::SAVE_CSF:
+            sequence_id = SequenceId::SAVE;
+            action_id = CommandActionId::SAVE_CSF;
+            argument_id = CommandArgumentId::FILE_PATH;
+            break;
+        case SimpleActionId::SAVE_STR:
+            sequence_id = SequenceId::SAVE;
+            action_id = CommandActionId::SAVE_STR;
+            argument_id = CommandArgumentId::FILE_PATH;
+            break;
+        case SimpleActionId::SAVE_STR_LANGUAGES:
+            sequence_id = SequenceId::SAVE;
+            action_id = CommandActionId::SAVE_MULTI_STR;
+            argument_id = CommandArgumentId::LANGUAGES;
+            overwrite_action_id = true;
+            break;
+    }
+
+    static_assert(g_simpleActionCount == 8, "SimpleAction is missing");
+
+    captainslog_assert(sequence_id != SequenceId::INVALID);
+
+    if (sequence_id != SequenceId::INVALID) {
+        CommandArgument argument;
+
+        {
+            const char *reader = command_value;
+            const char *word_begin = reader;
+            std::string word;
+
+            while (Parse_Next_Word(word, reader, { '|', '\0' })) {
+                result = Parse_Command_Argument(argument, word, argument_id);
+                if (result.id != ResultId::SUCCESS) {
+                    result.error_text = ErrorText(word_begin, reader);
+                    break;
+                }
+                word_begin = reader;
+            }
+        }
+
+        if (result.id == ResultId::SUCCESS) {
+            CommandAction &action = actions[size_t(sequence_id)];
+
+            if (action.action_id == CommandActionId::INVALID || overwrite_action_id) {
+                action.action_id = action_id;
+                action.command_index = command_index;
+            }
+            action.arguments.emplace_back(std::move(argument));
+        }
+    }
+
+    return result;
+}
+
+Processor::Result Processor::Parse_Command_Argument(
+    CommandArgument &argument, std::string &str, CommandArgumentId argument_id)
+{
+    Result result(ResultId::SUCCESS);
+
+    switch (argument_id) {
+        case CommandArgumentId::FILE_ID: {
+            FileId file_id;
+            file_id.value = std::stoi(str);
+            argument.value.emplace<FileId>(std::move(file_id));
+            break;
+        }
+        case CommandArgumentId::FILE_PATH: {
+            FilePath file_path;
+            file_path.value = str.c_str();
+            argument.value.emplace<FilePath>(std::move(file_path));
+            break;
+        }
+        case CommandArgumentId::LANGUAGES: {
+            LanguageID language;
+
+            if (strcasecmp(str.c_str(), "All") == 0) {
+                argument.value.emplace<Languages>(~Languages());
+
+            } else if (Name_To_Language(str.c_str(), language)) {
+                Languages languages;
+                const Languages *languages_ptr = std::get_if<Languages>(&argument.value);
+                if (languages_ptr != nullptr) {
+                    languages = *languages_ptr;
+                }
+                languages |= language;
+                argument.value.emplace<Languages>(std::move(languages));
+
+            } else {
+                result.id = ResultId::INVALID_LANGUAGE_VALUE;
+            }
+            break;
+        }
+        case CommandArgumentId::OPTIONS: {
+            GameTextOption option;
+
+            if (Name_To_Game_Text_Option(str.c_str(), option)) {
+                GameTextOptions options;
+                const GameTextOptions *options_ptr = std::get_if<GameTextOptions>(&argument.value);
+                if (options_ptr != nullptr) {
+                    options = *options_ptr;
+                }
+                options |= option;
+                argument.value.emplace<GameTextOptions>(std::move(options));
+
+            } else {
+                result.id = ResultId::INVALID_OPTION_VALUE;
+            }
+            break;
+        }
+    }
+
+    static_assert(g_commandArgumentCount == 4, "CommandArgument is missing");
+
+    return result;
+}
+
+Processor::Result Processor::Add_New_Command(CommandPtrs &commands, FileMap &file_map, const CommandAction &action)
+{
+    Result result(ResultId::SUCCESS);
+
+    Populate_File_Map(file_map, action);
+
+    switch (action.action_id) {
+        case CommandActionId::LOAD_CSF:
+            result = Add_Load_CSF_Command(commands, file_map, action);
+            break;
+        case CommandActionId::LOAD_STR:
+            result = Add_Load_STR_Command(commands, file_map, action);
+            break;
+        case CommandActionId::LOAD_MULTI_STR:
+            result = Add_Load_Multi_STR_Command(commands, file_map, action);
+            break;
+        case CommandActionId::SAVE_CSF:
+            result = Add_Save_CSF_Command(commands, file_map, action);
+            break;
+        case CommandActionId::SAVE_STR:
+            result = Add_Save_STR_Command(commands, file_map, action);
+            break;
+        case CommandActionId::SAVE_MULTI_STR:
+            result = Add_Save_Multi_STR_Command(commands, file_map, action);
+            break;
+        case CommandActionId::UNLOAD:
+            result = Add_Unload_Command(commands, file_map, action);
+            break;
+        case CommandActionId::RESET:
+            result = Add_Reset_Command(commands, file_map, action);
+            break;
+        case CommandActionId::MERGE_AND_OVERWRITE:
+            result = Add_Merge_Command(commands, file_map, action);
+            break;
+        case CommandActionId::SET_OPTIONS:
+            result = Add_Set_Options_Command(commands, file_map, action);
+            break;
+        case CommandActionId::SET_LANGUAGE:
+            result = Add_Set_Language_Command(commands, file_map, action);
+            break;
+        case CommandActionId::SWAP_LANGUAGE_STRINGS:
+            result = Add_Swap_Language_Command(commands, file_map, action);
+            break;
+        case CommandActionId::SWAP_AND_SET_LANGUAGE:
+            result = Add_Swap_Set_Language_Command(commands, file_map, action);
+            break;
+    }
+
+    static_assert(g_commandActionCount == 13, "CommandAction is missing");
+
+    if (result.id == ResultId::SUCCESS) {
+        commands.back()->Set_Id(action.command_index);
+    }
+
+    return result;
+}
+
+Processor::Result Processor::Add_Load_CSF_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto file_path = Get_File_Path(action.arguments);
+
+    if (file_path == nullptr) {
+        return Result(ResultId::MISSING_FILE_PATH_ARGUMENT);
+    }
+
+    commands.emplace_back(new LoadCsfCommand(file_ptr, file_path));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Load_STR_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto file_path = Get_File_Path(action.arguments);
+
+    if (file_path == nullptr) {
+        return Result(ResultId::MISSING_FILE_PATH_ARGUMENT);
+    }
+
+    commands.emplace_back(new LoadStrCommand(file_ptr, file_path));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Load_Multi_STR_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto file_path = Get_File_Path(action.arguments);
+    const auto languages = Get_Languages(action.arguments);
+
+    if (file_path == nullptr) {
+        return Result(ResultId::MISSING_FILE_PATH_ARGUMENT);
+    }
+
+    if (languages.none()) {
+        return Result(ResultId::MISSING_LANGUAGE_ARGUMENT);
+    }
+
+    commands.emplace_back(new LoadMultiStrCommand(file_ptr, file_path, languages));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Save_CSF_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto file_path = Get_File_Path(action.arguments);
+
+    if (file_path == nullptr) {
+        return Result(ResultId::MISSING_FILE_PATH_ARGUMENT);
+    }
+
+    commands.emplace_back(new SaveCsfCommand(file_ptr, file_path));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Save_STR_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto file_path = Get_File_Path(action.arguments);
+
+    if (file_path == nullptr) {
+        return Result(ResultId::MISSING_FILE_PATH_ARGUMENT);
+    }
+
+    commands.emplace_back(new SaveStrCommand(file_ptr, file_path));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Save_Multi_STR_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto file_path = Get_File_Path(action.arguments);
+    const auto languages = Get_Languages(action.arguments);
+
+    if (file_path == nullptr) {
+        return Result(ResultId::MISSING_FILE_PATH_ARGUMENT);
+    }
+
+    if (languages.none()) {
+        return Result(ResultId::MISSING_LANGUAGE_ARGUMENT);
+    }
+
+    commands.emplace_back(new SaveMultiStrCommand(file_ptr, file_path, languages));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Unload_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto languages = Get_Languages(action.arguments);
+
+    commands.emplace_back(new UnloadCommand(file_ptr, languages));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Reset_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+
+    commands.emplace_back(new ResetCommand(file_ptr));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Merge_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr_a = Get_File_Ptr(action.arguments, file_map, 0);
+    const auto file_ptr_b = Get_File_Ptr(action.arguments, file_map, 1);
+    const auto languages = Get_Languages(action.arguments);
+
+    if (file_ptr_a == file_ptr_b) {
+        return Result(ResultId::INVALID_FILE_ID_ARGUMENT);
+    }
+
+    commands.emplace_back(new MergeAndOverwriteCommand(file_ptr_a, file_ptr_b, languages));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Set_Options_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto options = Get_Options(action.arguments);
+
+    commands.emplace_back(new SetOptionsCommand(file_ptr, options));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Set_Language_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto language = Get_Language(action.arguments);
+
+    if (language == LanguageID::UNKNOWN) {
+        return Result(ResultId::MISSING_LANGUAGE_ARGUMENT);
+    }
+
+    commands.emplace_back(new SetLanguageCommand(file_ptr, language));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Swap_Language_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto language_a = Get_Language(action.arguments, 0);
+    const auto language_b = Get_Language(action.arguments, 1);
+
+    if (language_a == LanguageID::UNKNOWN) {
+        return Result(ResultId::MISSING_LANGUAGE_ARGUMENT);
+    }
+    if (language_b == LanguageID::UNKNOWN) {
+        return Result(ResultId::MISSING_LANGUAGE_ARGUMENT);
+    }
+
+    commands.emplace_back(new SwapLanguageStringsCommand(file_ptr, language_a, language_b));
+    return Result(ResultId::SUCCESS);
+}
+
+Processor::Result Processor::Add_Swap_Set_Language_Command(
+    CommandPtrs &commands, const FileMap &file_map, const CommandAction &action)
+{
+    const auto file_ptr = Get_File_Ptr(action.arguments, file_map);
+    const auto language = Get_Language(action.arguments, 0);
+
+    if (language == LanguageID::UNKNOWN) {
+        return Result(ResultId::MISSING_LANGUAGE_ARGUMENT);
+    }
+
+    commands.emplace_back(new SwapAndSetLanguageCommand(file_ptr, language));
+    return Result(ResultId::SUCCESS);
+}
+
+void Processor::Populate_File_Map(FileMap &file_map, const CommandAction &action)
+{
+    const FileId *file_id_ptr = Find_Ptr<FileId>(action.arguments);
+    const FileId file_id = (file_id_ptr == nullptr) ? s_defaultFileId : *file_id_ptr;
+    Populate_File_Map(file_map, file_id);
+}
+
+void Processor::Populate_File_Map(FileMap &file_map, FileId file_id)
+{
+    const FileMap::iterator it = file_map.find(file_id);
+    if (it == file_map.end()) {
+        auto *file = new GameTextFile();
+        file->Set_Options(GameTextOptions::Value::NONE);
+        file_map.emplace(file_id, file);
+    }
+}
+
+GameTextFilePtr Processor::Get_File_Ptr(const FileMap &file_map, FileId file_id)
+{
+    const FileMap::const_iterator it = file_map.find(file_id);
+    captainslog_assert(it != file_map.end());
+    return it->second;
+}
+
+template<class Type> const Type *Processor::Find_Ptr(const CommandArguments &arguments, size_t occurence)
+{
+    size_t num = 0;
+    for (const CommandArgument &argument : arguments) {
+        const Type *type_ptr = std::get_if<Type>(&argument.value);
+        if (type_ptr != nullptr) {
+            if (occurence == num++) {
+                return type_ptr;
+            }
+        }
+    }
+    return nullptr;
+}
+
+GameTextFilePtr Processor::Get_File_Ptr(const CommandArguments &arguments, const FileMap &file_map, size_t occurence)
+{
+    const FileId *ptr = Find_Ptr<FileId>(arguments, occurence);
+    const FileId file_id = (ptr == nullptr) ? s_defaultFileId : *ptr;
+    return Get_File_Ptr(file_map, file_id);
+}
+
+const char *Processor::Get_File_Path(const CommandArguments &arguments, size_t occurence)
+{
+    const FilePath *ptr = Find_Ptr<FilePath>(arguments, occurence);
+    return (ptr == nullptr) ? nullptr : ptr->value.c_str();
+}
+
+Languages Processor::Get_Languages(const CommandArguments &arguments, size_t occurence)
+{
+    const Languages *ptr = Find_Ptr<Languages>(arguments, occurence);
+    return (ptr == nullptr) ? Languages() : *ptr;
+}
+
+LanguageID Processor::Get_Language(const CommandArguments &arguments, size_t occurence)
+{
+    LanguageID language = LanguageID::UNKNOWN;
+    const Languages *ptr = Find_Ptr<Languages>(arguments, occurence);
+    if (ptr != nullptr) {
+        ptr->get(language, 0);
+    }
+    return language;
+}
+
+GameTextOptions Processor::Get_Options(const CommandArguments &arguments, size_t occurence)
+{
+    const GameTextOptions *ptr = Find_Ptr<GameTextOptions>(arguments, occurence);
+    return (ptr == nullptr) ? GameTextOptions() : *ptr;
+}
+
+} // namespace Thyme

--- a/src/tools/gametextcompiler/src/processor.h
+++ b/src/tools/gametextcompiler/src/processor.h
@@ -1,0 +1,162 @@
+/**
+ * @file
+ *
+ * @author xezon
+ *
+ * @brief Game Text Compiler Processor. (Thyme Feature)
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "commands.h"
+#include <array>
+#include <unordered_map>
+#include <utility/arrayview.h>
+#include <variant>
+#include <vector>
+
+namespace Thyme
+{
+class Processor
+{
+public:
+    enum class ResultId
+    {
+        SUCCESS,
+        INVALID_COMMAND_ACTION,
+        INVALID_COMMAND_ARGUMENT,
+        INVALID_LANGUAGE_VALUE,
+        INVALID_OPTION_VALUE,
+        INVALID_FILE_ID_ARGUMENT,
+        MISSING_FILE_PATH_ARGUMENT,
+        MISSING_LANGUAGE_ARGUMENT,
+        EXECUTION_ERROR,
+
+        // #TODO Add more detailed execution errors once GameTextFile supports it
+
+        COUNT
+    };
+
+    static const char *Get_Result_Name(ResultId id);
+
+    using ErrorText = rts::array_view<const char>;
+    using CommandTexts = rts::array_view<const char *>;
+
+    struct Result
+    {
+        explicit Result(ResultId id) : id(id), error_command_index(0), error_text() {}
+
+        ResultId id;
+        size_t error_command_index;
+        ErrorText error_text;
+    };
+
+public:
+    Processor();
+
+    Result Parse_Commands(const CommandTexts &command_texts);
+    Result Execute_Commands() const;
+
+private:
+    using CommandPtr = std::shared_ptr<Command>;
+    using CommandPtrs = std::vector<CommandPtr>;
+
+    struct FileId
+    {
+        bool operator==(const FileId &other) const { return value == other.value; }
+        int value;
+    };
+
+    struct FileIdHash
+    {
+        std::size_t operator()(const FileId &key) const { return std::hash<int>{}(key.value); }
+    };
+
+    using FileMap = std::unordered_map<FileId, GameTextFilePtr, FileIdHash>;
+
+    struct FilePath
+    {
+        std::string value;
+    };
+
+    struct CommandArgument
+    {
+        std::variant<FileId, FilePath, Languages, GameTextOptions> value;
+    };
+
+    using CommandArguments = std::vector<CommandArgument>;
+
+    struct CommandAction
+    {
+        CommandActionId action_id = CommandActionId::INVALID;
+        CommandArguments arguments;
+        size_t command_index = 0;
+    };
+
+    enum class SequenceId
+    {
+        INVALID = -1,
+        SET_OPTIONS,
+        LOAD,
+        SWAP_AND_SET_LANGUAGE,
+        SAVE,
+
+        COUNT
+    };
+
+    using CommandActionSequence = std::array<CommandAction, size_t(SequenceId::COUNT)>;
+
+private:
+    Result Parse_Function_Commands(const CommandTexts &command_texts);
+    Result Parse_Simple_Commands(const CommandTexts &command_texts);
+
+    static bool Has_Simple_Command(const CommandTexts &command_texts);
+    static bool Is_Simple_Command(const char *command_text);
+
+    template<size_t Size> bool static Parse_Next_Word(std::string &word, const char *&str, const char (&separators)[Size]);
+
+    static Result Parse_Function_Command(CommandAction &action, const char *command_text, size_t command_index);
+    static Result Parse_Simple_Command(
+        CommandActionSequence &actions, const char *command_name, const char *command_value, size_t command_index);
+    static Result Parse_Command_Argument(CommandArgument &argument, std::string &str, CommandArgumentId argument_id);
+
+    static Result Add_New_Command(CommandPtrs &commands, FileMap &file_map, const CommandAction &action);
+    static Result Add_Load_CSF_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Load_STR_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Load_Multi_STR_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Save_CSF_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Save_STR_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Save_Multi_STR_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Unload_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Reset_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Merge_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Set_Options_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Set_Language_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Swap_Language_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+    static Result Add_Swap_Set_Language_Command(CommandPtrs &commands, const FileMap &file_map, const CommandAction &action);
+
+    static void Populate_File_Map(FileMap &file_map, const CommandAction &action);
+    static void Populate_File_Map(FileMap &file_map, FileId file_id);
+    static GameTextFilePtr Get_File_Ptr(const FileMap &file_map, FileId file_id);
+
+    template<class Type> static const Type *Find_Ptr(const CommandArguments &arguments, size_t occurence = 0);
+    static GameTextFilePtr Get_File_Ptr(const CommandArguments &arguments, const FileMap &file_map, size_t occurence = 0);
+    static const char *Get_File_Path(const CommandArguments &arguments, size_t occurence = 0);
+    static Languages Get_Languages(const CommandArguments &arguments, size_t occurence = 0);
+    static LanguageID Get_Language(const CommandArguments &arguments, size_t occurence = 0);
+    static GameTextOptions Get_Options(const CommandArguments &arguments, size_t occurence = 0);
+
+private:
+    FileMap m_fileMap;
+    CommandPtrs m_commands;
+
+    static const FileId s_defaultFileId;
+};
+
+} // namespace Thyme


### PR DESCRIPTION
I setup 5 separate commits to organize this change better.

The new utility classes and function are used in the new feature code. Some of the functionality is redundant to c++11 to c++20 library features, but due the existence of STL Port had to be implemented for Thyme.

The `FileRef` class is an optional wrapper for `File*` to allow using game files more comfortably without worrying about leaks.

The `GameTextFile` class contains all new code to read and write CSF, STR and Multi STR files. Read result is identical to original implementation for the most part, but can also read UTF8 STR, which the original cannot. Performance likely is much better, mainly because of using new Buffered File IO. Read and Write have been designed with performance in mind.

The `GameTextManager` class is an alternative implementation to the legacy `GameTextManager` class using the new `GameTextFile`. It provides the same functionality as the original, and a bit more sugar on top. Memory footprint is a little smaller than original, due absence of buffers as class members.

The `gametextcompiler` supports simple command line aka `-LOAD_STR generals.csf` but also more powerful function like syntax which can perform more complex operations.

### New Utilities Overview ###

**rts::array<>** : Wants to be the same as `std::array` (c++11). Does suffer from non-constexpr `std::reverse_iterator` due STL Port.

**rts::array_view<>** : Wants to be the same as `std::span` (c++20). Does suffer from non-constexpr `std::reverse_iterator` due STL Port. Constructors are not quite the same as `std::span`.

**rts array util functions** : Functions to build `rts::array_view<>`. Has custom functions catered to `Utf8String` and `Utf16String`. **Has no STL equivalent as far as I know.**

**rts::ebitflags<>** : Capsulates enum or enum class with bit values into object with some functionality for bit operations. **Has no equivalent in STL.**

**rts::enumflags<>** : Capsulates enum or enum class with incremental values into object with some functionality for bit operations. `std::bitset` is similar, but is not catered to `enum` types, so they cannot be used interchangeably. **Has no equivalent in STL.**

**rts::enumerator<>** : Capsulates `enum` or `enum class` with incremental values into object with some functionality for enumeration operations. **Has no equivalent in STL.**

**rts file utility functions** : Provides some helper functions to read and write data with game files. **Has no equivalent in STL.**

**rts::intrusive_ptr<>** : Wraps any reference counted object and provides strong guarantee that the contained object will be deleted when all references are destroyed. Is compatible with DirectX classes. **Has no equivalent in STL.**

**rts:shared_ptr<>** : Wraps any heap allocated object and provides strong guarantee that the contained object will be deleted when all references are destroyed. Is similar to `std::shared_ptr<>`, though not quite as sophisticated. E.g. it does not support automatic `delete[]` when an array pointer was assigned. Array deleter has to be explicitly set when needed. Also locality of the allocated reference counter is not optimal in `rts::shared_ptr<>`. As far as I know in `std::shared_ptr<>` it somehow allocates reference counter close to object when using `std::make_shared<>`. `rts:shared_ptr<>` does allow for non-atomic reference counter. In any case, user code of `rts::shared_ptr<>` could be swapped for `std::shared_ptr<>`.

**rts ref counter** : has functions and classes that implement atomic and non-atomic reference counters. They are fit to be used with `rts::intrusive_ptr<>` and `rts::shared_ptr<>`. **Has no equivalent in STL.**

**rts atomicop functions** : Interlocked functions for atomic integer operations. Is used due the absence of `std::atomic` in STL Port.

**deleter functions** : Deleters for smart pointers. **Has no equivalent in STL.**

**rts::sized integer classes** : Will be removed once this code is in typesize.h. See: #484

**rts util functions** : Just some helper functions for STL. **Has no equivalent in STL.**