### PR TITLE
Avoid crash if texture passed to GameAssetManager::Recolor_Texture_On…

### DIFF
--- a/src/w3d/renderer/assetmgr.cpp
+++ b/src/w3d/renderer/assetmgr.cpp
@@ -931,7 +931,8 @@ TextureClass *GameAssetManager::Recolor_Texture_One_Time(TextureClass *texture, 
 {
     const char *name = texture->Get_Name();
 
-    if (name && name[0] == '!') {
+    // #BUGFIX Return if name is null too
+    if (name == nullptr || name[0] == '!') {
         return nullptr;
     }
 


### PR DESCRIPTION
…e_Time has no name