### PR TITLE
Remove Matrix4 C casts

### DIFF
--- a/src/game/client/shader/cloudshader.cpp
+++ b/src/game/client/shader/cloudshader.cpp
@@ -21,14 +21,14 @@ int CloudTextureShader::Set(int pass)
 {
 #ifdef BUILD_WITH_D3D8
     D3DXMATRIX m;
-    DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+    DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
     D3DXMATRIX m2;
     float f;
     D3DXMatrixInverse(&m2, &f, &m);
     g_terrainShader2Stage.Update_Noise_1(&m, &m2, false);
     DX8Wrapper::Set_DX8_Texture_Stage_State(pass, D3DTSS_TEXCOORDINDEX, D3DTSS_TCI_CAMERASPACEPOSITION);
     DX8Wrapper::Set_DX8_Texture_Stage_State(pass, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2);
-    DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(pass + D3DTS_TEXTURE0), (Matrix4 &)m);
+    DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(pass + D3DTS_TEXTURE0), m);
     DX8Wrapper::Set_DX8_Texture_Stage_State(pass, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
     DX8Wrapper::Set_DX8_Texture_Stage_State(pass, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
     DX8Wrapper::Set_DX8_Texture_Stage_State(pass, D3DTSS_ADDRESSU, D3DTADDRESS_WRAP);

--- a/src/game/client/shader/flatshroudshader.cpp
+++ b/src/game/client/shader/flatshroudshader.cpp
@@ -41,7 +41,7 @@ int FlatShroudTextureShader::Set(int pass)
     if (shroud) {
         D3DXMATRIX m;
         D3DXMATRIX m2;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m2);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m2);
         float f;
         D3DXMatrixInverse(&m, &f, &m2);
         D3DXMATRIX m3;
@@ -61,7 +61,7 @@ int FlatShroudTextureShader::Set(int pass)
         sy = 1.0f / ((float)shroud->Get_Texture_Height() * sy);
         D3DXMatrixScaling(&m3, sx, sy, 1.0f);
         m2 = m * m4 * m3;
-        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(pass + D3DTS_TEXTURE0), (Matrix4 &)m2);
+        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(pass + D3DTS_TEXTURE0), m2);
     }
 
     m_pass = pass;

--- a/src/game/client/shader/flatterrainshader.cpp
+++ b/src/game/client/shader/flatterrainshader.cpp
@@ -49,7 +49,7 @@ int FlatTerrainShader2Stage::Set(int pass)
     if (pass) {
         if (pass == 1) {
             D3DXMATRIX m;
-            DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+            DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
             DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
             DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
             DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
@@ -67,13 +67,13 @@ int FlatTerrainShader2Stage::Set(int pass)
 
             if (W3DShaderManager::Get_Current_Shader() == W3DShaderManager::ST_FLAT_TERRAIN_NOISE12) {
                 g_terrainShader2Stage.Update_Noise_1(&m, &m2, true);
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, (Matrix4 &)m);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, m);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
                 DX8Wrapper::Get_D3D_Device8()->SetTexture(
                     0, W3DShaderManager::Get_Shader_Texture(2)->Peek_Platform_Base_Texture());
                 g_terrainShader2Stage.Update_Noise_2(&m, &m2, true);
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, (Matrix4 &)m);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, m);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_MINFILTER, D3DTEXF_POINT);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_COLORARG1, D3DTA_TEXTURE);
@@ -103,7 +103,7 @@ int FlatTerrainShader2Stage::Set(int pass)
 
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, (Matrix4 &)m);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, m);
             }
         }
     } else {
@@ -126,7 +126,7 @@ int FlatTerrainShader2Stage::Set(int pass)
             if (shroud) {
                 D3DXMATRIX m2;
                 D3DXMATRIX m;
-                DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+                DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
                 float f;
                 D3DXMatrixInverse(&m2, &f, &m);
                 D3DXMATRIX m3;
@@ -146,7 +146,7 @@ int FlatTerrainShader2Stage::Set(int pass)
                 sy = 1.0f / ((float)shroud->Get_Texture_Height() * sy);
                 D3DXMatrixScaling(&m3, sx, sy, 1.0f);
                 m = m2 * m4 * m3;
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, (Matrix4 &)m);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, m);
             }
         } else {
             DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_COLOROP, D3DTOP_SELECTARG2);
@@ -232,7 +232,7 @@ int FlatTerrainShaderPixelShader::Set(int pass)
         DX8Wrapper::Set_DX8_Texture_Stage_State(i, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2);
         D3DXMATRIX m2;
         D3DXMATRIX m;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
         float f;
         D3DXMatrixInverse(&m2, &f, &m);
         D3DXMATRIX m3;
@@ -252,7 +252,7 @@ int FlatTerrainShaderPixelShader::Set(int pass)
         sy = 1.0f / ((float)shroud->Get_Texture_Height() * sy);
         D3DXMatrixScaling(&m3, sx, sy, 1.0f);
         m = m2 * m4 * m3;
-        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(i + D3DTS_TEXTURE0), (Matrix4 &)m);
+        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(i + D3DTS_TEXTURE0), m);
         DX8Wrapper::Set_DX8_Texture_Stage_State(i, D3DTSS_ADDRESSU, D3DTADDRESS_CLAMP);
         DX8Wrapper::Set_DX8_Texture_Stage_State(i, D3DTSS_ADDRESSV, D3DTADDRESS_CLAMP);
         DX8Wrapper::Set_DX8_Texture_Stage_State(i, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
@@ -266,7 +266,7 @@ int FlatTerrainShaderPixelShader::Set(int pass)
     if (W3DShaderManager::Get_Current_Shader() == W3DShaderManager::ST_FLAT_TERRAIN_NOISE1
         || W3DShaderManager::Get_Current_Shader() == W3DShaderManager::ST_FLAT_TERRAIN_NOISE12) {
         D3DXMATRIX m;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
         D3DXMATRIX m2;
         float f;
         D3DXMatrixInverse(&m2, &f, &m);
@@ -276,7 +276,7 @@ int FlatTerrainShaderPixelShader::Set(int pass)
         DX8Wrapper::Set_DX8_Texture_Stage_State(i, D3DTSS_ADDRESSV, 1);
         DX8Wrapper::Get_D3D_Device8()->SetTexture(i, W3DShaderManager::Get_Shader_Texture(2)->Peek_Platform_Base_Texture());
         g_terrainShader2Stage.Update_Noise_1(&m, &m2, true);
-        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(i + D3DTS_TEXTURE0), (Matrix4 &)m);
+        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(i + D3DTS_TEXTURE0), m);
         DX8Wrapper::Set_DX8_Texture_Stage_State(i, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
         DX8Wrapper::Set_DX8_Texture_Stage_State(i++, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
 
@@ -288,7 +288,7 @@ int FlatTerrainShaderPixelShader::Set(int pass)
     if (W3DShaderManager::Get_Current_Shader() == W3DShaderManager::ST_FLAT_TERRAIN_NOISE2
         || W3DShaderManager::Get_Current_Shader() == W3DShaderManager::ST_FLAT_TERRAIN_NOISE12) {
         D3DXMATRIX m;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
         D3DXMATRIX m2;
         float f;
         D3DXMatrixInverse(&m2, &f, &m);
@@ -298,7 +298,7 @@ int FlatTerrainShaderPixelShader::Set(int pass)
         DX8Wrapper::Set_DX8_Texture_Stage_State(i, D3DTSS_ADDRESSV, D3DTADDRESS_WRAP);
         DX8Wrapper::Get_D3D_Device8()->SetTexture(i, W3DShaderManager::Get_Shader_Texture(3)->Peek_Platform_Base_Texture());
         g_terrainShader2Stage.Update_Noise_2(&m, &m2, true);
-        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(i + D3DTS_TEXTURE0), (Matrix4 &)m);
+        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(i + D3DTS_TEXTURE0), m);
         DX8Wrapper::Set_DX8_Texture_Stage_State(i, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
         DX8Wrapper::Set_DX8_Texture_Stage_State(i++, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
         if (i == 1) {

--- a/src/game/client/shader/maskshader.cpp
+++ b/src/game/client/shader/maskshader.cpp
@@ -41,7 +41,7 @@ int MaskTextureShader::Set(int pass)
     DX8Wrapper::Set_Shader(s);
     DX8Wrapper::Apply_Render_State_Changes();
     D3DXMATRIX m1;
-    DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m1);
+    DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m1);
     DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_TEXCOORDINDEX, D3DTSS_TCI_CAMERASPACEPOSITION);
     DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2);
     D3DXMATRIX m2;
@@ -74,7 +74,7 @@ int MaskTextureShader::Set(int pass)
         m1 = m2 * m4 * m3;
     }
 
-    DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, (Matrix4 &)m1);
+    DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, m1);
 #endif
     return 1;
 }

--- a/src/game/client/shader/roadshader.cpp
+++ b/src/game/client/shader/roadshader.cpp
@@ -31,7 +31,7 @@ int RoadShaderPixelShader::Set(int pass)
     DX8Wrapper::Set_DX8_Render_State(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
     DX8Wrapper::Set_DX8_Render_State(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
     D3DXMATRIX m;
-    DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+    DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
     D3DXMATRIX m2;
     float f;
     D3DXMatrixInverse(&m2, &f, &m);
@@ -58,9 +58,9 @@ int RoadShaderPixelShader::Set(int pass)
     DX8Wrapper::Set_DX8_Texture_Stage_State(2, D3DTSS_MINFILTER, D3DTEXF_POINT);
     DX8Wrapper::Set_DX8_Texture_Stage_State(2, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
     g_terrainShader2Stage.Update_Noise_1(&m, &m2, false);
-    DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, (Matrix4 &)m);
+    DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, m);
     g_terrainShader2Stage.Update_Noise_2(&m, &m2, false);
-    DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, (Matrix4 &)m);
+    DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, m);
     DX8Wrapper::Set_DX8_Texture_Stage_State(2, D3DTSS_TEXCOORDINDEX, D3DTSS_TCI_CAMERASPACEPOSITION);
     DX8Wrapper::Set_DX8_Texture_Stage_State(2, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2);
 #endif
@@ -144,7 +144,7 @@ int RoadShader2Stage::Set(int pass)
 
     if (pass) {
         D3DXMATRIX m;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
         D3DXMATRIX m2;
         float f;
         D3DXMatrixInverse(&m2, &f, &m);
@@ -177,7 +177,7 @@ int RoadShader2Stage::Set(int pass)
         DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
         DX8Wrapper::Set_DX8_Render_State(D3DRS_SRCBLEND, D3DBLEND_ZERO);
         DX8Wrapper::Set_DX8_Render_State(D3DRS_DESTBLEND, D3DBLEND_SRCCOLOR);
-        DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, (Matrix4 &)m);
+        DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, m);
     } else {
         DX8Wrapper::Set_DX8_Render_State(D3DRS_SRCBLEND, D3DBLEND_SRCALPHA);
         DX8Wrapper::Set_DX8_Render_State(D3DRS_DESTBLEND, D3DBLEND_INVSRCALPHA);
@@ -187,7 +187,7 @@ int RoadShader2Stage::Set(int pass)
             DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
         } else {
             D3DXMATRIX m;
-            DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+            DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
             D3DXMATRIX m2;
             float f;
             D3DXMatrixInverse(&m2, &f, &m);
@@ -214,7 +214,7 @@ int RoadShader2Stage::Set(int pass)
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
                 g_terrainShader2Stage.Update_Noise_1(&m, &m2, false);
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, (Matrix4 &)m);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, m);
             } else {
                 if (W3DShaderManager::Get_Current_Shader() == W3DShaderManager::ST_ROAD_NOISE1) {
                     DX8Wrapper::Set_Texture(1, W3DShaderManager::Get_Shader_Texture(1));
@@ -227,7 +227,7 @@ int RoadShader2Stage::Set(int pass)
                 }
 
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, (Matrix4 &)m);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, m);
             }
         }
     }

--- a/src/game/client/shader/shroudshader.cpp
+++ b/src/game/client/shader/shroudshader.cpp
@@ -55,7 +55,7 @@ int ShroudTextureShader::Set(int pass)
     if (shroud) {
         D3DXMATRIX m;
         D3DXMATRIX m2;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m2);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m2);
         float f;
         D3DXMatrixInverse(&m, &f, &m2);
         D3DXMATRIX m3;
@@ -75,7 +75,7 @@ int ShroudTextureShader::Set(int pass)
         sy = 1.0f / ((float)shroud->Get_Texture_Height() * sy);
         D3DXMatrixScaling(&m3, sx, sy, 1.0f);
         m2 = m * m4 * m3;
-        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(pass + D3DTS_TEXTURE0), (Matrix4 &)m2);
+        DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(pass + D3DTS_TEXTURE0), m2);
     }
 
     m_pass = pass;

--- a/src/game/client/shader/terrainshader.cpp
+++ b/src/game/client/shader/terrainshader.cpp
@@ -77,7 +77,7 @@ int TerrainShader2Stage::Set(int pass)
 
         case 2:
             D3DXMATRIX m2;
-            DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m2);
+            DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m2);
             DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
             DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
             DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_COLOROP, D3DTOP_SELECTARG1);
@@ -96,12 +96,12 @@ int TerrainShader2Stage::Set(int pass)
             if (W3DShaderManager::Get_Current_Shader() == W3DShaderManager::ST_TERRAIN_NOISE12) {
                 DX8Wrapper::Set_Texture(0, W3DShaderManager::Get_Shader_Texture(2));
                 Update_Noise_1(&m2, &m, true);
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, (Matrix4 &)m2);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, m2);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(0, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
                 DX8Wrapper::Set_Texture(1, W3DShaderManager::Get_Shader_Texture(3));
                 Update_Noise_2(&m2, &m, true);
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, (Matrix4 &)m2);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE1, m2);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_MINFILTER, D3DTEXF_POINT);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_COLORARG1, D3DTA_TEXTURE);
@@ -127,7 +127,7 @@ int TerrainShader2Stage::Set(int pass)
 
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_COLOROP, D3DTOP_DISABLE);
                 DX8Wrapper::Set_DX8_Texture_Stage_State(1, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
-                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, (Matrix4 &)m2);
+                DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE0, m2);
             }
             break;
     }
@@ -389,7 +389,7 @@ int TerrainShaderPixelShader::Set(int pass)
         DX8Wrapper::Get_D3D_Device8()->SetPixelShader(m_dwBasePixelShader);
     } else {
         D3DXMATRIX m;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
         D3DXMATRIX m2;
         float f;
         D3DXMatrixInverse(&m2, &f, &m);
@@ -411,9 +411,9 @@ int TerrainShaderPixelShader::Set(int pass)
             DX8Wrapper::Set_DX8_Texture_Stage_State(3, D3DTSS_MINFILTER, D3DTEXF_POINT);
             DX8Wrapper::Set_DX8_Texture_Stage_State(3, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
             g_terrainShader2Stage.Update_Noise_1(&m, &m2, true);
-            DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, (Matrix4 &)m);
+            DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, m);
             g_terrainShader2Stage.Update_Noise_2(&m, &m2, true);
-            DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE3, (Matrix4 &)m);
+            DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE3, m);
             DX8Wrapper::Set_DX8_Texture_Stage_State(3, D3DTSS_TEXCOORDINDEX, D3DTSS_TCI_CAMERASPACEPOSITION);
             DX8Wrapper::Set_DX8_Texture_Stage_State(3, D3DTSS_TEXTURETRANSFORMFLAGS, D3DTTFF_COUNT2);
         } else {
@@ -432,7 +432,7 @@ int TerrainShaderPixelShader::Set(int pass)
             }
 
             DX8Wrapper::Set_DX8_Texture_Stage_State(2, D3DTSS_MAGFILTER, D3DTEXF_LINEAR);
-            DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, (Matrix4 &)m);
+            DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, m);
         }
     }
 #endif

--- a/src/game/client/shadermanager.cpp
+++ b/src/game/client/shadermanager.cpp
@@ -471,7 +471,7 @@ bool W3DShaderManager::Set_Shroud_Tex(int stage)
     DX8Wrapper::Set_DX8_Texture_Stage_State(stage, D3DTSS_ALPHAOP, D3DTOP_SELECTARG2);
     D3DXMATRIX m2;
     D3DXMATRIX m;
-    DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m);
+    DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m);
     float f;
     D3DXMatrixInverse(&m2, &f, &m);
     D3DXMATRIX m3;
@@ -491,7 +491,7 @@ bool W3DShaderManager::Set_Shroud_Tex(int stage)
     sy = 1.0f / ((float)shroud->Get_Texture_Height() * sy);
     D3DXMatrixScaling(&m3, sx, sy, 1.0f);
     m = m2 * m4 * m3;
-    DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(stage + D3DTS_TEXTURE0), (Matrix4 &)m);
+    DX8Wrapper::Set_DX8_Transform((D3DTRANSFORMSTATETYPE)(stage + D3DTS_TEXTURE0), m);
 #endif
     return true;
 }

--- a/src/game/client/shadow/w3dprojectedshadow.cpp
+++ b/src/game/client/shadow/w3dprojectedshadow.cpp
@@ -35,6 +35,9 @@
 #include "w3dmodeldraw.h"
 #include "worldheightmap.h"
 #include <cstring>
+#ifdef BUILD_WITH_D3D8
+#include <d3dx8math.h>
+#endif
 
 using std::memset;
 using std::strcpy;
@@ -564,7 +567,7 @@ int W3DProjectedShadowManager::Render_Projected_Terrain_Shadow(W3DProjectedShado
 void W3DProjectedShadowManager::Flush_Decals(W3DShadowTexture *texture, ShadowType type)
 {
 #ifdef BUILD_WITH_D3D8
-    static Matrix4 mWorld(true);
+    static D3DXMATRIX mWorld = *D3DXMatrixIdentity(&mWorld);
 
     if (g_nShadowDecalVertsInBatch || g_nShadowDecalPolysInBatch) {
         IDirect3DDevice8 *dev = DX8Wrapper::Get_D3D_Device8();
@@ -589,7 +592,7 @@ void W3DProjectedShadowManager::Flush_Decals(W3DShadowTexture *texture, ShadowTy
 
             DX8Wrapper::Apply_Render_State_Changes();
             dev->SetIndices(g_shadowDecalIndexBufferD3D, g_nShadowDecalStartBatchVertex);
-            dev->SetTransform(D3DTS_WORLD, (D3DMATRIX *)&mWorld);
+            dev->SetTransform(D3DTS_WORLD, &mWorld);
             dev->SetStreamSource(0, g_shadowDecalVertexBufferD3D, sizeof(SHADOW_DECAL_VERTEX));
             dev->SetVertexShader(D3DFVF_TEX1 | D3DFVF_DIFFUSE | D3DFVF_XYZ);
 

--- a/src/game/client/water/w3dwater.cpp
+++ b/src/game/client/water/w3dwater.cpp
@@ -1090,17 +1090,16 @@ void WaterRenderObjClass::Draw_Sea(RenderInfoClass &rinfo)
         ww3d.m[2][1] = 1.0f;
         ww3d.m[1][2] = 1.0f;
         ww3d.m[3][3] = 1.0f;
-        Matrix3D m4(m_transform);
 
-        DX8Wrapper::Set_Transform(D3DTS_WORLD, m4);
+        DX8Wrapper::Set_Transform(D3DTS_WORLD, m_transform);
         DX8Wrapper::Set_Texture(0, nullptr);
         DX8Wrapper::Set_Texture(1, nullptr);
         DX8Wrapper::Apply_Render_State_Changes();
 
         Vector3 v;
         rinfo.m_camera.Get_Transform().Get_Translation(&v);
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)view);
-        DX8Wrapper::Get_DX8_Transform(D3DTS_PROJECTION, (Matrix4 &)proj);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, view);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_PROJECTION, proj);
 
         m_pDev->SetTextureStageState(0, D3DTSS_COLORARG1, D3DTA_TEXTURE);
         m_pDev->SetTextureStageState(0, D3DTSS_COLORARG2, D3DTA_DIFFUSE);
@@ -1217,8 +1216,8 @@ void WaterRenderObjClass::Draw_Sea(RenderInfoClass &rinfo)
         m_pDev->SetTextureStageState(2, D3DTSS_COLOROP, D3DTOP_DISABLE);
         m_pDev->SetTextureStageState(2, D3DTSS_ALPHAOP, D3DTOP_DISABLE);
 
-        DX8Wrapper::Set_DX8_Transform(D3DTS_VIEW, (Matrix4 &)view);
-        DX8Wrapper::Set_DX8_Transform(D3DTS_PROJECTION, (Matrix4 &)proj);
+        DX8Wrapper::Set_DX8_Transform(D3DTS_VIEW, view);
+        DX8Wrapper::Set_DX8_Transform(D3DTS_PROJECTION, proj);
         m_pDev->SetPixelShader(0);
         m_pDev->SetVertexShader(DX8_FVF_XYZDUV1);
         DX8Wrapper::Invalidate_Cached_Render_States();
@@ -1239,7 +1238,7 @@ void WaterRenderObjClass::Draw_Sea(RenderInfoClass &rinfo)
                     m10.m[3][0] = (float)(14 * j) * 40.0f;
                     m10.m[3][2] = (float)(14 * i) * 40.0f;
                     D3DXMatrixMultiply(&m10, &patch, &ww3d);
-                    DX8Wrapper::Set_DX8_Transform(D3DTS_WORLD, (Matrix4 &)m10);
+                    DX8Wrapper::Set_DX8_Transform(D3DTS_WORLD, m10);
                     m_pDev->DrawIndexedPrimitive(D3DPT_TRIANGLESTRIP, 0, m_numVertices, 0, m_numIndices);
                 }
             }
@@ -1487,8 +1486,7 @@ void WaterRenderObjClass::Render_Water_Mesh()
         }
 
         m_vertexBufferD3D->Unlock();
-        Matrix3D m(m_transform);
-        DX8Wrapper::Set_Transform(D3DTS_WORLD, m);
+        DX8Wrapper::Set_Transform(D3DTS_WORLD, m_transform);
         DX8Wrapper::Set_Material(m_meshVertexMaterialClass);
         ShaderClass::CullModeType cull = m_shaderClass.Get_Cull_Mode();
         ShaderClass::DepthMaskType mask = m_shaderClass.Get_Depth_Mask();
@@ -2020,7 +2018,7 @@ void WaterRenderObjClass::Setup_Flat_Water_Shader()
         DX8Wrapper::Set_DX8_Texture_Stage_State(2, D3DTSS_ADDRESSV, D3DTADDRESS_WRAP);
         D3DXMATRIX m;
         D3DXMATRIX m2;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m2);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m2);
         float f;
         D3DXMatrixInverse(&m, &f, &m2);
         D3DXMATRIX m3;
@@ -2028,7 +2026,7 @@ void WaterRenderObjClass::Setup_Flat_Water_Shader()
         D3DXMATRIX m4 = m * m3;
         D3DXMatrixTranslation(&m3, m_riverVOrigin, m_riverVOrigin, 0.0f);
         m4 = m4 * m3;
-        DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, (Matrix4 &)m4);
+        DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, m4);
     }
 
     m_pDev->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR);
@@ -2388,7 +2386,7 @@ void WaterRenderObjClass::Setup_Jba_Water_Shader()
 
         D3DXMATRIX m;
         D3DXMATRIX m2;
-        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, (Matrix4 &)m2);
+        DX8Wrapper::Get_DX8_Transform(D3DTS_VIEW, m2);
         float f;
         D3DXMatrixInverse(&m, &f, &m2);
         D3DXMATRIX m3;
@@ -2396,7 +2394,7 @@ void WaterRenderObjClass::Setup_Jba_Water_Shader()
         D3DXMATRIX m4 = m * m3;
         D3DXMatrixTranslation(&m3, m_riverVOrigin, m_riverVOrigin, 0.0f);
         m4 = m4 * m3;
-        DX8Wrapper::Set_Transform(D3DTS_TEXTURE2, (Matrix4 &)m4);
+        DX8Wrapper::Set_DX8_Transform(D3DTS_TEXTURE2, m4);
     }
 
     m_pDev->SetTextureStageState(0, D3DTSS_MINFILTER, D3DTEXF_LINEAR);

--- a/src/game/common/beziersegment.cpp
+++ b/src/game/common/beziersegment.cpp
@@ -17,8 +17,15 @@
 #include "bezfwditerator.h"
 #include "vector4.h"
 
-const Matrix4 BezierSegment::s_bezBasisMatrix =
-    Matrix4(-1.0f, 3.0f, -3.0f, 1.0f, 3.0f, -6.0f, 3.0f, 0.0f, -3.0f, 3.0f, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f);
+// clang-format off
+// Symmetrical matrix. Identical when transposed, thus equally compatible for D3DMATRIX and Matrix4.
+const Matrix4 BezierSegment::s_bezBasisMatrix = Matrix4(
+    -1.0f,  3.0f, -3.0f, 1.0f,
+     3.0f, -6.0f,  3.0f, 0.0f,
+    -3.0f,  3.0f,  0.0f, 0.0f,
+     1.0f,  0.0f,  0.0f, 0.0f
+);
+// clang-format on
 
 BezierSegment::BezierSegment()
 {

--- a/src/hooker/setupglobals_zh.cpp
+++ b/src/hooker/setupglobals_zh.cpp
@@ -266,7 +266,7 @@ RenderStateStruct &DX8Wrapper::s_renderState = Make_Global<RenderStateStruct>(PI
 unsigned &DX8Wrapper::s_renderStateChanged = Make_Global<unsigned>(PICK_ADDRESS(0x00A42778, 0x00DE8FB0));
 float &DX8Wrapper::s_zNear = Make_Global<float>(PICK_ADDRESS(0x00A47E38, 0x00DEE670));
 float &DX8Wrapper::s_zFar = Make_Global<float>(PICK_ADDRESS(0x00A47EB8, 0x00DEE6F0));
-Matrix4 &DX8Wrapper::s_projectionMatrix = Make_Global<Matrix4>(PICK_ADDRESS(0x00A47DF8, 0x00DEE630));
+D3DMATRIX &DX8Wrapper::s_projectionMatrix = Make_Global<D3DMATRIX>(PICK_ADDRESS(0x00A47DF8, 0x00DEE630));
 int &DX8Wrapper::s_mainThreadID = Make_Global<int>(PICK_ADDRESS(0x00A47F2C, 0x00DEE764));
 int &DX8Wrapper::s_currentRenderDevice = Make_Global<int>(PICK_ADDRESS(0x00A15CDC, 0x00CC36BC));
 DX8Caps *&DX8Wrapper::s_currentCaps = Make_Global<DX8Caps *>(PICK_ADDRESS(0x00A47F30, 0x00DEE768));
@@ -302,7 +302,8 @@ DynamicVectorClass<StringClass> &DX8Wrapper::s_renderDeviceShortNameTable =
 DynamicVectorClass<RenderDeviceDescClass> &DX8Wrapper::s_renderDeviceDescriptionTable =
     Make_Global<DynamicVectorClass<RenderDeviceDescClass>>(PICK_ADDRESS(0x00A427A8, 0x00DE8FE0));
 w3dadapterid_t &DX8Wrapper::s_currentAdapterIdentifier = Make_Global<w3dadapterid_t>(PICK_ADDRESS(0x00A470C0, 0x00DED8F8));
-ARRAY_DEF(PICK_ADDRESS(0x00A42840, 0x00DE9078), Matrix4, DX8Wrapper::s_DX8Transforms, 257);
+static_assert(D3DTS_WORLD1 == 257, "Expected match");
+ARRAY_DEF(PICK_ADDRESS(0x00A42840, 0x00DE9078), D3DMATRIX, DX8Wrapper::s_DX8Transforms, D3DTS_WORLD1);
 D3DMATRIX &DX8Wrapper::s_oldPrj = Make_Global<D3DMATRIX>(PICK_ADDRESS(0x00A46C80, 0x00DED4B8));
 D3DMATRIX &DX8Wrapper::s_oldView = Make_Global<D3DMATRIX>(PICK_ADDRESS(0x00A47D78, 0x00DEE5B0));
 D3DMATRIX &DX8Wrapper::s_oldWorld = Make_Global<D3DMATRIX>(PICK_ADDRESS(0x00A47E78, 0x00DEE6B0));

--- a/src/w3d/math/matrix4.cpp
+++ b/src/w3d/math/matrix4.cpp
@@ -90,3 +90,71 @@ void Matrix4::Multiply(const Matrix4 &a, const Matrix3D &b, Matrix4 *res)
 #undef ROWCOL
 #undef ROWCOL4
 }
+
+#ifdef BUILD_WITH_D3D8
+#include <d3d8types.h>
+
+namespace Thyme
+{
+void To_D3DMATRIX(_D3DMATRIX &dxm, const Matrix4 &m)
+{
+    dxm.m[0][0] = m[0][0];
+    dxm.m[0][1] = m[1][0];
+    dxm.m[0][2] = m[2][0];
+    dxm.m[0][3] = m[3][0];
+
+    dxm.m[1][0] = m[0][1];
+    dxm.m[1][1] = m[1][1];
+    dxm.m[1][2] = m[2][1];
+    dxm.m[1][3] = m[3][1];
+
+    dxm.m[2][0] = m[0][2];
+    dxm.m[2][1] = m[1][2];
+    dxm.m[2][2] = m[2][2];
+    dxm.m[2][3] = m[3][2];
+
+    dxm.m[3][0] = m[0][3];
+    dxm.m[3][1] = m[1][3];
+    dxm.m[3][2] = m[2][3];
+    dxm.m[3][3] = m[3][3];
+}
+
+_D3DMATRIX To_D3DMATRIX(const Matrix4 &m)
+{
+    _D3DMATRIX dxm;
+    To_D3DMATRIX(dxm, m);
+    return dxm;
+}
+
+void To_Matrix4(Matrix4 &m, const _D3DMATRIX &dxm)
+{
+    m[0][0] = dxm.m[0][0];
+    m[0][1] = dxm.m[1][0];
+    m[0][2] = dxm.m[2][0];
+    m[0][3] = dxm.m[3][0];
+
+    m[1][0] = dxm.m[0][1];
+    m[1][1] = dxm.m[1][1];
+    m[1][2] = dxm.m[2][1];
+    m[1][3] = dxm.m[3][1];
+
+    m[2][0] = dxm.m[0][2];
+    m[2][1] = dxm.m[1][2];
+    m[2][2] = dxm.m[2][2];
+    m[2][3] = dxm.m[3][2];
+
+    m[3][0] = dxm.m[0][3];
+    m[3][1] = dxm.m[1][3];
+    m[3][2] = dxm.m[2][3];
+    m[3][3] = dxm.m[3][3];
+}
+
+Matrix4 To_Matrix4(const _D3DMATRIX &dxm)
+{
+    Matrix4 m;
+    To_Matrix4(m, dxm);
+    return m;
+}
+} // namespace Thyme
+
+#endif

--- a/src/w3d/math/matrix4.h
+++ b/src/w3d/math/matrix4.h
@@ -377,7 +377,7 @@ public:
 
     static const Matrix4 IDENTITY;
 
-protected:
+public:
     Vector4 Row[4];
 };
 
@@ -476,3 +476,21 @@ __forceinline Vector4 operator*(const Matrix4 &a, const Vector4 &v)
         a[2][0] * v[0] + a[2][1] * v[1] + a[2][2] * v[2] + a[2][3] * v[3],
         a[3][0] * v[0] + a[3][1] * v[1] + a[3][2] * v[2] + a[3][3] * v[3]);
 }
+
+#ifdef BUILD_WITH_D3D8
+struct _D3DMATRIX;
+
+namespace Thyme
+{
+// When converting Matrix4 to D3DMATRIX or vice versa always use conversion function below.
+// Reason being, D3DMATRIX is row major matrix, and Matrix4 is column major matrix.
+// Thus copying from one to another will always require a transpose (or invert).
+
+void To_D3DMATRIX(_D3DMATRIX &dxm, const Matrix4 &m);
+[[nodiscard]] _D3DMATRIX To_D3DMATRIX(const Matrix4 &m);
+
+void To_Matrix4(Matrix4 &m, const _D3DMATRIX &dxm);
+[[nodiscard]] Matrix4 To_Matrix4(const _D3DMATRIX &dxm);
+
+} // namespace Thyme
+#endif

--- a/src/w3d/renderer/dx8renderer.cpp
+++ b/src/w3d/renderer/dx8renderer.cpp
@@ -578,7 +578,9 @@ void DX8TextureCategoryClass::Render()
             }
 
             if (identity) {
+#ifdef BUILD_WITH_D3D8
                 DX8Wrapper::Set_World_Identity();
+#endif
             } else {
 #ifdef BUILD_WITH_D3D8
                 DX8Wrapper::Set_Transform(D3DTS_WORLD, tm);

--- a/src/w3d/renderer/dx8wrapper.cpp
+++ b/src/w3d/renderer/dx8wrapper.cpp
@@ -76,7 +76,11 @@ RenderStateStruct DX8Wrapper::s_renderState;
 unsigned DX8Wrapper::s_renderStateChanged;
 float DX8Wrapper::s_zNear;
 float DX8Wrapper::s_zFar;
+#ifdef BUILD_WITH_D3D8
+D3DMATRIX DX8Wrapper::s_projectionMatrix;
+#else
 Matrix4 DX8Wrapper::s_projectionMatrix;
+#endif
 int DX8Wrapper::s_mainThreadID;
 int DX8Wrapper::s_currentRenderDevice = -1;
 DX8Caps *DX8Wrapper::s_currentCaps;
@@ -108,7 +112,11 @@ DynamicVectorClass<StringClass> DX8Wrapper::s_renderDeviceNameTable;
 DynamicVectorClass<StringClass> DX8Wrapper::s_renderDeviceShortNameTable;
 DynamicVectorClass<RenderDeviceDescClass> DX8Wrapper::s_renderDeviceDescriptionTable;
 w3dadapterid_t DX8Wrapper::s_currentAdapterIdentifier;
+#ifdef BUILD_WITH_D3D8
+D3DMATRIX DX8Wrapper::s_DX8Transforms[D3DTS_WORLD1];
+#else
 Matrix4 DX8Wrapper::s_DX8Transforms[257];
+#endif
 bool DX8Wrapper::s_EnableTriangleDraw = true;
 int DX8Wrapper::s_ZBias;
 Vector3 DX8Wrapper::s_ambientColor;
@@ -1552,7 +1560,7 @@ void DX8Wrapper::Apply_Render_State_Changes()
 
         if (s_renderStateChanged & LIGHTS_CHANGED) {
             unsigned mask = LIGHT0_CHANGED;
-            for (unsigned index = 0; index < GFX_LIGHT_COUNT; ++index, mask <<= 1) {
+            for (int index = 0; index < GFX_LIGHT_COUNT; ++index, mask <<= 1) {
                 if (s_renderStateChanged & mask) {
                     if (s_renderState.LightEnable[index]) {
                         Set_DX8_Light(index, &s_renderState.Lights[index]);

--- a/src/w3d/renderer/sortingrenderer.cpp
+++ b/src/w3d/renderer/sortingrenderer.cpp
@@ -271,14 +271,17 @@ void SortingRendererClass::Insert_Triangles(const SphereClass &bounding_sphere,
         captainslog_assert(state->vertex_count <= vertex_buffer->Get_Vertex_Count());
 
         D3DXMATRIX mtx;
-        D3DXMatrixMultiply(
-            &mtx, (const D3DXMATRIX *)&state->sorting_state.world, (const D3DXMATRIX *)&state->sorting_state.view);
-        D3DXVECTOR3 vec;
-        D3DXVECTOR4 transformed_vec;
-        D3DXVec3Transform(&transformed_vec, &vec, &mtx);
-        state->transformed_center.X = transformed_vec.x;
-        state->transformed_center.Y = transformed_vec.y;
-        state->transformed_center.Z = transformed_vec.z;
+        D3DXMatrixMultiply(&mtx, &state->sorting_state.world, &state->sorting_state.view);
+        D3DXVECTOR3 bounding_sphere_center;
+        bounding_sphere_center.x = state->bounding_sphere.Center.X;
+        bounding_sphere_center.y = state->bounding_sphere.Center.Y;
+        bounding_sphere_center.z = state->bounding_sphere.Center.Z;
+        D3DXVECTOR4 transformed_center;
+        D3DXVec3Transform(&transformed_center, &bounding_sphere_center, &mtx);
+        state->transformed_center.X = transformed_center.x;
+        state->transformed_center.Y = transformed_center.y;
+        state->transformed_center.Z = transformed_center.z;
+
         SortingNodeStruct *i;
 
         for (i = g_sortedList.Head(); i; i = i->Succ()) {
@@ -351,7 +354,8 @@ void SortingRendererClass::Flush_Sorting_Pool()
             for (unsigned int node_id = 0; node_id < g_overlappingNodeCount; node_id++) {
                 SortingNodeStruct *state = g_overlappingNodes[node_id];
                 VertexFormatXYZNDUV2 *src_verts = nullptr;
-                SortingVertexBufferClass *vertex_buffer = (SortingVertexBufferClass *)state->sorting_state.vertex_buffers[0];
+                SortingVertexBufferClass *vertex_buffer =
+                    static_cast<SortingVertexBufferClass *>(state->sorting_state.vertex_buffers[0]);
 
                 captainslog_assert(vertex_buffer);
                 src_verts = vertex_buffer->Get_Sorting_Vertex_Buffer();
@@ -361,12 +365,12 @@ void SortingRendererClass::Flush_Sorting_Pool()
                     state->sorting_state.vba_offset + state->sorting_state.index_base_offset + state->min_vertex_index;
                 memcpy(dest_verts, src_verts, sizeof(VertexFormatXYZNDUV2) * state->vertex_count);
                 dest_verts += state->vertex_count;
-                D3DXMATRIX d3d_mtx;
-                D3DXMatrixMultiply(&d3d_mtx,
-                    (const D3DXMATRIX *)&state->sorting_state.world,
-                    (const D3DXMATRIX *)&state->sorting_state.view);
 
-                SortingIndexBufferClass *index_buffer = (SortingIndexBufferClass *)state->sorting_state.index_buffer;
+                D3DXMATRIX d3d_mtx;
+                D3DXMatrixMultiply(&d3d_mtx, &state->sorting_state.world, &state->sorting_state.view);
+
+                SortingIndexBufferClass *index_buffer =
+                    static_cast<SortingIndexBufferClass *>(state->sorting_state.index_buffer);
                 captainslog_assert(index_buffer);
                 unsigned short *indices = index_buffer->Get_Sorting_Index_Buffer();
                 captainslog_assert(indices);


### PR DESCRIPTION
The goal here is to not have `Matrix4` mistaken for a `D3DMATRIX` and vice versa. **They are not the same thing**. And therefore should not be used interchangeably.

If a matrix is in `D3DMATRIX` form, then it will be stored that way. Otherwise it is a `Matrix4`. New conversion functions make the conversion explicit and readable. All C casts have been removed. ~~Only one `reinterpret_cast` was left.~~