### PR TITLE
Double shadow buffers in W3DBufferManager

### DIFF
--- a/src/platform/w3dengine/client/shadow/w3dbuffermanager.cpp
+++ b/src/platform/w3dengine/client/shadow/w3dbuffermanager.cpp
@@ -329,10 +329,9 @@ W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::Allocate_Slot_Storage(V
 
         W3DVertexBuffer *buf = m_W3DVertexBuffers[fvf_type];
 
-        // #TODO investigate
+        // TODO investigate
         // We allocate count for vertex buffer but size and start index is set by the original size
-        // As it stands this doesn't seem to make any sense.
-        // A 4 byte alignment on the buffer would be understandable but this...
+        // As it stands this doesn't seem to make any sense, i'd understand a 4 byte alignement on the buffer but this...
         int vb_size = std::max(8192, size);
 
         buf->m_DX8VertexBuffer =
@@ -340,7 +339,7 @@ W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::Allocate_Slot_Storage(V
         buf->m_format = fvf_type;
         buf->m_startFreeIndex = size;
         buf->m_size = vb_size;
-        // #BUGFIX Original didn't clear this
+        // BUGFIX Original didn't clear this
         buf->m_renderTaskList = nullptr;
 
         W3DVertexBufferSlot *slot = &m_W3DVertexBufferEmptySlots[m_numEmptyVertexSlotsAllocated++];

--- a/src/platform/w3dengine/client/shadow/w3dbuffermanager.cpp
+++ b/src/platform/w3dengine/client/shadow/w3dbuffermanager.cpp
@@ -329,9 +329,10 @@ W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::Allocate_Slot_Storage(V
 
         W3DVertexBuffer *buf = m_W3DVertexBuffers[fvf_type];
 
-        // TODO investigate
+        // #TODO investigate
         // We allocate count for vertex buffer but size and start index is set by the original size
-        // As it stands this doesn't seem to make any sense, i'd understand a 4 byte alignement on the buffer but this...
+        // As it stands this doesn't seem to make any sense.
+        // A 4 byte alignment on the buffer would be understandable but this...
         int vb_size = std::max(8192, size);
 
         buf->m_DX8VertexBuffer =
@@ -339,7 +340,7 @@ W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::Allocate_Slot_Storage(V
         buf->m_format = fvf_type;
         buf->m_startFreeIndex = size;
         buf->m_size = vb_size;
-        // BUGFIX Original didn't clear this
+        // #BUGFIX Original didn't clear this
         buf->m_renderTaskList = nullptr;
 
         W3DVertexBufferSlot *slot = &m_W3DVertexBufferEmptySlots[m_numEmptyVertexSlotsAllocated++];

--- a/src/platform/w3dengine/client/shadow/w3dbuffermanager.h
+++ b/src/platform/w3dengine/client/shadow/w3dbuffermanager.h
@@ -107,15 +107,15 @@ public:
 
     enum
     {
-        MAX_NUMBER_SLOTS = 4096,
+        // #BUGFIX Double the original sizes to avoid crash when many 3D shadows are drawn on screen.
+        // #TODO Investigate crash further by reducing sizes and make it work even if sizes are exceeded.
+        MAX_NUMBER_SLOTS = 4096 * 2,
+        MAX_VERTEX_BUFFERS_CREATED = 32 * 2,
+        MAX_INDEX_BUFFERS_CREATED = 32 * 2,
 
-        // Don't change these two
-        // Changing these breaks shadows so something elsewhere relies on them
+        // Don't change these two yet. Changing these breaks shadows, meaning something elsewhere relies on them.
         MAX_VB_SIZES = 128,
         MAX_IB_SIZES = 128,
-
-        MAX_VERTEX_BUFFERS_CREATED = 32,
-        MAX_INDEX_BUFFERS_CREATED = 32,
     };
 
     W3DBufferManager();

--- a/src/platform/w3dengine/client/shadow/w3dbuffermanager.h
+++ b/src/platform/w3dengine/client/shadow/w3dbuffermanager.h
@@ -107,13 +107,17 @@ public:
 
     enum
     {
-        // #BUGFIX Double the original sizes to avoid crash when many 3D shadows are drawn on screen.
-        // #TODO Investigate crash further by reducing sizes and make it work even if sizes are exceeded.
+        // The number of slots corresponds to number of meshes casting shadows in the scene.
+        // The more meshes there are, the larger the slots needs to be.
+        // #BUGFIX Double the original sizes to allow for twice as many shadows to be created in the scene.
         MAX_NUMBER_SLOTS = 4096 * 2,
+
         MAX_VERTEX_BUFFERS_CREATED = 32 * 2,
         MAX_INDEX_BUFFERS_CREATED = 32 * 2,
 
-        // Don't change these two yet. Changing these breaks shadows, meaning something elsewhere relies on them.
+        // The max sizes correspond to a number of vertices and indices of a mesh casting shadows in the scene.
+        // The more vertices the meshes are supposed to have, the higher these limits need to be.
+        // Multiplying these numbers by 32 gives the max supported amount of vertices and indices.
         MAX_VB_SIZES = 128,
         MAX_IB_SIZES = 128,
     };


### PR DESCRIPTION
This change doubles the shadow slots in W3DBufferManager. This allows twice as many meshes in a scene to cast shadows before the buffer space runs out.