### PR TITLE
Remove ArrayDef macro and cleanup of Make_Global

### DIFF
--- a/src/game/client/shadermanager.h
+++ b/src/game/client/shadermanager.h
@@ -111,7 +111,7 @@ private:
     static w3dsurface_t s_newRenderSurface;
     static w3dsurface_t s_oldDepthSurface;
 #ifdef GAME_DLL
-    static ARRAY_DEC(TextureClass *, s_textures, MAX_TEXTURE_STAGES);
+    static TextureClass *(&s_textures)[MAX_TEXTURE_STAGES];
     static bool &s_renderingToTexture;
     static ShaderTypes &s_currentShader;
 #else

--- a/src/game/client/water.h
+++ b/src/game/client/water.h
@@ -79,7 +79,7 @@ private:
 };
 
 #ifdef GAME_DLL
-extern ARRAY_DEC(WaterSetting, g_waterSettings, TIME_OF_DAY_COUNT);
+extern WaterSetting (&g_waterSettings)[TIME_OF_DAY_COUNT];
 extern Override<WaterTransparencySetting> &g_theWaterTransparency;
 #else
 extern WaterSetting g_waterSettings[TIME_OF_DAY_COUNT];

--- a/src/game/client/worldheightmap.h
+++ b/src/game/client/worldheightmap.h
@@ -182,7 +182,7 @@ public:
     }
 
 #ifdef GAME_DLL
-    static ARRAY_DEC(TileData *, s_alphaTiles, 12);
+    static TileData *(&s_alphaTiles)[12];
 #else
     static TileData *s_alphaTiles[12];
 #endif

--- a/src/hooker/hooker.h
+++ b/src/hooker/hooker.h
@@ -150,8 +150,3 @@ template<typename T> void Hook_Method(uintptr_t in, T out)
       __asm push in                         \
       __asm call Hook_Func     \
       __asm add esp, 8 }
-
-#define ARRAY_DEC(type, var, size) type(&var)[size]
-#define ARRAY_DEF(address, type, var, size) type(&var)[size] = Make_Global<type[size]>(address);
-#define ARRAY2D_DEC(type, var, x, y) type(&var)[x][y]
-#define ARRAY2D_DEF(address, type, var, x, y) type(&var)[x][y] = Make_Global<type[x][y]>(address);

--- a/src/hooker/hooker.h
+++ b/src/hooker/hooker.h
@@ -44,10 +44,12 @@
 // the correct type and address. This should not change from run to run if the
 // exe loads at a standard base address.
 
-// Typical use will be to use define to create a friendly name, e.g:
-// #define SomeGlobalVar (Make_Global<bool>(0x00FF00FF))
+// Typical use will:
+// bool &SomeGlobalVar = Make_Global<bool>(0x00FF00FF);
+// bool (&SomeGlobalVar2)[32] = Make_Global<bool[32]>(0x00FF00FF);
 // allows you to use SomeGlobalVar as though it was a bool you declared, though
 // it will reflect the value the original exe sees at address 0x00FF00FF
+// Likewise for SomeGlobalVar2 when it is an array.
 template<typename T> __forceinline T &Make_Global(const uintptr_t address)
 {
     return *reinterpret_cast<T *>(address);

--- a/src/hooker/setupglobals_zh.cpp
+++ b/src/hooker/setupglobals_zh.cpp
@@ -647,3 +647,7 @@ int &Drawable::s_modelLockCount = Make_Global<int>(PICK_ADDRESS(0x00A2B920, 0x00
 // imemanagerinterface.cpp
 class IMEManagerInterface;
 IMEManagerInterface *&g_theIMEManager = Make_Global<IMEManagerInterface *>(PICK_ADDRESS(0x00A29B8C, 0));
+
+// systimer.cpp
+#include "systimer.h"
+SysTimeClass &g_theSysTimer = Make_Global<SysTimeClass>(0x00A66B30);

--- a/src/hooker/setupglobals_zh.cpp
+++ b/src/hooker/setupglobals_zh.cpp
@@ -55,7 +55,8 @@ uint32_t &View::s_idNext = Make_Global<uint32_t>(PICK_ADDRESS(0x009D4178, 0));
 
 // water.cpp
 #include "water.h"
-ARRAY_DEF(PICK_ADDRESS(0x00A2F0B8, 0x00A2F0B8), WaterSetting, g_waterSettings, TIME_OF_DAY_COUNT);
+WaterSetting (&g_waterSettings)[TIME_OF_DAY_COUNT] = Make_Global<WaterSetting[TIME_OF_DAY_COUNT]>(
+    PICK_ADDRESS(0x00A2F0B8, 0x00A2F0B8));
 Override<WaterTransparencySetting> &g_theWaterTransparency =
     Make_Global<Override<WaterTransparencySetting>>(PICK_ADDRESS(0x00A2F0B0, 0x00A2F0B0));
 
@@ -252,13 +253,15 @@ IDirect3D8 *(__stdcall *&DX8Wrapper::s_d3dCreateFunction)(unsigned) = Make_Globa
 HMODULE &DX8Wrapper::s_d3dLib = Make_Global<HMODULE>(PICK_ADDRESS(0x00A47F70, 0x00DEE7A8));
 IDirect3D8 *&DX8Wrapper::s_d3dInterface = Make_Global<IDirect3D8 *>(PICK_ADDRESS(0x00A47EEC, 0x00DEE724));
 IDirect3DDevice8 *&DX8Wrapper::s_d3dDevice = Make_Global<IDirect3DDevice8 *>(PICK_ADDRESS(0x00A47EF0, 0x00DEE728));
-ARRAY_DEF(PICK_ADDRESS(0x00A42784, 0x00DE8FBC), w3dbasetexture_t, DX8Wrapper::s_textures, MAX_TEXTURE_STAGES);
+w3dbasetexture_t (&DX8Wrapper::s_textures)[MAX_TEXTURE_STAGES] = Make_Global<w3dbasetexture_t[MAX_TEXTURE_STAGES]>(
+    PICK_ADDRESS(0x00A42784, 0x00DE8FBC));
 void *&DX8Wrapper::s_shadowMap = Make_Global<void *>(PICK_ADDRESS(0x00A47EBC, 0x00DEE6F4));
 HWND &DX8Wrapper::s_hwnd = Make_Global<HWND>(PICK_ADDRESS(0x00A47EC4, 0x00DEE6FC));
-ARRAY_DEF(PICK_ADDRESS(0x00A46CC0, 0x00DED4F8), unsigned, DX8Wrapper::s_renderStates, 256);
-ARRAY2D_DEF(PICK_ADDRESS(0x00A46880, 0x00DED0B8), unsigned, DX8Wrapper::s_textureStageStates, MAX_TEXTURE_STAGES, 32);
-ARRAY_DEF(PICK_ADDRESS(0x00A47778, 0x00DEDFB0), Vector4, DX8Wrapper::s_vertexShaderConstants, 96);
-ARRAY_DEF(PICK_ADDRESS(0x00A427C0, 0x00DE8FF8), unsigned, DX8Wrapper::s_pixelShaderConstants, 32);
+unsigned (&DX8Wrapper::s_renderStates)[256] = Make_Global<unsigned[256]>(PICK_ADDRESS(0x00A46CC0, 0x00DED4F8));
+unsigned (&DX8Wrapper::s_textureStageStates)[MAX_TEXTURE_STAGES][32] = Make_Global<unsigned[MAX_TEXTURE_STAGES][32]>(
+    PICK_ADDRESS(0x00A46880, 0x00DED0B8));
+Vector4 (&DX8Wrapper::s_vertexShaderConstants)[96] = Make_Global<Vector4[96]>(PICK_ADDRESS(0x00A47778, 0x00DEDFB0));
+unsigned (&DX8Wrapper::s_pixelShaderConstants)[32] = Make_Global<unsigned[32]>(PICK_ADDRESS(0x00A427C0, 0x00DE8FF8));
 bool &DX8Wrapper::s_isInitialised = Make_Global<bool>(PICK_ADDRESS(0x00A47EC8, 0x00DEE700));
 bool &DX8Wrapper::s_isWindowed = Make_Global<bool>(PICK_ADDRESS(0x00A47EC9, 0x00DEE701));
 bool &DX8Wrapper::s_debugIsWindowed = Make_Global<bool>(PICK_ADDRESS(0x00A15CD8, 0x00CC36B8));
@@ -274,7 +277,7 @@ int &DX8Wrapper::s_resolutionWidth = Make_Global<int>(PICK_ADDRESS(0x00A15CE0, 0
 int &DX8Wrapper::s_resolutionHeight = Make_Global<int>(PICK_ADDRESS(0x00A15CE4, 0x00CC36C4));
 int &DX8Wrapper::s_bitDepth = Make_Global<int>(PICK_ADDRESS(0x00A15CE8, 0x00CC36C8));
 int &DX8Wrapper::s_textureBitDepth = Make_Global<int>(PICK_ADDRESS(0x00A15CEC, 0x00CC36CC));
-ARRAY_DEF(PICK_ADDRESS(0x00A4277C, 0x00DE8FB4), bool, DX8Wrapper::s_currentLightEnables, 4);
+bool (&DX8Wrapper::s_currentLightEnables)[4] = Make_Global<bool[4]>(PICK_ADDRESS(0x00A4277C, 0x00DE8FB4));
 unsigned &DX8Wrapper::s_matrixChanges = Make_Global<unsigned>(PICK_ADDRESS(0x00A47F08, 0x00DEE740));
 unsigned &DX8Wrapper::s_materialChanges = Make_Global<unsigned>(PICK_ADDRESS(0x00A47F0C, 0x00DEE744));
 unsigned &DX8Wrapper::s_vertexBufferChanges = Make_Global<unsigned>(PICK_ADDRESS(0x00A47F10, 0x00DEE748));
@@ -302,7 +305,7 @@ DynamicVectorClass<StringClass> &DX8Wrapper::s_renderDeviceShortNameTable =
 DynamicVectorClass<RenderDeviceDescClass> &DX8Wrapper::s_renderDeviceDescriptionTable =
     Make_Global<DynamicVectorClass<RenderDeviceDescClass>>(PICK_ADDRESS(0x00A427A8, 0x00DE8FE0));
 w3dadapterid_t &DX8Wrapper::s_currentAdapterIdentifier = Make_Global<w3dadapterid_t>(PICK_ADDRESS(0x00A470C0, 0x00DED8F8));
-ARRAY_DEF(PICK_ADDRESS(0x00A42840, 0x00DE9078), Matrix4, DX8Wrapper::s_DX8Transforms, 257);
+Matrix4 (&DX8Wrapper::s_DX8Transforms)[257] = Make_Global<Matrix4[257]>(PICK_ADDRESS(0x00A42840, 0x00DE9078));
 D3DMATRIX &DX8Wrapper::s_oldPrj = Make_Global<D3DMATRIX>(PICK_ADDRESS(0x00A46C80, 0x00DED4B8));
 D3DMATRIX &DX8Wrapper::s_oldView = Make_Global<D3DMATRIX>(PICK_ADDRESS(0x00A47D78, 0x00DEE5B0));
 D3DMATRIX &DX8Wrapper::s_oldWorld = Make_Global<D3DMATRIX>(PICK_ADDRESS(0x00A47E78, 0x00DEE6B0));
@@ -427,8 +430,9 @@ HOOK_AUTOPOOL(MatPassTaskClass, 256, PICK_ADDRESS(0x00A4C468, 0x00DEEB78));
 float &PredictiveLODOptimizerClass::s_TotalCost = Make_Global<float>(PICK_ADDRESS(0x00A480AC, 0x00DEEB04));
 
 // w3dformat.cpp
-ARRAY_DEF(PICK_ADDRESS(0x00A5243C, 0x00DF6B20), WW3DFormat, g_D3DFormatToWW3DFormatConversionArray, 63);
-ARRAY_DEF(PICK_ADDRESS(0x00A522FC, 0x00DF69E0), WW3DZFormat, g_D3DFormatToWW3DZFormatConversionArray, 80);
+WW3DFormat (&g_D3DFormatToWW3DFormatConversionArray)[63] = Make_Global<WW3DFormat[63]>(PICK_ADDRESS(0x00A5243C, 0x00DF6B20));
+WW3DZFormat (&g_D3DFormatToWW3DZFormatConversionArray)[80] = Make_Global<WW3DZFormat[80]>(
+    PICK_ADDRESS(0x00A522FC, 0x00DF69E0));
 
 // wwstring.cpp
 #include "wwstring.h"
@@ -448,7 +452,8 @@ DrawGroupInfo *&g_theDrawGroupInfo = Make_Global<DrawGroupInfo *>(PICK_ADDRESS(0
 
 // shadermanager.cpp
 #include "shadermanager.h"
-ARRAY_DEF(PICK_ADDRESS(0x00A3AB20, 0x00E1A7C8), TextureClass *, W3DShaderManager::s_textures, MAX_TEXTURE_STAGES);
+TextureClass *(&W3DShaderManager::s_textures)[MAX_TEXTURE_STAGES] = Make_Global<TextureClass *[MAX_TEXTURE_STAGES]>(
+    PICK_ADDRESS(0x00A3AB20, 0x00E1A7C8));
 bool &W3DShaderManager::s_renderingToTexture = Make_Global<bool>(PICK_ADDRESS(0x00A3AB98, 0x00E1A840));
 W3DShaderManager::ShaderTypes &W3DShaderManager::s_currentShader =
     Make_Global<ShaderTypes>(PICK_ADDRESS(0x00A3AA80, 0x00E1A728));
@@ -474,7 +479,7 @@ RayEffectSystem *&g_theRayEffects = Make_Global<RayEffectSystem *>(PICK_ADDRESS(
 // win32mouse.cpp
 #include "win32mouse.h"
 Win32Mouse *&g_theWin32Mouse = Make_Global<Win32Mouse *>(PICK_ADDRESS(0x00A27B10, 0));
-ARRAY2D_DEF(PICK_ADDRESS(0x00A31F00, 0), HCURSOR, Win32Mouse::s_loadedCursors, CURSOR_COUNT, 8);
+HCURSOR (&Win32Mouse::s_loadedCursors)[CURSOR_COUNT][8] = Make_Global<HCURSOR[CURSOR_COUNT][8]>(PICK_ADDRESS(0x00A31F00, 0));
 
 // globallanguage.cpp
 class FontLibrary;
@@ -488,11 +493,11 @@ View *&g_theTacticalView = Make_Global<View *>(PICK_ADDRESS(0x00A2B684, 0x00E23A
 #include "w3dmouse.h"
 MouseThreadClass &W3DMouse::s_mouseThread = Make_Global<MouseThreadClass>(0x00A3B370);
 bool &W3DMouse::s_mouseThreadIsDrawing = Make_Global<bool>(0x00A3B3C8);
-ARRAY_DEF(0x00A3B18C, HAnimClass *, W3DMouse::s_W3DMouseAssets1, CURSOR_COUNT);
-ARRAY_DEF(0x00A3B22C, RenderObjClass *, W3DMouse::s_W3DMouseAssets2, CURSOR_COUNT);
-ARRAY2D_DEF(
-    0x00A3B3D8, TextureBaseClass *, W3DMouse::s_D3DMouseAssets, CURSOR_COUNT, W3DMouse::MAX_FRAMES); // TODO unsure on type
-ARRAY_DEF(0x00A3B2CC, uint32_t, W3DMouse::s_PolyMouseAssets, CURSOR_COUNT); // unsure on type
+HAnimClass *(&W3DMouse::s_W3DMouseAssets1)[CURSOR_COUNT] = Make_Global<HAnimClass *[CURSOR_COUNT]>(0x00A3B18C);
+RenderObjClass *(&W3DMouse::s_W3DMouseAssets2)[CURSOR_COUNT] = Make_Global<RenderObjClass *[CURSOR_COUNT]>(0x00A3B22C);
+TextureBaseClass *(&W3DMouse::s_D3DMouseAssets)[CURSOR_COUNT][W3DMouse::MAX_FRAMES] =
+    Make_Global<TextureBaseClass *[CURSOR_COUNT][W3DMouse::MAX_FRAMES]>(0x00A3B3D8); // TODO unsure on type
+uint32_t (&W3DMouse::s_PolyMouseAssets)[CURSOR_COUNT] = Make_Global<uint32_t[CURSOR_COUNT]>(0x00A3B2CC); // unsure on type
 CriticalSectionClass &g_mouseCriticalSection = Make_Global<CriticalSectionClass>(0x00A3B3D0);
 
 // w3ddisplay.cpp
@@ -520,10 +525,8 @@ Display *&g_theDisplay = Make_Global<Display *>(PICK_ADDRESS(0x00A2A6D0, 0));
 
 // vertmaterial.cpp
 #include "vertmaterial.h"
-ARRAY_DEF(PICK_ADDRESS(0x00A4C1FC, 0x00DE8E38),
-    VertexMaterialClass *,
-    VertexMaterialClass::s_presets,
-    VertexMaterialClass::PRESET_COUNT);
+VertexMaterialClass *(&VertexMaterialClass::s_presets)[VertexMaterialClass::PRESET_COUNT] =
+    Make_Global<VertexMaterialClass * [VertexMaterialClass::PRESET_COUNT]>(PICK_ADDRESS(0x00A4C1FC, 0x00DE8E38));
 
 // w3dsmudge.cpp
 #include "w3dsmudge.h"
@@ -599,7 +602,7 @@ int &g_drawEdgeY = Make_Global<int>(0x00A3ACDC);
 
 // worldheightmap.cpp
 #include "worldheightmap.h"
-ARRAY_DEF(0x00A3A96C, TileData *, WorldHeightMap::s_alphaTiles, 12);
+TileData *(&WorldHeightMap::s_alphaTiles)[12] = Make_Global<TileData *[12]>(0x00A3A96C);
 
 // w3dfilesystem.cpp
 class W3DFileSystem;

--- a/src/platform/input/win32mouse.h
+++ b/src/platform/input/win32mouse.h
@@ -58,7 +58,7 @@ private:
     };
 #ifdef PLATFORM_WINDOWS
 #ifdef GAME_DLL
-    static ARRAY2D_DEC(HCURSOR, s_loadedCursors, CURSOR_COUNT, 8);
+    static HCURSOR (&s_loadedCursors)[CURSOR_COUNT][8];
 #else
     static HCURSOR s_loadedCursors[CURSOR_COUNT][8];
 #endif

--- a/src/platform/w3dengine/client/w3dmouse.h
+++ b/src/platform/w3dengine/client/w3dmouse.h
@@ -72,10 +72,10 @@ private:
 #ifdef GAME_DLL
     static MouseThreadClass &s_mouseThread;
     static bool &s_mouseThreadIsDrawing;
-    static ARRAY_DEC(HAnimClass *, s_W3DMouseAssets1, CURSOR_COUNT);
-    static ARRAY_DEC(RenderObjClass *, s_W3DMouseAssets2, CURSOR_COUNT);
-    static ARRAY2D_DEC(TextureBaseClass *, s_D3DMouseAssets, CURSOR_COUNT, MAX_FRAMES); // TODO unsure on type
-    static ARRAY_DEC(uint32_t, s_PolyMouseAssets, CURSOR_COUNT);
+    static HAnimClass *(&s_W3DMouseAssets1)[CURSOR_COUNT];
+    static RenderObjClass *(&s_W3DMouseAssets2)[CURSOR_COUNT];
+    static TextureBaseClass *(&s_D3DMouseAssets)[CURSOR_COUNT][MAX_FRAMES]; // TODO unsure on type
+    static uint32_t (&s_PolyMouseAssets)[CURSOR_COUNT];
 #else
     static MouseThreadClass s_mouseThread;
     static bool s_mouseThreadIsDrawing;

--- a/src/w3d/lib/systimer.cpp
+++ b/src/w3d/lib/systimer.cpp
@@ -13,8 +13,10 @@
  *            LICENSE
  */
 #include "systimer.h"
-#include "hooker.h"
 #include "rtsutils.h"
+#ifdef GAME_DLL
+#include "hooker.h"
+#endif
 
 #ifndef GAME_DLL
 SysTimeClass g_theSysTimer;

--- a/src/w3d/lib/systimer.cpp
+++ b/src/w3d/lib/systimer.cpp
@@ -13,6 +13,7 @@
  *            LICENSE
  */
 #include "systimer.h"
+#include "hooker.h"
 #include "rtsutils.h"
 
 #ifndef GAME_DLL
@@ -28,7 +29,7 @@ void SysTimeClass::Reset()
 int SysTimeClass::Get()
 {
 #ifdef GAME_DLL
-#define _is_init (Make_Global<bool>(0x00A66B30))
+    bool &_is_init = Make_Global<bool>(0x00A66B30);
 #else
     static bool _is_init;
 #endif

--- a/src/w3d/lib/systimer.h
+++ b/src/w3d/lib/systimer.h
@@ -54,10 +54,7 @@ inline SysTimeClass::~SysTimeClass()
 }
 
 #ifdef GAME_DLL
-#include "hooker.h"
-
-// This needs to stay here like this to avoid static init issues in cpudetect.
-#define g_theSysTimer (Make_Global<SysTimeClass>(0x00A66B30))
+extern SysTimeClass &g_theSysTimer;
 #else
 extern SysTimeClass g_theSysTimer;
 #endif

--- a/src/w3d/lib/thread.cpp
+++ b/src/w3d/lib/thread.cpp
@@ -28,7 +28,7 @@ using std::strcpy;
 #include <synchapi.h>
 #ifdef GAME_DLL
 #include "hooker.h"
-#define test_event (Make_Global<void *>(0x00A65178))
+void *&test_event = Make_Global<void *>(0x00A65178);
 #else
 void *test_event = CreateEventA(nullptr, FALSE, FALSE, "");
 #endif

--- a/src/w3d/renderer/dx8wrapper.h
+++ b/src/w3d/renderer/dx8wrapper.h
@@ -306,15 +306,15 @@ protected:
     static D3DCOLOR &s_fogColor;
     static D3DFORMAT &s_displayFormat;
 #endif
-    static ARRAY_DEC(w3dbasetexture_t, s_textures, MAX_TEXTURE_STAGES);
+    static w3dbasetexture_t (&s_textures)[MAX_TEXTURE_STAGES];
 #ifdef PLATFORM_WINDOWS
     static HWND &s_hwnd;
 #endif
     static void *&s_shadowMap;
-    static ARRAY_DEC(unsigned, s_renderStates, 256);
-    static ARRAY2D_DEC(unsigned, s_textureStageStates, MAX_TEXTURE_STAGES, 32);
-    static ARRAY_DEC(Vector4, s_vertexShaderConstants, 96);
-    static ARRAY_DEC(unsigned, s_pixelShaderConstants, 32);
+    static unsigned (&s_renderStates)[256];
+    static unsigned (&s_textureStageStates)[MAX_TEXTURE_STAGES][32];
+    static Vector4 (&s_vertexShaderConstants)[96];
+    static unsigned (&s_pixelShaderConstants)[32];
     static bool &s_isInitialised;
     static bool &s_isWindowed;
     static bool &s_debugIsWindowed;
@@ -330,7 +330,7 @@ protected:
     static int &s_resolutionHeight;
     static int &s_bitDepth;
     static int &s_textureBitDepth;
-    static ARRAY_DEC(bool, s_currentLightEnables, GFX_LIGHT_COUNT);
+    static bool (&s_currentLightEnables)[GFX_LIGHT_COUNT];
     static unsigned &s_matrixChanges;
     static unsigned &s_materialChanges;
     static unsigned &s_vertexBufferChanges;
@@ -354,7 +354,7 @@ protected:
     static DynamicVectorClass<StringClass> &s_renderDeviceShortNameTable;
     static DynamicVectorClass<RenderDeviceDescClass> &s_renderDeviceDescriptionTable;
     static w3dadapterid_t &s_currentAdapterIdentifier;
-    static ARRAY_DEC(Matrix4, s_DX8Transforms, 257);
+    static Matrix4 (&s_DX8Transforms)[257];
     static bool &s_EnableTriangleDraw;
     static int &s_ZBias;
     static Vector3 &s_ambientColor;

--- a/src/w3d/renderer/texture.cpp
+++ b/src/w3d/renderer/texture.cpp
@@ -23,21 +23,12 @@
 #include <cstring>
 
 #ifdef GAME_DLL
-ARRAY2D_DEF(PICK_ADDRESS(0x00A4C284, 0x00DF68D8),
-    unsigned,
-    g_minTextureFilters,
-    MAX_TEXTURE_STAGES,
-    TextureFilterClass::FILTER_TYPE_COUNT);
-ARRAY2D_DEF(PICK_ADDRESS(0x00A4C304, 0x00DF6958),
-    unsigned,
-    g_magTextureFilters,
-    MAX_TEXTURE_STAGES,
-    TextureFilterClass::FILTER_TYPE_COUNT);
-ARRAY2D_DEF(PICK_ADDRESS(0x00A4C204, 0x00DF6858),
-    unsigned,
-    g_mipMapFilters,
-    MAX_TEXTURE_STAGES,
-    TextureFilterClass::FILTER_TYPE_COUNT);
+unsigned (&g_minTextureFilters)[MAX_TEXTURE_STAGES][TextureFilterClass::FILTER_TYPE_COUNT] =
+    Make_Global<unsigned[MAX_TEXTURE_STAGES][TextureFilterClass::FILTER_TYPE_COUNT]>(PICK_ADDRESS(0x00A4C284, 0x00DF68D8));
+unsigned (&g_magTextureFilters)[MAX_TEXTURE_STAGES][TextureFilterClass::FILTER_TYPE_COUNT] =
+    Make_Global<unsigned[MAX_TEXTURE_STAGES][TextureFilterClass::FILTER_TYPE_COUNT]>(PICK_ADDRESS(0x00A4C304, 0x00DF6958));
+unsigned (&g_mipMapFilters)[MAX_TEXTURE_STAGES][TextureFilterClass::FILTER_TYPE_COUNT] =
+    Make_Global<unsigned[MAX_TEXTURE_STAGES][TextureFilterClass::FILTER_TYPE_COUNT]>(PICK_ADDRESS(0x00A4C204, 0x00DF6858));
 #else
 static unsigned g_minTextureFilters[MAX_TEXTURE_STAGES][TextureFilterClass::FILTER_TYPE_COUNT];
 static unsigned g_magTextureFilters[MAX_TEXTURE_STAGES][TextureFilterClass::FILTER_TYPE_COUNT];

--- a/src/w3d/renderer/vertmaterial.h
+++ b/src/w3d/renderer/vertmaterial.h
@@ -202,7 +202,7 @@ private:
     unsigned long Compute_CRC() const;
 
 #ifdef GAME_DLL
-    static ARRAY_DEC(VertexMaterialClass *, s_presets, PRESET_COUNT);
+    static VertexMaterialClass *(&s_presets)[PRESET_COUNT];
 #else
     static VertexMaterialClass *s_presets[PRESET_COUNT];
 #endif

--- a/src/w3d/renderer/w3dformat.h
+++ b/src/w3d/renderer/w3dformat.h
@@ -192,8 +192,8 @@ inline bool Is_Compressed(WW3DFormat format)
 
 #ifdef GAME_DLL
 #include "hooker.h"
-extern ARRAY_DEC(WW3DFormat, g_D3DFormatToWW3DFormatConversionArray, 63);
-extern ARRAY_DEC(WW3DZFormat, g_D3DFormatToWW3DZFormatConversionArray, 80);
+extern WW3DFormat (&g_D3DFormatToWW3DFormatConversionArray)[63];
+extern WW3DZFormat (&g_D3DFormatToWW3DZFormatConversionArray)[80];
 #else
 extern WW3DFormat g_D3DFormatToWW3DFormatConversionArray[63];
 extern WW3DZFormat g_D3DFormatToWW3DZFormatConversionArray[80];


### PR DESCRIPTION
I used a regex to find/replace the ArrayDefs with the equivalent Make_Global code.
I also noticed that two users of Make_Global were from a very old version where a macro was used for the identifier name. I've brought those into normal alignment.
One item of note whilst doing this is that we have a handful of Make_Globals outside of the setupglobals file.
Unsure if they should all be moved into setupglobals.