### PR TITLE
Fix unsafe string operation in DDSFileClass and ThumbnailClass

### DIFF
--- a/src/w3d/lib/wwstring.h
+++ b/src/w3d/lib/wwstring.h
@@ -58,6 +58,7 @@ public:
 
     int Compare(const char *string) const { return strcmp(m_buffer, string); }
     int Compare_No_Case(const char *string) const { return strcasecmp(m_buffer, string); }
+    int Get_Allocated_Length() const;
     int Get_Length() const;
     bool Is_Empty() const { return (m_buffer[0] == m_nullChar); }
     void Erase(int start_index, int char_count);
@@ -99,7 +100,6 @@ private:
     void Store_Length(int length);
     void Store_Allocated_Length(int allocated_length);
     HEADER *Get_Header() const;
-    int Get_Allocated_Length() const;
     void Set_Buffer_And_Allocated_Length(char *buffer, size_t length);
 
     char *m_buffer;

--- a/src/w3d/renderer/ddsfile.cpp
+++ b/src/w3d/renderer/ddsfile.cpp
@@ -44,11 +44,11 @@ DDSFileClass::DDSFileClass(const char *filename, unsigned reduction_factor) :
     m_totalSizeMaybe(0)
 {
     // Copy the name across and replace the extension with dds.
-    strlcpy_tpl(m_name, filename);
+    const size_t name_len = strlcpy_tpl(m_name, filename);
 
     // #BUGFIX Change texture extension safely.
     // Originally code would just write over name length -3 bytes without any checking.
-    Thyme::Change_Texture_File_Extension(m_name, "dds");
+    Thyme::Change_Texture_File_Extension(m_name, name_len, "dds");
 
     auto_file_ptr fp(g_theFileFactory, m_name);
 
@@ -639,12 +639,13 @@ unsigned DDSFileClass::Calculate_S3TC_Surface_Size(unsigned width, unsigned heig
 
 namespace Thyme
 {
-void Change_Texture_File_Extension(char *str, size_t str_capacity, const char *new_ext)
+void Change_Texture_File_Extension(char *str, size_t str_len, size_t str_capacity, const char *new_ext)
 {
-    const size_t len = strlen(str);
+    captainslog_dbgassert(str_len < str_capacity, "String length is expected to be smaller than string capacity");
+
     char *begin = str;
     char *end = str + str_capacity - 1u;
-    char *ext = str + len;
+    char *ext = str + str_len;
 
     while (--ext != begin) {
         char ch = *ext;
@@ -655,7 +656,7 @@ void Change_Texture_File_Extension(char *str, size_t str_capacity, const char *n
         }
         if (ch == ':' || ch == '/' || ch == '\\') {
             // No file extension found.
-            ext = begin + len;
+            ext = begin + str_len;
             if (ext != end) {
                 *ext++ = '.';
             }
@@ -665,7 +666,7 @@ void Change_Texture_File_Extension(char *str, size_t str_capacity, const char *n
 
     if (ext == begin) {
         // No file extension found.
-        ext = begin + len;
+        ext = begin + str_len;
         if (ext != end) {
             *ext++ = '.';
         }

--- a/src/w3d/renderer/ddsfile.h
+++ b/src/w3d/renderer/ddsfile.h
@@ -182,3 +182,13 @@ inline uint32_t DDSFileClass::Decode_Line_Code(uint8_t *packed)
 {
     return uint32_t(packed[0]) | (uint32_t(packed[1]) << 8) | (uint32_t(packed[2]) << 16) | (uint32_t(packed[3]) << 24);
 }
+
+namespace Thyme
+{
+void Change_Texture_File_Extension(char *str, size_t str_capacity, const char *new_ext);
+
+template<size_t StrCapacity> inline void Change_Texture_File_Extension(char (&str)[StrCapacity], const char *new_ext)
+{
+    Change_Texture_File_Extension(str, StrCapacity, new_ext);
+}
+} // namespace Thyme

--- a/src/w3d/renderer/ddsfile.h
+++ b/src/w3d/renderer/ddsfile.h
@@ -185,10 +185,11 @@ inline uint32_t DDSFileClass::Decode_Line_Code(uint8_t *packed)
 
 namespace Thyme
 {
-void Change_Texture_File_Extension(char *str, size_t str_capacity, const char *new_ext);
+void Change_Texture_File_Extension(char *str, size_t str_len, size_t str_capacity, const char *new_ext);
 
-template<size_t StrCapacity> inline void Change_Texture_File_Extension(char (&str)[StrCapacity], const char *new_ext)
+template<size_t StrCapacity>
+inline void Change_Texture_File_Extension(char (&str)[StrCapacity], size_t str_len, const char *new_ext)
 {
-    Change_Texture_File_Extension(str, StrCapacity, new_ext);
+    Change_Texture_File_Extension(str, str_len, StrCapacity, new_ext);
 }
 } // namespace Thyme

--- a/src/w3d/renderer/thumbnail.cpp
+++ b/src/w3d/renderer/thumbnail.cpp
@@ -72,7 +72,8 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass *manager, const StringClass
 
         // #BUGFIX Change texture extension safely.
         // Originally code would just write over name length -3 bytes without any checking.
-        Thyme::Change_Texture_File_Extension(m_filename.Peek_Buffer(), m_filename.Get_Allocated_Length(), "dds");
+        Thyme::Change_Texture_File_Extension(
+            m_filename.Peek_Buffer(), m_filename.Get_Length(), m_filename.Get_Allocated_Length(), "dds");
 
         unsigned levels = 0;
         while (levels < mips - 1 && (dds.Get_Width(levels) > 32 || dds.Get_Height(levels) > 32)) {
@@ -145,7 +146,8 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass *manager, const StringClass
 
             // #BUGFIX Change texture extension safely.
             // Originally code would just write over name length -3 bytes without any checking.
-            Thyme::Change_Texture_File_Extension(m_filename.Peek_Buffer(), m_filename.Get_Allocated_Length(), "tga");
+            Thyme::Change_Texture_File_Extension(
+                m_filename.Peek_Buffer(), m_filename.Get_Length(), m_filename.Get_Allocated_Length(), "tga");
 
             m_bitmap = new uint8_t[2 * m_width * m_height];
             m_isAllocated = true;

--- a/src/w3d/renderer/thumbnail.cpp
+++ b/src/w3d/renderer/thumbnail.cpp
@@ -69,10 +69,10 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass *manager, const StringClass
     // Try loading a dds version of a texture first, then fall back to looking for targa.
     if (mips != 0 && dds.Load()) {
         m_time = dds.Get_Time();
-        int len = m_filename.Get_Length();
-        m_filename[len - 3] = 'd';
-        m_filename[len - 2] = 'd';
-        m_filename[len - 1] = 's';
+
+        // #BUGFIX Change texture extension safely.
+        // Originally code would just write over name length -3 bytes without any checking.
+        Thyme::Change_Texture_File_Extension(m_filename.Peek_Buffer(), m_filename.Get_Allocated_Length(), "dds");
 
         unsigned levels = 0;
         while (levels < mips - 1 && (dds.Get_Width(levels) > 32 || dds.Get_Height(levels) > 32)) {
@@ -143,10 +143,10 @@ ThumbnailClass::ThumbnailClass(ThumbnailManagerClass *manager, const StringClass
                 ptr->Close();
             }
 
-            int len = m_filename.Get_Length();
-            m_filename[len - 3] = 't';
-            m_filename[len - 2] = 'g';
-            m_filename[len - 1] = 'a';
+            // #BUGFIX Change texture extension safely.
+            // Originally code would just write over name length -3 bytes without any checking.
+            Thyme::Change_Texture_File_Extension(m_filename.Peek_Buffer(), m_filename.Get_Allocated_Length(), "tga");
+
             m_bitmap = new uint8_t[2 * m_width * m_height];
             m_isAllocated = true;
 


### PR DESCRIPTION
As I was looking through code I saw this unsafe memory operation. The way it wants to write file extension is unsafe and will corrupt memory if file name is shorter than 3 characters. Or destroy file name if file extension is not set.

I placed proper function that can react to file names and then perform appropriate action. I put breakpoint at `// No file extension found.` and checked if hit, but it was not in my tests, which is good.