### PR TITLE
Force tests off when building with dll

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -98,6 +98,7 @@ cmake_dependent_option(USE_STDFS "Use C++ 17 filesystem for crossplatform file h
 if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
     if(CMAKE_SIZEOF_VOID_P EQUAL 4)
         option(BUILD_DLL "Build an injectable dll version." ON)
+	set(BUILD_TESTS OFF)
     endif()
 endif()
 

--- a/tests/test_filesystem.cpp
+++ b/tests/test_filesystem.cpp
@@ -20,8 +20,6 @@
 #include <stdlocalfilesystem.h>
 #endif
 
-extern LocalFileSystem *g_theLocalFileSystem;
-
 TEST(filesystem, win32bigfile)
 {
     g_theLocalFileSystem = new Win32LocalFileSystem;


### PR DESCRIPTION
This is because thyme.lib is not available when in dll mode.
Also removed incorrect declaration its part of the header