### PR TITLE
Add placement new operators to IMPLEMENT_NAMED_POOL macro

### DIFF
--- a/src/game/client/anim2d.h
+++ b/src/game/client/anim2d.h
@@ -79,9 +79,6 @@ class Anim2D : public MemoryPoolObject, public SnapShot
         STATUS_ANIM_COMPLETE = 4,
     };
 
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
-
 public:
     Anim2D(Anim2DTemplate *tmplate, Anim2DCollection *collection);
     virtual ~Anim2D() override;

--- a/src/game/client/draw/w3dmodeldraw.h
+++ b/src/game/client/draw/w3dmodeldraw.h
@@ -261,9 +261,6 @@ class W3DModelDraw : public DrawModule, public ObjectDrawInterface
 {
     IMPLEMENT_POOL(W3DModelDraw);
 
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
-
 public:
     struct RecoilInfo
     {

--- a/src/game/client/image.h
+++ b/src/game/client/image.h
@@ -28,9 +28,6 @@ class Image : public MemoryPoolObject
 {
     IMPLEMENT_POOL(Image);
 
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
-
 protected:
     virtual ~Image() override;
 

--- a/src/game/client/system/particlesystem/particle.h
+++ b/src/game/client/system/particlesystem/particle.h
@@ -27,9 +27,6 @@ class Particle : public MemoryPoolObject, public ParticleInfo
     friend class ParticleSystem;
     friend class ParticleSystemManager;
 
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
-
 protected:
     virtual ~Particle() override;
 

--- a/src/game/client/system/particlesystem/particlesys.h
+++ b/src/game/client/system/particlesystem/particlesys.h
@@ -32,9 +32,6 @@ class ParticleSystem : public MemoryPoolObject, public ParticleSystemInfo
     IMPLEMENT_NAMED_POOL(ParticleSystem, ParticleSystemPool);
     friend class ParticleSystemManager;
 
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
-
 protected:
     virtual ~ParticleSystem() override;
 

--- a/src/game/common/audio/audioeventinfo.h
+++ b/src/game/common/audio/audioeventinfo.h
@@ -131,9 +131,6 @@ class DynamicAudioEventInfo : public AudioEventInfo
 {
     IMPLEMENT_POOL(DynamicAudioEventInfo);
 
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
-
 public:
     enum OverriddenFields
     {

--- a/src/game/common/mapobject.h
+++ b/src/game/common/mapobject.h
@@ -41,9 +41,6 @@ class MapObject : public MemoryPoolObject
 {
     IMPLEMENT_POOL(MapObject)
 
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
-
 protected:
     virtual ~MapObject() override;
 

--- a/src/game/common/statemachine.h
+++ b/src/game/common/statemachine.h
@@ -126,10 +126,7 @@ private:
 
 class StateMachine : public MemoryPoolObject, public SnapShot
 {
-    IMPLEMENT_ABSTRACT_POOL(StateMachine);
-
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
+    IMPLEMENT_POOL(StateMachine);
 
 public:
 #ifdef GAME_DLL

--- a/src/game/logic/object/update/swayclientupdate.h
+++ b/src/game/logic/object/update/swayclientupdate.h
@@ -50,10 +50,6 @@ private:
     void Stop_Sway();
 
 #ifdef GAME_DLL
-private:
-    void *operator new(size_t size, void *where) { return where; }
-    void operator delete(void *ptr, void *where) {}
-
 public:
     SwayClientUpdate *Hook_Ctor(Thing *thing, const ModuleData *module_data)
     {

--- a/src/game/network/gamemessageparser.h
+++ b/src/game/network/gamemessageparser.h
@@ -41,9 +41,6 @@ class GameMessageParser : public MemoryPoolObject
 {
     IMPLEMENT_POOL(GameMessageParser);
 
-    void *operator new(size_t size, void *dst) { return dst; }
-    void operator delete(void *p, void *q) {}
-
 protected:
     virtual ~GameMessageParser() override;
 

--- a/src/w3d/lib/w3dmpo.h
+++ b/src/w3d/lib/w3dmpo.h
@@ -45,8 +45,8 @@ private: \
 \
 public: \
     void *operator new(size_t size) { return Allocate_From_Pool(Get_Class_Pool(), sizeof(classname)); } \
-    void *operator new(size_t size, void *dst) { return dst; } \
-    void operator delete(void *p, void *q) {} \
+    void *operator new(size_t size, void *where) { return where; } \
+    void operator delete(void *p, void *where) {} \
     void operator delete(void *ptr) { return Free_From_Pool(Get_Class_Pool(), ptr); } \
     virtual int glueEnforcer() { return 4; }; \
 \


### PR DESCRIPTION
As discussed internally, placement new operator can be added to the pool macro, because it is cause of the pool that they are required to begin with.