### PR TITLE
Fix compile warning in TurretAI::Update_Turret_AI

### DIFF
--- a/src/game/logic/ai/turretai.cpp
+++ b/src/game/logic/ai/turretai.cpp
@@ -865,7 +865,7 @@ UpdateSleepTime TurretAI::Update_Turret_AI()
         }
 
         if (type > 0) {
-            if (type < time) {
+            if (static_cast<UpdateSleepTime>(type) < time) {
                 time = static_cast<UpdateSleepTime>(type);
             }
         } else {


### PR DESCRIPTION
This change fixes compile warning

src\game\logic\ai\turretai.cpp(868,22): warning C4018: '<': signed/unsigned mismatch
