### PR TITLE
Alters how wxWidgets dependency is handled.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -268,8 +268,11 @@ if(NOT wxWidgets_FOUND AND BUILD_TOOLS)
         GIT_SHALLOW     TRUE
     )
     
-    FetchContent_GetProperties(wxWidgets)
     FetchContent_MakeAvailable(wxWidgets)
+    if(IS_DIRECTORY "${wxWidgets_SOURCE_DIR}")
+        set_property(DIRECTORY ${wxWidgets_SOURCE_DIR} PROPERTY EXCLUDE_FROM_ALL YES)
+    endif()
+
     set(wxWidgets_FOUND TRUE)
     set(wxWidgets_LIBRARIES wxcore wxbase wxxrc wxxml wxhtml wxadv)
 


### PR DESCRIPTION
Now excludes wxwidgets targets from being built unless they are used. Should prevent issues with wxWidgets polluting the "install" target with its own files.
Only affects builds where external wxWidgets was not found and library is built as part of the Thyme build.