### PR TITLE
Reverts test for success in dinputkeybd.cpp.

### DIFF
--- a/src/platform/directx/dinputkeybd.cpp
+++ b/src/platform/directx/dinputkeybd.cpp
@@ -127,12 +127,7 @@ void DirectInputKeyboard::Open_Keyboard()
         return;
     }
 
-    if (FAILED(m_inputDevice->Acquire())) {
-        captainslog_error("Failed to acquire device.");
-        Close_Keyboard(); // bugfix, close if fails
-        return;
-    }
-
+    m_inputDevice->Acquire();
     captainslog_info("DirectInput keyboard device initialised successfully.");
 }
 


### PR DESCRIPTION
Reverts a test that checks if Acquire failed and closed the keyboard if it did. Seems this breaks the keyboard input as it doesn't seem to matter if it fails here.