### PR TITLE
Reduce file string allocations

### DIFF
--- a/src/game/common/system/file.cpp
+++ b/src/game/common/system/file.cpp
@@ -44,7 +44,17 @@ bool Decode_Buffered_File_Mode(int mode, int &buffer_size)
     }
     return false;
 }
+
+// Optimization to reduce string allocations.
+const Utf8String s_defaultFileName("<no file>");
+
 } // namespace Thyme
+
+File::File() : m_access(0), m_open(false), m_deleteOnClose(false)
+{
+    // Set_Name("<no file>");
+    m_name = Thyme::s_defaultFileName;
+}
 
 File::~File()
 {
@@ -93,7 +103,8 @@ bool File::Open(const char *filename, int mode)
 void File::Close()
 {
     if (m_open) {
-        Set_Name("<no file>");
+        // Set_Name("<no file>");
+        m_name = Thyme::s_defaultFileName;
         m_open = false;
 
         if (m_deleteOnClose) {

--- a/src/game/common/system/file.h
+++ b/src/game/common/system/file.h
@@ -95,7 +95,7 @@ public:
     void Delete_On_Close() { m_deleteOnClose = true; }
 
 protected:
-    File() : m_access(0), m_open(false), m_deleteOnClose(false) { Set_Name("<no file>"); }
+    File();
 
 protected:
     Utf8String m_name;


### PR DESCRIPTION
Reduces unnecessary string allocations in file class. Optimization.

The way it works is `Utf8String` is reference counted. So by having a static string, constructor can borrow this static and simply increase its ref count when assigning it. It no longer needs to allocate this `"<no file>"` string, effectively elimitating 1 wasted allocation per file open.