### PR TITLE
Refactor matrix math to be closer to what the assembler does

### DIFF
--- a/src/w3d/math/gamemath.h
+++ b/src/w3d/math/gamemath.h
@@ -56,6 +56,8 @@
 #define DEG_TO_RADF(x) (((float)x) * GAMEMATH_PI / 180.0f)
 #endif
 
+#define TWICE(x) ((x) + (x))
+
 const int ARC_TABLE_SIZE = 1024;
 const int SIN_TABLE_SIZE = 1024;
 

--- a/src/w3d/math/matrix3.cpp
+++ b/src/w3d/math/matrix3.cpp
@@ -48,15 +48,15 @@ void Matrix3::Set(const Matrix4 &m)
 
 void Matrix3::Set(const Quaternion &q)
 {
-    Row[0][0] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[2] * q[2]));
-    Row[0][1] = (float)(2.0 * (q[0] * q[1] - q[2] * q[3]));
-    Row[0][2] = (float)(2.0 * (q[2] * q[0] + q[1] * q[3]));
-    Row[1][0] = (float)(2.0 * (q[0] * q[1] + q[2] * q[3]));
-    Row[1][1] = (float)(1.0 - 2.0f * (q[2] * q[2] + q[0] * q[0]));
-    Row[1][2] = (float)(2.0 * (q[1] * q[2] - q[0] * q[3]));
-    Row[2][0] = (float)(2.0 * (q[2] * q[0] - q[1] * q[3]));
-    Row[2][1] = (float)(2.0 * (q[1] * q[2] + q[0] * q[3]));
-    Row[2][2] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[0] * q[0]));
+    Row[0][0] = (float)(1.0 - TWICE(q[1] * q[1] + q[2] * q[2]));
+    Row[0][1] = (float)(TWICE(q[0] * q[1] - q[2] * q[3]));
+    Row[0][2] = (float)(TWICE(q[2] * q[0] + q[1] * q[3]));
+    Row[1][0] = (float)(TWICE(q[0] * q[1] + q[2] * q[3]));
+    Row[1][1] = (float)(1.0 - TWICE(q[2] * q[2] + q[0] * q[0]));
+    Row[1][2] = (float)(TWICE(q[1] * q[2] - q[0] * q[3]));
+    Row[2][0] = (float)(TWICE(q[2] * q[0] - q[1] * q[3]));
+    Row[2][1] = (float)(TWICE(q[1] * q[2] + q[0] * q[3]));
+    Row[2][2] = (float)(1.0 - TWICE(q[1] * q[1] + q[0] * q[0]));
 }
 
 Matrix3 &Matrix3::operator=(const Matrix3D &m)

--- a/src/w3d/math/matrix3d.cpp
+++ b/src/w3d/math/matrix3d.cpp
@@ -193,15 +193,15 @@ Vector3 Matrix3D::Inverse_Rotate_Vector(const Vector3 &vect) const
 
 void Matrix3D::Set_Rotation(const Quaternion &q)
 {
-    Row[0][0] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[2] * q[2]));
-    Row[0][1] = (float)(2.0 * (q[0] * q[1] - q[2] * q[3]));
-    Row[0][2] = (float)(2.0 * (q[2] * q[0] + q[1] * q[3]));
-    Row[1][0] = (float)(2.0 * (q[0] * q[1] + q[2] * q[3]));
-    Row[1][1] = (float)(1.0 - 2.0f * (q[2] * q[2] + q[0] * q[0]));
-    Row[1][2] = (float)(2.0 * (q[1] * q[2] - q[0] * q[3]));
-    Row[2][0] = (float)(2.0 * (q[2] * q[0] - q[1] * q[3]));
-    Row[2][1] = (float)(2.0 * (q[1] * q[2] + q[0] * q[3]));
-    Row[2][2] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[0] * q[0]));
+    Row[0][0] = (float)(1.0 - TWICE(q[1] * q[1] + q[2] * q[2]));
+    Row[0][1] = (float)(TWICE(q[0] * q[1] - q[2] * q[3]));
+    Row[0][2] = (float)(TWICE(q[2] * q[0] + q[1] * q[3]));
+    Row[1][0] = (float)(TWICE(q[0] * q[1] + q[2] * q[3]));
+    Row[1][1] = (float)(1.0 - TWICE(q[2] * q[2] + q[0] * q[0]));
+    Row[1][2] = (float)(TWICE(q[1] * q[2] - q[0] * q[3]));
+    Row[2][0] = (float)(TWICE(q[2] * q[0] - q[1] * q[3]));
+    Row[2][1] = (float)(TWICE(q[1] * q[2] + q[0] * q[3]));
+    Row[2][2] = (float)(1.0 - TWICE(q[1] * q[1] + q[0] * q[0]));
 }
 
 void Matrix3D::Set_Rotation(const Matrix3 &m)

--- a/src/w3d/math/quaternion.cpp
+++ b/src/w3d/math/quaternion.cpp
@@ -463,17 +463,17 @@ Matrix3 Build_Matrix3(const Quaternion &q)
 {
     Matrix3 m;
 
-    m[0][0] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[2] * q[2]));
-    m[0][1] = (float)(2.0 * (q[0] * q[1] - q[2] * q[3]));
-    m[0][2] = (float)(2.0 * (q[2] * q[0] + q[1] * q[3]));
+    m[0][0] = (float)(1.0 - TWICE(q[1] * q[1] + q[2] * q[2]));
+    m[0][1] = (float)(TWICE(q[0] * q[1] - q[2] * q[3]));
+    m[0][2] = (float)(TWICE(q[2] * q[0] + q[1] * q[3]));
 
-    m[1][0] = (float)(2.0 * (q[0] * q[1] + q[2] * q[3]));
-    m[1][1] = (float)(1.0 - 2.0f * (q[2] * q[2] + q[0] * q[0]));
-    m[1][2] = (float)(2.0 * (q[1] * q[2] - q[0] * q[3]));
+    m[1][0] = (float)(TWICE(q[0] * q[1] + q[2] * q[3]));
+    m[1][1] = (float)(1.0 - TWICE(q[2] * q[2] + q[0] * q[0]));
+    m[1][2] = (float)(TWICE(q[1] * q[2] - q[0] * q[3]));
 
-    m[2][0] = (float)(2.0 * (q[2] * q[0] - q[1] * q[3]));
-    m[2][1] = (float)(2.0 * (q[1] * q[2] + q[0] * q[3]));
-    m[2][2] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[0] * q[0]));
+    m[2][0] = (float)(TWICE(q[2] * q[0] - q[1] * q[3]));
+    m[2][1] = (float)(TWICE(q[1] * q[2] + q[0] * q[3]));
+    m[2][2] = (float)(1.0 - TWICE(q[1] * q[1] + q[0] * q[0]));
 
     return m;
 }
@@ -483,17 +483,17 @@ Matrix3D Build_Matrix3D(const Quaternion &q)
     Matrix3D m;
 
     // initialize the rotation sub-matrix
-    m[0][0] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[2] * q[2]));
-    m[0][1] = (float)(2.0 * (q[0] * q[1] - q[2] * q[3]));
-    m[0][2] = (float)(2.0 * (q[2] * q[0] + q[1] * q[3]));
+    m[0][0] = (float)(1.0 - TWICE(q[1] * q[1] + q[2] * q[2]));
+    m[0][1] = (float)(TWICE(q[0] * q[1] - q[2] * q[3]));
+    m[0][2] = (float)(TWICE(q[2] * q[0] + q[1] * q[3]));
 
-    m[1][0] = (float)(2.0 * (q[0] * q[1] + q[2] * q[3]));
-    m[1][1] = (float)(1.0 - 2.0f * (q[2] * q[2] + q[0] * q[0]));
-    m[1][2] = (float)(2.0 * (q[1] * q[2] - q[0] * q[3]));
+    m[1][0] = (float)(TWICE(q[0] * q[1] + q[2] * q[3]));
+    m[1][1] = (float)(1.0 - TWICE(q[2] * q[2] + q[0] * q[0]));
+    m[1][2] = (float)(TWICE(q[1] * q[2] - q[0] * q[3]));
 
-    m[2][0] = (float)(2.0 * (q[2] * q[0] - q[1] * q[3]));
-    m[2][1] = (float)(2.0 * (q[1] * q[2] + q[0] * q[3]));
-    m[2][2] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[0] * q[0]));
+    m[2][0] = (float)(TWICE(q[2] * q[0] - q[1] * q[3]));
+    m[2][1] = (float)(TWICE(q[1] * q[2] + q[0] * q[3]));
+    m[2][2] = (float)(1.0 - TWICE(q[1] * q[1] + q[0] * q[0]));
 
     // no translation
     m[0][3] = m[1][3] = m[2][3] = 0.0f;
@@ -506,17 +506,17 @@ Matrix4 Build_Matrix4(const Quaternion &q)
     Matrix4 m;
 
     // initialize the rotation sub-matrix
-    m[0][0] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[2] * q[2]));
-    m[0][1] = (float)(2.0 * (q[0] * q[1] - q[2] * q[3]));
-    m[0][2] = (float)(2.0 * (q[2] * q[0] + q[1] * q[3]));
+    m[0][0] = (float)(1.0 - TWICE(q[1] * q[1] + q[2] * q[2]));
+    m[0][1] = (float)(TWICE(q[0] * q[1] - q[2] * q[3]));
+    m[0][2] = (float)(TWICE(q[2] * q[0] + q[1] * q[3]));
 
-    m[1][0] = (float)(2.0 * (q[0] * q[1] + q[2] * q[3]));
-    m[1][1] = (float)(1.0 - 2.0f * (q[2] * q[2] + q[0] * q[0]));
-    m[1][2] = (float)(2.0 * (q[1] * q[2] - q[0] * q[3]));
+    m[1][0] = (float)(TWICE(q[0] * q[1] + q[2] * q[3]));
+    m[1][1] = (float)(1.0 - TWICE(q[2] * q[2] + q[0] * q[0]));
+    m[1][2] = (float)(TWICE(q[1] * q[2] - q[0] * q[3]));
 
-    m[2][0] = (float)(2.0 * (q[2] * q[0] - q[1] * q[3]));
-    m[2][1] = (float)(2.0 * (q[1] * q[2] + q[0] * q[3]));
-    m[2][2] = (float)(1.0 - 2.0 * (q[1] * q[1] + q[0] * q[0]));
+    m[2][0] = (float)(TWICE(q[2] * q[0] - q[1] * q[3]));
+    m[2][1] = (float)(TWICE(q[1] * q[2] + q[0] * q[3]));
+    m[2][2] = (float)(1.0 - TWICE(q[1] * q[1] + q[0] * q[0]));
 
     // no translation
     m[0][3] = m[1][3] = m[2][3] = 0.0f;


### PR DESCRIPTION
In assembler, it does not multiply value by 2, but adds it to become twice. I tested if there is any difference between 2.0f * x and x + x, but there appeared no difference in the calculated results. Anyway, I thought it can't hurt to write it the way it is calculated in assembler for best representation of calculation.