### PR TITLE
Remove Vector3 C casts

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -327,6 +327,7 @@ set(GAMEENGINE_SRC
     w3d/math/quaternion.cpp
     w3d/math/tri.cpp
     w3d/math/v3_rnd.cpp
+    w3d/math/vector4.cpp
     w3d/math/vp.cpp
     w3d/renderer/animobj.cpp
     w3d/renderer/aabtree.cpp

--- a/src/w3d/math/tri.h
+++ b/src/w3d/math/tri.h
@@ -178,7 +178,7 @@ inline bool Cast_Semi_Infinite_Axis_Aligned_Ray_To_Triangle(const Vector3 &tri_p
                     tri.V[0] = &tri_point0;
                     tri.V[1] = &tri_point1;
                     tri.V[2] = &tri_point2;
-                    tri.N = (Vector3 *)&tri_plane;
+                    tri.N = Thyme::To_Vector3_Ptr(&tri_plane);
 
                     if (tri.Contains_Point(ray_start)) {
                         flags |= TRI_RAYCAST_FLAG_START_IN_TRI;

--- a/src/w3d/math/vector4.cpp
+++ b/src/w3d/math/vector4.cpp
@@ -1,0 +1,23 @@
+/**
+ * @file
+ *
+ * @author Tiberian Technologies
+ * @author OmniBlade
+ *
+ * @brief 4D Vector class.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#include "vector4.h"
+
+#include "vector3.h"
+
+static_assert(offsetof(Vector4, X) == offsetof(Vector3, X), "Must match if Vector pointers are meant to be compatible");
+static_assert(offsetof(Vector4, Y) == offsetof(Vector3, Y), "Must match if Vector pointers are meant to be compatible");
+static_assert(offsetof(Vector4, Z) == offsetof(Vector3, Z), "Must match if Vector pointers are meant to be compatible");
+static_assert(sizeof(Vector3) == 12, "Must match if Vector pointers are meant to be compatible");

--- a/src/w3d/math/vector4.h
+++ b/src/w3d/math/vector4.h
@@ -236,3 +236,20 @@ __forceinline Vector4 Lerp(const Vector4 &a, const Vector4 &b, float alpha)
     return Vector4(
         (a.X + (b.X - a.X) * alpha), (a.Y + (b.Y - a.Y) * alpha), (a.Z + (b.Z - a.Z) * alpha), (a.W + (b.W - a.W) * alpha));
 }
+
+class Vector3;
+
+namespace Thyme
+{
+// Casting from Vector4 pointer to Vector3 pointer is considered safe.
+
+inline const Vector3 *To_Vector3_Ptr(const Vector4 *vector)
+{
+    return reinterpret_cast<const Vector3 *>(vector);
+}
+
+inline Vector3 *To_Vector3_Ptr(Vector4 *vector)
+{
+    return reinterpret_cast<Vector3 *>(vector);
+}
+} // namespace Thyme

--- a/src/w3d/renderer/meshgeometry.cpp
+++ b/src/w3d/renderer/meshgeometry.cpp
@@ -313,7 +313,7 @@ void MeshGeometryClass::Generate_Rigid_APT(const Vector3 &view_dir, SimpleDynVec
         tri.V[0] = &(loc[polys[poly_counter][0]]);
         tri.V[1] = &(loc[polys[poly_counter][1]]);
         tri.V[2] = &(loc[polys[poly_counter][2]]);
-        tri.N = (Vector3 *)&(norms[poly_counter]);
+        tri.N = Thyme::To_Vector3_Ptr(&(norms[poly_counter]));
 
         if (Vector3::Dot_Product(*tri.N, view_dir) < 0.0f) {
             apt.Add(poly_counter);
@@ -335,7 +335,7 @@ void MeshGeometryClass::Generate_Rigid_APT(const OBBoxClass &local_box, SimpleDy
             tri.V[0] = &(loc[polys[poly_counter][0]]);
             tri.V[1] = &(loc[polys[poly_counter][1]]);
             tri.V[2] = &(loc[polys[poly_counter][2]]);
-            tri.N = (Vector3 *)&(norms[poly_counter]);
+            tri.N = Thyme::To_Vector3_Ptr(&(norms[poly_counter]));
 
             if (CollisionMath::Intersection_Test(local_box, tri)) {
                 apt.Add(poly_counter);
@@ -359,7 +359,7 @@ void MeshGeometryClass::Generate_Rigid_APT(
             tri.V[0] = &(loc[polys[poly_counter][0]]);
             tri.V[1] = &(loc[polys[poly_counter][1]]);
             tri.V[2] = &(loc[polys[poly_counter][2]]);
-            tri.N = (Vector3 *)&(norms[poly_counter]);
+            tri.N = Thyme::To_Vector3_Ptr(&(norms[poly_counter]));
 
             if (Vector3::Dot_Product(*tri.N, viewdir) < 0.0f) {
                 if (CollisionMath::Intersection_Test(local_box, tri)) {
@@ -634,7 +634,7 @@ bool MeshGeometryClass::Intersect_OBBox_Brute_Force(OBBoxIntersectionTestClass &
         tri.V[0] = &(loc[polyverts[i][0]]);
         tri.V[1] = &(loc[polyverts[i][1]]);
         tri.V[2] = &(loc[polyverts[i][2]]);
-        tri.N = (Vector3 *)&(norms[i]);
+        tri.N = Thyme::To_Vector3_Ptr(&(norms[i]));
 
         if (CollisionMath::Intersection_Test(localtest.m_box, tri)) {
             return true;
@@ -656,7 +656,7 @@ bool MeshGeometryClass::Cast_Ray_Brute_Force(RayCollisionTestClass &raytest)
         tri.V[0] = &(loc[polyverts[i][0]]);
         tri.V[1] = &(loc[polyverts[i][1]]);
         tri.V[2] = &(loc[polyverts[i][2]]);
-        tri.N = (Vector3 *)&(norms[i]);
+        tri.N = Thyme::To_Vector3_Ptr(&(norms[i]));
 
         hit = hit | CollisionMath::Collide(raytest.m_ray, tri, raytest.m_result);
         if (hit) {
@@ -682,7 +682,7 @@ bool MeshGeometryClass::Cast_AABox_Brute_Force(AABoxCollisionTestClass &boxtest)
         tri.V[0] = &(loc[polyverts[i][0]]);
         tri.V[1] = &(loc[polyverts[i][1]]);
         tri.V[2] = &(loc[polyverts[i][2]]);
-        tri.N = (Vector3 *)&(norms[i]);
+        tri.N = Thyme::To_Vector3_Ptr(&(norms[i]));
 
         if (CollisionMath::Collide(boxtest.m_box, boxtest.m_move, tri, boxtest.m_result)) {
             polyhit = i;
@@ -712,7 +712,7 @@ bool MeshGeometryClass::Cast_OBBox_Brute_Force(OBBoxCollisionTestClass &boxtest)
         tri.V[0] = &(loc[polyverts[i][0]]);
         tri.V[1] = &(loc[polyverts[i][1]]);
         tri.V[2] = &(loc[polyverts[i][2]]);
-        tri.N = (Vector3 *)&(norms[i]);
+        tri.N = Thyme::To_Vector3_Ptr(&(norms[i]));
 
         if (CollisionMath::Collide(boxtest.m_box, boxtest.m_move, tri, Vector3(0, 0, 0), boxtest.m_result)) {
             polyhit = i;


### PR DESCRIPTION
I put static asserts and new methods to provide casting functionality for Vector4 to Vector3. This way there is visibility and confidence that this is ok to do.