### PR TITLE
Fix unsafe Game String copy overlap

### DIFF
--- a/src/game/common/system/unicodestring.cpp
+++ b/src/game/common/system/unicodestring.cpp
@@ -92,7 +92,9 @@ void Utf16String::Ensure_Unique_Buffer_Of_Size(
 
     if (m_data != nullptr && m_data->ref_count == 1 && m_data->num_chars_allocated >= chars_needed) {
         if (str_to_cpy != nullptr) {
-            u_strcpy(Peek(), str_to_cpy);
+            // #BUGFIX Originally uses u_strcpy here. Use memmove to support overlaps gracefully.
+            captainslog_dbgassert(u_strlen(str_to_cpy) == chars_needed - 1, "Length does not match");
+            memmove(Peek(), str_to_cpy, chars_needed * sizeof(value_type));
         }
 
         if (str_to_cat != nullptr) {
@@ -294,7 +296,7 @@ void Utf16String::Concat(const unichar_t *s)
     if (add_len > 0) {
         if (m_data != nullptr) {
             const size_type cur_len = static_cast<size_type>(u_strlen(Peek()));
-            Ensure_Unique_Buffer_Of_Size(cur_len + add_len + 1, true, 0, s);
+            Ensure_Unique_Buffer_Of_Size(cur_len + add_len + 1, true, nullptr, s);
         } else {
             Set(s);
         }

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -122,10 +122,6 @@ public:
     const unichar_t *Peek() const;
     unichar_t *Peek();
     void Release_Buffer();
-    void Ensure_Unique_Buffer_Of_Size(size_type chars_needed,
-        bool keep_data = false,
-        const unichar_t *str_to_cpy = nullptr,
-        const unichar_t *str_to_cat = nullptr);
     size_type Get_Length() const;
     void Clear();
     unichar_t Get_Char(size_type index) const;
@@ -191,6 +187,11 @@ public:
 
 private:
     void Translate_Internal(const char *utf8_string, const size_type utf8_len);
+
+    void Ensure_Unique_Buffer_Of_Size(size_type chars_needed,
+        bool keep_data = false,
+        const unichar_t *str_to_cpy = nullptr,
+        const unichar_t *str_to_cat = nullptr);
 
     UnicodeStringData *m_data;
 };


### PR DESCRIPTION
```
==3131301==ERROR: AddressSanitizer: strcpy-param-overlap: memory ranges [0x7f54d3846bf0,0x7f54d3846c07) and [0x7f54d3846bf4, 0x7f54d3846c0b) overlap
    #0 0x7f54dc95a3e6 in __interceptor_strcpy ../../../../src/libsanitizer/asan/asan_interceptors.cpp:438
    #1 0x55b2dbc78589 in Utf8String::Ensure_Unique_Buffer_Of_Size(int, bool, char const*, char const*) /home/mbits/Development/Thyme/src/game/common/system/asciistring.cpp:112
    #2 0x55b2dbc78a36 in Utf8String::Set(char const*) /home/mbits/Development/Thyme/src/game/common/system/asciistring.cpp:217
    #3 0x55b2dbc7a871 in Utf8String::Next_Token(Utf8String*, char const*) /home/mbits/Development/Thyme/src/game/common/system/asciistring.cpp:645
```

Original implementation is no problem the way it is used. The problem triggered by Address Sanitizer is a false positive, but we can treat it anyway with the `memmove` as suggested and make it more robust.