### PR TITLE
Remove public mutable string functions in Utf8String and Utf16String

### DIFF
--- a/src/game/common/system/archivefile.cpp
+++ b/src/game/common/system/archivefile.cpp
@@ -154,8 +154,8 @@ bool ArchiveFile::Search_String_Matches(Utf8String string, Utf8String search)
         return false;
     }
 
-    const char *cstring = string.Peek();
-    const char *csearch = search.Peek();
+    const char *cstring = string.Str();
+    const char *csearch = search.Str();
 
     // ? is wildcard for a single character.
     // * is wildcard for a run of characters.

--- a/src/game/common/system/asciistring.cpp
+++ b/src/game/common/system/asciistring.cpp
@@ -176,14 +176,6 @@ char Utf8String::Get_Char(size_type index) const
     return Peek()[index];
 }
 
-char &Utf8String::Get_Char(size_type index)
-{
-    captainslog_dbgassert(index >= 0, "Index must be equal or larger than 0.");
-    captainslog_dbgassert(index < Get_Length(), "Index must be smaller than length.");
-
-    return Peek()[index];
-}
-
 /**
  * This is effectively ToString() It is in original code, but never called.
  */

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -103,17 +103,14 @@ public:
     operator const char *() const { return Str(); }
 
     char operator[](size_type index) const { return Get_Char(index); }
-    char &operator[](size_type index) { return Get_Char(index); }
 
     void Validate();
     const char *Peek() const;
-    char *Peek();
     void Release_Buffer();
     size_type Get_Length() const;
 
     void Clear() { Release_Buffer(); }
     char Get_Char(size_type index) const;
-    char &Get_Char(size_type index);
     const char *Str() const;
     char *Get_Buffer_For_Read(size_type len);
     // These two should probably be private with the = operator being the preferred interface?
@@ -194,6 +191,9 @@ public:
     Utf8String *Hook_Ctor1(const char *s) { return new (this) Utf8String(s); }
     Utf8String *Hook_Ctor2(Utf8String const &string) { return new (this) Utf8String(string); }
 #endif
+
+protected:
+    char *Peek();
 
 private:
     void Translate_Internal(const unichar_t *utf16_string, const size_type utf16_len);

--- a/src/game/common/system/datachunk.cpp
+++ b/src/game/common/system/datachunk.cpp
@@ -271,9 +271,10 @@ Utf8String DataChunkInput::Read_AsciiString()
 
     captainslog_dbgassert(m_chunkStack->data_left >= size, "Read past end of chunk reading Utf8String string.");
 
-    m_file->Read(string.Get_Buffer_For_Read(size), size);
+    char *buf = string.Get_Buffer_For_Read(size);
+    m_file->Read(buf, size);
     Decrement_Data_Left(size);
-    string.Peek()[size] = '\0';
+    buf[size] = '\0';
 
     return string;
 }
@@ -305,7 +306,6 @@ Utf16String DataChunkInput::Read_UnicodeString()
     }
 
     Decrement_Data_Left(sizeof(ch) * size);
-    string.Peek()[size] = L'\0';
 
     return string;
 }

--- a/src/game/common/system/datachunktoc.cpp
+++ b/src/game/common/system/datachunktoc.cpp
@@ -111,8 +111,9 @@ void DataChunkTableOfContents::Read(ChunkInputStream &stream)
 
             // If we have a name length, read it and null terminate it.
             if (name_len > 0) {
-                stream.Read(map->m_name.Get_Buffer_For_Read(name_len), name_len);
-                map->m_name.Peek()[name_len] = '\0';
+                char *buf = map->m_name.Get_Buffer_For_Read(name_len);
+                stream.Read(buf, name_len);
+                buf[name_len] = '\0';
             }
 
             stream.Read(&map->m_id, sizeof(map->m_id));

--- a/src/game/common/system/unicodestring.cpp
+++ b/src/game/common/system/unicodestring.cpp
@@ -164,14 +164,6 @@ unichar_t Utf16String::Get_Char(size_type index) const
     return U_CHAR('\0');
 }
 
-unichar_t &Utf16String::Get_Char(size_type index)
-{
-    captainslog_dbgassert(index >= 0, "Index must be equal or larger than 0.");
-    captainslog_dbgassert(index < Get_Length(), "Index must be smaller than length.");
-
-    return m_data->Peek()[index];
-}
-
 const unichar_t *Utf16String::Str() const
 {
     static const unichar_t *TheNullChr = U_CHAR("");

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -116,16 +116,13 @@ public:
     operator const unichar_t *() const { return Str(); }
 
     unichar_t operator[](size_type index) const { return Get_Char(index); }
-    unichar_t &operator[](size_type index) { return Get_Char(index); }
 
     void Validate();
     const unichar_t *Peek() const;
-    unichar_t *Peek();
     void Release_Buffer();
     size_type Get_Length() const;
     void Clear();
     unichar_t Get_Char(size_type index) const;
-    unichar_t &Get_Char(size_type index);
     const unichar_t *Str() const;
     unichar_t *Get_Buffer_For_Read(size_type len);
     void Set(const unichar_t *s);
@@ -184,6 +181,9 @@ public:
 
 public:
     static Utf16String const s_emptyString;
+
+protected:
+    unichar_t *Peek();
 
 private:
     void Translate_Internal(const char *utf8_string, const size_type utf8_len);

--- a/src/game/network/lanapi.cpp
+++ b/src/game/network/lanapi.cpp
@@ -561,7 +561,7 @@ void LANAPI::Send_Message(LANMessage *msg, uint32_t addr)
  *
  * 0x005E1D20
  */
-uint32_t LANAPI::Resolve_IP(Utf8String addr)
+uint32_t LANAPI::Resolve_IP(const Utf8String &addr)
 {
     // No string, no IP.
     if (addr.Is_Empty()) {

--- a/src/game/network/lanapi.h
+++ b/src/game/network/lanapi.h
@@ -88,7 +88,7 @@ public:
 
 private:
     void Send_Message(LANMessage *msg, uint32_t addr);
-    static uint32_t Resolve_IP(Utf8String addr);
+    static uint32_t Resolve_IP(const Utf8String &addr);
 
 private:
     LANPlayer *m_lobbyPlayers;


### PR DESCRIPTION
Make mutable string functions in Utf8String and Utf16String private.

Fix discrepancies with code game.