### PR TITLE
Fix W3D Overlord tint crash

### DIFF
--- a/src/game/client/draw/w3doverlordaircraftdraw.cpp
+++ b/src/game/client/draw/w3doverlordaircraftdraw.cpp
@@ -47,7 +47,9 @@ void W3DOverlordAircraftDraw::Do_Draw_Module(const Matrix3D *transform)
 
             if (rider->Get_Drawable() != nullptr) {
                 Drawable *drawable = rider->Get_Drawable();
-                drawable->Set_Tint_Color_Envelope(Get_Drawable()->Get_Tint_Color_Envelope());
+                if (const TintEnvelope *envelope = Get_Drawable()->Get_Tint_Color_Envelope()) {
+                    drawable->Set_Tint_Color_Envelope(envelope);
+                }
                 drawable->Notify_Drawable_Dependency_Cleared();
                 drawable->Draw(nullptr);
             } else {

--- a/src/game/client/draw/w3doverlordtankdraw.cpp
+++ b/src/game/client/draw/w3doverlordtankdraw.cpp
@@ -46,7 +46,9 @@ void W3DOverlordTankDraw::Do_Draw_Module(const Matrix3D *transform)
         if (rider != nullptr) {
             if (rider->Get_Drawable() != nullptr) {
                 Drawable *drawable = rider->Get_Drawable();
-                drawable->Set_Tint_Color_Envelope(Get_Drawable()->Get_Tint_Color_Envelope());
+                if (const TintEnvelope *envelope = Get_Drawable()->Get_Tint_Color_Envelope()) {
+                    drawable->Set_Tint_Color_Envelope(envelope);
+                }
                 drawable->Notify_Drawable_Dependency_Cleared();
                 drawable->Draw(nullptr);
             }

--- a/src/game/client/draw/w3doverlordtruckdraw.cpp
+++ b/src/game/client/draw/w3doverlordtruckdraw.cpp
@@ -46,7 +46,9 @@ void W3DOverlordTruckDraw::Do_Draw_Module(const Matrix3D *transform)
         if (rider != nullptr) {
             if (rider->Get_Drawable() != nullptr) {
                 Drawable *drawable = rider->Get_Drawable();
-                drawable->Set_Tint_Color_Envelope(Get_Drawable()->Get_Tint_Color_Envelope());
+                if (const TintEnvelope *envelope = Get_Drawable()->Get_Tint_Color_Envelope()) {
+                    drawable->Set_Tint_Color_Envelope(envelope);
+                }
                 drawable->Notify_Drawable_Dependency_Cleared();
                 drawable->Draw(nullptr);
             }


### PR DESCRIPTION
Game crashed when spawning the Spectre Gunship.