### PR TITLE
Cleans up ifdefs for posix header strings.h.

### DIFF
--- a/deps/baseconfig/CMakeLists.txt
+++ b/deps/baseconfig/CMakeLists.txt
@@ -148,6 +148,11 @@ if(WIN32 OR "${CMAKE_SYSTEM}" MATCHES "Windows")
     endif()
 endif()
 
+if(NOT HAVE_STRINGS_H)
+    target_sources(base PRIVATE src/strings/strings.h)
+    target_include_directories(base PUBLIC src/strings)
+endif()
+
 # We don't need to link anything if we have win32 threads. Affects MinGW builds primarily.
 if(CMAKE_USE_PTHREADS_INIT AND NOT CMAKE_USE_WIN32_THREADS_INIT)
     target_link_libraries(base Threads::Threads)

--- a/deps/baseconfig/src/always.h
+++ b/deps/baseconfig/src/always.h
@@ -45,14 +45,6 @@
 
 // Based on the build system generated config.h information we define some stuff here
 // for cross platform consistency.
-#if defined HAVE__STRICMP && !defined HAVE_STRCASECMP
-#define strcasecmp _stricmp
-#endif
-
-#if defined HAVE__STRNICMP && !defined HAVE_STRNCASECMP
-#define strncasecmp _strnicmp
-#endif
-
 #ifndef HAVE_STRLWR
 #define strlwr ex_strlwr
 #endif

--- a/deps/baseconfig/src/strings/strings.h
+++ b/deps/baseconfig/src/strings/strings.h
@@ -1,0 +1,31 @@
+
+#ifndef BASECONFIG_STRINGS_H
+#define BASECONFIG_STRINGS_H
+
+#include "config.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif /* __cplusplus */
+
+#ifndef HAVE_STRCASECMP
+#ifdef HAVE__STRICMP
+#define strcasecmp(s1, s2) _stricmp(s1, s2)
+#else
+#error "strcasecmp equivalent not known for this platform."
+#endif
+#endif
+
+#ifndef HAVE_STRNCASECMP
+#ifdef HAVE__STRNICMP
+#define strncasecmp(s1, s2, n) _strnicmp(s1, s2, n)
+#else
+#error "strncasecmp equivalent not known for this platform."
+#endif
+#endif
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* BASECONFIG_STRINGS_H */

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -19,6 +19,7 @@
 #include <cstddef>
 #include <cstring>
 #include <new>
+#include <strings.h>
 
 // Using STLPort seems to screw up some of the C++11 header inclusions.
 #ifndef GAME_DLL

--- a/src/game/common/system/gamememoryinit.cpp
+++ b/src/game/common/system/gamememoryinit.cpp
@@ -17,6 +17,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstring>
+#include <strings.h>
 
 #ifndef PLATFORM_WINDOWS
 #include <libgen.h>

--- a/src/w3d/lib/hash.cpp
+++ b/src/w3d/lib/hash.cpp
@@ -15,10 +15,7 @@
 #include "hash.h"
 #include "crc.h"
 #include <captainslog.h>
-
-#ifdef HAVE_STRINGS_H
 #include <strings.h>
-#endif
 
 /**
  * 0x008A0900

--- a/src/w3d/lib/wwstring.h
+++ b/src/w3d/lib/wwstring.h
@@ -20,6 +20,7 @@
 #include <cstdarg>
 #include <cstring>
 #include <cwchar>
+#include <strings.h>
 
 #ifdef BUILD_WITH_ICU
 #include <unicode/ustring.h>

--- a/src/w3d/renderer/htree.cpp
+++ b/src/w3d/renderer/htree.cpp
@@ -19,6 +19,7 @@
 #include "quaternion.h"
 #include "w3d_file.h"
 #include <cstring>
+#include <strings.h>
 
 using std::memcpy;
 using std::strcpy;


### PR DESCRIPTION
Implements header in baseconfig when not found on the system so it is always available.