### PR TITLE
Cleanup RenderObjClass properly

### DIFF
--- a/src/w3d/renderer/rendobj.cpp
+++ b/src/w3d/renderer/rendobj.cpp
@@ -107,6 +107,16 @@ RenderObjClass &RenderObjClass::RenderObjClass::operator=(const RenderObjClass &
     return *this;
 }
 
+RenderObjClass::~RenderObjClass()
+{
+    if (m_unknown) {
+        delete m_unknown;
+    }
+
+    // BUGFIX Cleanup always to avoid dangling pointers.
+    RenderObjClass::Remove();
+}
+
 float RenderObjClass::Get_Screen_Size(CameraClass &camera)
 {
     Vector3 cam = camera.Get_Position();

--- a/src/w3d/renderer/rendobj.h
+++ b/src/w3d/renderer/rendobj.h
@@ -123,12 +123,7 @@ public:
     RenderObjClass(const RenderObjClass &src);
     RenderObjClass &operator=(const RenderObjClass &that);
 
-    virtual ~RenderObjClass()
-    {
-        if (m_unknown) {
-            delete m_unknown;
-        }
-    }
+    virtual ~RenderObjClass();
 
     virtual RenderObjClass *Clone() const = 0;
     virtual int Class_ID() const { return CLASSID_UNKNOWN; }


### PR DESCRIPTION
Untested. ~~Not applicable for `GAME_DLL` I think, because touches vtable.~~

The idea is call `Remove` function before deletion, to make sure that the deleted object is being disconnected always. If it is not disconnected, then dangling pointer can cause game crash. Essentially this change makes code more robust.