### PR TITLE
Integrate tracy

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ endif()
 option(STANDALONE "Build a standalone version." ${DEFAULT_STANDALONE})
 option(USE_GAMEMATH "Use own maths library rather than libc version for this platform." ON)
 option(USE_FFMPEG "Use FFMPEG for codec handling." ${DEFAULT_FFMPEG})
+option(USE_TRACY "Use Tracy for profiling." OFF)
 option(LOGGING "Enable debug logging." ${DEFAULT_LOGGING})
 option(ASSERTIONS "Enable debug assertions." ${DEFAULT_ASSERTIONS})
 option(USE_CRASHPAD "Enable the use of the Crashpad library for crash handling and reporting." OFF)
@@ -256,6 +257,21 @@ endif()
 
 if(USE_FFMPEG)
     find_package(FFmpeg COMPONENTS AVFORMAT AVCODEC AVUTIL REQUIRED)
+endif()
+
+if(USE_TRACY)
+    include(FetchContent)
+
+    set(TRACY_NO_EXIT ON CACHE BOOL "Keep application open after being finished")
+
+    FetchContent_Declare(
+        tracy
+        GIT_REPOSITORY https://github.com/wolfpld/tracy.git
+        GIT_TAG        v0.9
+    )
+
+    # We don't use FetchContent_MakeAvailable here because we don't want all crashpad targets including, just our dependencies.
+    FetchContent_MakeAvailable(tracy)
 endif()
 
 if(USE_CRASHPAD)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,8 +262,6 @@ endif()
 if(USE_TRACY)
     include(FetchContent)
 
-    set(TRACY_NO_EXIT ON CACHE BOOL "Keep application open after being finished")
-
     FetchContent_Declare(
         tracy
         GIT_REPOSITORY https://github.com/wolfpld/tracy.git

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -40,6 +40,8 @@ set(GAMEENGINE_INCLUDES
     w3d/math
     w3d/renderer
     w3d/saveload
+    # our own code
+    dbg/
 )
 
 set(HOOKER_SRC
@@ -472,6 +474,11 @@ if(USE_FFMPEG)
     list(APPEND GAMEENGINE_INCLUDES ${FFMPEG_INCLUDE_DIRS})
     list(APPEND GAME_LINK_LIBRARIES ${FFMPEG_LIBRARIES})
     list(APPEND GAME_COMPILE_OPTIONS -DBUILD_WITH_FFMPEG ${FFMPEG_DEFINITIONS})
+endif()
+
+if(USE_TRACY)
+    list(APPEND GAME_LINK_LIBRARIES Tracy::TracyClient)
+    list(APPEND GAME_COMPILE_OPTIONS -DBUILD_WITH_TRACY)
 endif()
 
 if(DINPUT8_FOUND)

--- a/src/dbg/profiler.h
+++ b/src/dbg/profiler.h
@@ -1,0 +1,29 @@
+/**
+ * @file
+ *
+ * @author feliwir
+ *
+ * @brief Profiler abstraction header.
+ *
+ * @copyright Thyme is free software: you can redistribute it and/or
+ *            modify it under the terms of the GNU General Public License
+ *            as published by the Free Software Foundation, either version
+ *            2 of the License, or (at your option) any later version.
+ *            A full copy of the GNU General Public License can be found in
+ *            LICENSE
+ */
+#pragma once
+
+#include "always.h"
+
+#ifdef BUILD_WITH_TRACY
+#define USE_PROFILER
+#include <tracy/Tracy.hpp>
+
+#define PROFILER_MSG(M) TracyMessageL(M);
+#define PROFILER_FRAME_START(N) FrameMarkStart(N);
+#define PROFILER_FRAME_END(N) FrameMarkEnd(N);
+
+#define PROFILER_BLOCK_SCOPED ZoneScoped;
+#define PROFILER_BLOCK_TEXT(N, S) ZoneText(N, S);
+#endif

--- a/src/dbg/profiler.h
+++ b/src/dbg/profiler.h
@@ -20,10 +20,19 @@
 #define USE_PROFILER
 #include <tracy/Tracy.hpp>
 
-#define PROFILER_MSG(M) TracyMessageL(M);
+// Misc
+#define PROFILER_MSG(M) TracyMessage(M, strlen(M));
 #define PROFILER_FRAME_START(N) FrameMarkStart(N);
 #define PROFILER_FRAME_END(N) FrameMarkEnd(N);
 
+// Blocks
 #define PROFILER_BLOCK_SCOPED ZoneScoped;
 #define PROFILER_BLOCK_TEXT(N, S) ZoneText(N, S);
+
+// Memory profiling
+#define PROFILER_ALLOC(P, S) TracySecureAlloc(P, S);
+#define PROFILER_FREE(P) TracySecureFree(P);
+
+#define PROFILER_ALLOC_NAMED(P, S, N) TracySecureAllocN(P, S, N);
+#define PROFILER_FREE_NAMED(P, N) TracySecureFreeN(P, N);
 #endif

--- a/src/game/client/gametext.cpp
+++ b/src/game/client/gametext.cpp
@@ -15,6 +15,7 @@
 #include "gametext.h"
 #include "filesystem.h"
 #include "main.h" // For g_applicationHWnd
+#include "profiler.h"
 #include "registry.h"
 #include "rtsutils.h"
 #include <algorithm>
@@ -398,6 +399,10 @@ bool GameTextManager::Get_CSF_Info(const char *filename)
 // Parses older format string files which only support ascii.
 bool GameTextManager::Parse_String_File(const char *filename)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(filename, strlen(filename))
+#endif
     captainslog_info("Parsing string file '%s'.", filename);
     File *file = g_theFileSystem->Open_File(filename, File::TEXT | File::READ);
 
@@ -483,6 +488,10 @@ bool GameTextManager::Parse_String_File(const char *filename)
 // Parses CSF files which support UCS2 strings, essentially the BMP of unicode.
 bool GameTextManager::Parse_CSF_File(const char *filename)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(filename, strlen(filename))
+#endif
     captainslog_info("Parsing CSF file '%s'.", filename);
     CSFHeader header;
     File *file = g_theFileSystem->Open_File(filename, File::BINARY | File::READ);

--- a/src/game/common/crc.cpp
+++ b/src/game/common/crc.cpp
@@ -13,6 +13,7 @@
  *            LICENSE
  */
 #include "crc.h"
+#include "profiler.h"
 #include <cctype>
 
 using std::toupper;
@@ -47,6 +48,9 @@ void CRC::Add_CRC(uint8_t byte)
 
 void CRC::Compute_CRC(void const *data, int bytes)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+#endif
     if (data == nullptr) {
         return;
     }

--- a/src/game/common/gameengine.cpp
+++ b/src/game/common/gameengine.cpp
@@ -108,7 +108,7 @@ void GameEngine::Init(int argc, char *argv[])
     ini.Load("Data/INI/Default/Water.ini", INI_LOAD_OVERWRITE, &xfer);
     ini.Load("Data/INI/Water.ini", INI_LOAD_OVERWRITE, &xfer);
     ini.Load("Data/INI/Default/Weather.ini", INI_LOAD_OVERWRITE, &xfer);
-    // ini.Load("Data/INI/Weather.ini", INI_LOAD_OVERWRITE, &xfer);
+    ini.Load("Data/INI/Weather.ini", INI_LOAD_OVERWRITE, &xfer);
 
     // Text manager isn't controlled by ini files, it uses either a csf or str file.
     Init_Subsystem(g_theGameText, "TheGameText", GameTextManager::Create_Game_Text_Interface());
@@ -140,11 +140,11 @@ void GameEngine::Init(int argc, char *argv[])
         "Data/INI/Default/Roads.ini",
         "Data/INI/Roads.ini");
     Init_Subsystem(g_theGlobalLanguage, "TheGlobalLanguageData", new GlobalLanguage);
-    // Init_Subsystem(g_theAudio, "TheAudio", Create_Audio_Manager());
+    Init_Subsystem(g_theAudio, "TheAudio", Create_Audio_Manager());
 
-    // if (!g_theAudio->Is_Music_Already_Loaded()) {
-    //     Set_Quitting(true);
-    // }
+    if (!g_theAudio->Is_Music_Already_Loaded()) {
+        Set_Quitting(true);
+    }
 
     Init_Subsystem(g_theFunctionLexicon, "TheFunctionLexicon", Create_Function_Lexicon());
     Init_Subsystem(g_theModuleFactory, "TheModuleFactory", Create_Module_Factory());

--- a/src/game/common/gameengine.cpp
+++ b/src/game/common/gameengine.cpp
@@ -108,7 +108,7 @@ void GameEngine::Init(int argc, char *argv[])
     ini.Load("Data/INI/Default/Water.ini", INI_LOAD_OVERWRITE, &xfer);
     ini.Load("Data/INI/Water.ini", INI_LOAD_OVERWRITE, &xfer);
     ini.Load("Data/INI/Default/Weather.ini", INI_LOAD_OVERWRITE, &xfer);
-    ini.Load("Data/INI/Weather.ini", INI_LOAD_OVERWRITE, &xfer);
+    // ini.Load("Data/INI/Weather.ini", INI_LOAD_OVERWRITE, &xfer);
 
     // Text manager isn't controlled by ini files, it uses either a csf or str file.
     Init_Subsystem(g_theGameText, "TheGameText", GameTextManager::Create_Game_Text_Interface());
@@ -140,11 +140,11 @@ void GameEngine::Init(int argc, char *argv[])
         "Data/INI/Default/Roads.ini",
         "Data/INI/Roads.ini");
     Init_Subsystem(g_theGlobalLanguage, "TheGlobalLanguageData", new GlobalLanguage);
-    Init_Subsystem(g_theAudio, "TheAudio", Create_Audio_Manager());
+    // Init_Subsystem(g_theAudio, "TheAudio", Create_Audio_Manager());
 
-    if (!g_theAudio->Is_Music_Already_Loaded()) {
-        Set_Quitting(true);
-    }
+    // if (!g_theAudio->Is_Music_Already_Loaded()) {
+    //     Set_Quitting(true);
+    // }
 
     Init_Subsystem(g_theFunctionLexicon, "TheFunctionLexicon", Create_Function_Lexicon());
     Init_Subsystem(g_theModuleFactory, "TheModuleFactory", Create_Module_Factory());

--- a/src/game/common/gamemain.cpp
+++ b/src/game/common/gamemain.cpp
@@ -13,6 +13,7 @@
  *            LICENSE
  */
 #include "gamemain.h"
+#include "profiler.h"
 #include "win32gameengine.h"
 
 GameEngine *Create_Game_Engine()
@@ -29,6 +30,9 @@ GameEngine *Create_Game_Engine()
 
 void Game_Main(int argc, char *argv[])
 {
+#ifdef USE_PROFILER
+    PROFILER_MSG("Starting the game engine!")
+#endif
     g_theGameEngine = Create_Game_Engine();
     g_theGameEngine->Init(argc, argv);
     g_theGameEngine->Execute();

--- a/src/game/common/globaldata.cpp
+++ b/src/game/common/globaldata.cpp
@@ -18,6 +18,7 @@
 #include "filesystem.h"
 #include "gitverinfo.h"
 #include "optionpreferences.h"
+#include "profiler.h"
 #include "rtsutils.h"
 #include "version.h"
 #include "weapon.h"
@@ -667,6 +668,9 @@ const FieldParse GlobalData::s_fieldParseTable[] = {
 
 GlobalData::GlobalData()
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+#endif
     if (s_theOriginal == nullptr) {
         s_theOriginal = this;
     }

--- a/src/game/common/ini/ini.cpp
+++ b/src/game/common/ini/ini.cpp
@@ -36,6 +36,7 @@
 #include "objectcreationlist.h"
 #include "particlesysmanager.h"
 #include "playertemplate.h"
+#include "profiler.h"
 #include "rankinfo.h"
 #include "science.h"
 #include "terrainroads.h"
@@ -204,6 +205,10 @@ INI::~INI() {}
 
 void INI::Load(Utf8String filename, INILoadType type, Xfer *xfer)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(filename.Str(), filename.Get_Length())
+#endif
     Set_FP_Mode(); // Ensure floating point mode is a consistent mode for loading.
     g_sXfer = xfer;
     Prep_File(filename, type);

--- a/src/game/common/system/archivefile.cpp
+++ b/src/game/common/system/archivefile.cpp
@@ -14,6 +14,7 @@
  */
 #include "archivefile.h"
 #include "file.h"
+#include "profiler.h"
 bool Search_String_Matches(Utf8String string, Utf8String search);
 
 const ArchivedFileInfo *ArchiveFile::Get_Archived_File_Info(Utf8String const &filename) const
@@ -88,6 +89,10 @@ void ArchiveFile::Get_File_List_In_Directory(Utf8String const &subdir,
     std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist,
     bool search_subdir) const
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(dirpath.Str(), dirpath.Get_Length())
+#endif
     Utf8String path = dirpath;
     path.To_Lower();
     Utf8String token;

--- a/src/game/common/system/archivefilesystem.cpp
+++ b/src/game/common/system/archivefilesystem.cpp
@@ -15,6 +15,7 @@
 #include "archivefilesystem.h"
 #include "archivefile.h"
 #include "globaldata.h"
+#include "profiler.h"
 #include <captainslog.h>
 
 #ifndef GAME_DLL
@@ -79,6 +80,10 @@ bool ArchiveFileSystem::Does_File_Exist(const char *filename) const
 // replace the backing for a file name if it already has an entry in the tree.
 void ArchiveFileSystem::Load_Into_Directory_Tree(ArchiveFile const *file, Utf8String const &archive_path, bool overwrite)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(archive_path.Str(), archive_path.Get_Length())
+#endif
     std::set<Utf8String, rts::less_than_nocase<Utf8String>> file_list;
 
     // Retrieve a list of files in the archive

--- a/src/game/common/system/memdynalloc.cpp
+++ b/src/game/common/system/memdynalloc.cpp
@@ -19,6 +19,7 @@
 #include "memblock.h"
 #include "mempool.h"
 #include "mempoolfact.h"
+#include "profiler.h"
 #include <cstring>
 
 using std::memset;
@@ -147,6 +148,10 @@ void *DynamicMemoryAllocator::Allocate_Bytes_No_Zero(int bytes)
 
     ++m_usedBlocksInDma;
 
+#ifdef USE_PROFILER
+    PROFILER_ALLOC(block, bytes)
+#endif
+
     return block;
 #endif
 }
@@ -167,6 +172,10 @@ void DynamicMemoryAllocator::Free_Bytes(void *block)
 #ifdef __SANITIZE_ADDRESS__
     free(block);
 #else
+
+#ifdef USE_PROFILER
+    PROFILER_FREE(block)
+#endif
     ScopedCriticalSectionClass cs(g_dmaCriticalSection);
 
     MemoryPoolSingleBlock *sblock = MemoryPoolSingleBlock::Recover_Block_From_User_Data(block);

--- a/src/game/common/system/mempoolobj.h
+++ b/src/game/common/system/mempoolobj.h
@@ -60,7 +60,7 @@ protected:
         PROFILER_FREE_NAMED(ptr, #classname) \
     } \
     void *operator new(size_t size, void *where) { return where; } \
-    void operator delete(void *ptr, void *where) {} 
+    void operator delete(void *ptr, void *where) {}
 #else
 #define OPERATOR_IMPL(classname) \
     void *operator new(size_t size) { return operator new(size, classname##_GLUE_NOT_IMPLEMENTED); } \
@@ -78,7 +78,7 @@ protected:
         Get_Class_Pool()->Free_Block(ptr); \
     } \
     void *operator new(size_t size, void *where) { return where; } \
-    void operator delete(void *ptr, void *where) {} 
+    void operator delete(void *ptr, void *where) {}
 #endif
 
 // Use within a class declaration on a none virtual MemoryPoolObject

--- a/src/game/common/system/mempoolobj.h
+++ b/src/game/common/system/mempoolobj.h
@@ -17,6 +17,7 @@
 #include "errorcodes.h"
 #include "mempool.h"
 #include "mempoolfact.h"
+#include "profiler.h"
 #include <captainslog.h>
 #include <new>
 
@@ -39,6 +40,51 @@ protected:
     // Class implementing Get_Object_Pool needs to provide these
     // use macros below to generated them.
 };
+
+#ifdef USE_PROFILER
+#define OPERATOR_IMPL(classname) \
+    void *operator new(size_t size) { return operator new(size, classname##_GLUE_NOT_IMPLEMENTED); } \
+    void *operator new(size_t size, classname##MagicEnum) \
+    { \
+        captainslog_dbgassert(size == sizeof(classname), \
+            "The wrong operator new is being called; ensure all objects in the hierarchy have MemoryPoolGlue set up " \
+            "correctly"); \
+        void* ptr = Get_Class_Pool()->Allocate_Block(); \
+        PROFILER_ALLOC_NAMED(ptr, size, #classname) \
+        return ptr; \
+    } \
+    void operator delete(void *ptr) { operator delete(ptr, classname##_GLUE_NOT_IMPLEMENTED); } \
+    void operator delete(void *ptr, classname##MagicEnum) \
+    { \
+        Get_Class_Pool()->Free_Block(ptr); \
+        PROFILER_FREE_NAMED(ptr, #classname) \
+    } \
+    void *operator new(size_t size, void *where) { \
+        PROFILER_ALLOC_NAMED(where, size, #classname) \
+        return where; \
+    } \
+    void operator delete(void *ptr, void *where) { \
+        PROFILER_FREE_NAMED(where, #classname) \
+    } 
+#else
+#define OPERATOR_IMPL(classname) \
+    void *operator new(size_t size) { return operator new(size, classname##_GLUE_NOT_IMPLEMENTED); } \
+    void *operator new(size_t size, classname##MagicEnum) \
+    { \
+        captainslog_dbgassert(size == sizeof(classname), \
+            "The wrong operator new is being called; ensure all objects in the hierarchy have MemoryPoolGlue set up " \
+            "correctly"); \
+        return Get_Class_Pool()->Allocate_Block(); \
+    } \
+    void operator delete(void *ptr) { operator delete(ptr, classname##_GLUE_NOT_IMPLEMENTED); } \
+    void operator delete(void *ptr, classname##MagicEnum) \
+    { \
+        captainslog_dbgassert(0, "Please call Delete_Instance instead of delete."); \
+        Get_Class_Pool()->Free_Block(ptr); \
+    } \
+    void *operator new(size_t size, void *where) { return where; } \
+    void operator delete(void *ptr, void *where) {} 
+#endif
 
 // Use within a class declaration on a none virtual MemoryPoolObject
 // based class to implement required functions. "classname" must match
@@ -84,22 +130,7 @@ private: \
 public: \
     enum classname##MagicEnum{ classname##_GLUE_NOT_IMPLEMENTED = 0 }; \
 \
-    void *operator new(size_t size) { return operator new(size, classname##_GLUE_NOT_IMPLEMENTED); } \
-    void *operator new(size_t size, classname##MagicEnum) \
-    { \
-        captainslog_dbgassert(size == sizeof(classname), \
-            "The wrong operator new is being called; ensure all objects in the hierarchy have MemoryPoolGlue set up " \
-            "correctly"); \
-        return Get_Class_Pool()->Allocate_Block(); \
-    } \
-    void operator delete(void *ptr) { operator delete(ptr, classname##_GLUE_NOT_IMPLEMENTED); } \
-    void operator delete(void *ptr, classname##MagicEnum) \
-    { \
-        captainslog_dbgassert(0, "Please call Delete_Instance instead of delete."); \
-        Get_Class_Pool()->Free_Block(ptr); \
-    } \
-    void *operator new(size_t size, void *where) { return where; } \
-    void operator delete(void *ptr, void *where) {}
+    OPERATOR_IMPL(classname)
 
 /* NOTE: Operator delete above must exist because of the pairing operator new. However, it should never be called directly.
  * Reason being, a pointer to a derived class of this class, must use the correct memory pool for deletion. This is possible
@@ -128,7 +159,7 @@ private:
 inline void MemoryPoolObject::Delete_Instance()
 {
     if (this != nullptr) {
-#ifdef __SANITIZE_ADDRESS__
+#if defined __SANITIZE_ADDRESS__ || defined USE_PROFILER
         delete this;
 #else
         MemoryPool *pool = Get_Object_Pool();

--- a/src/game/common/system/mempoolobj.h
+++ b/src/game/common/system/mempoolobj.h
@@ -49,7 +49,7 @@ protected:
         captainslog_dbgassert(size == sizeof(classname), \
             "The wrong operator new is being called; ensure all objects in the hierarchy have MemoryPoolGlue set up " \
             "correctly"); \
-        void* ptr = Get_Class_Pool()->Allocate_Block(); \
+        void *ptr = Get_Class_Pool()->Allocate_Block(); \
         PROFILER_ALLOC_NAMED(ptr, size, #classname) \
         return ptr; \
     } \
@@ -59,13 +59,8 @@ protected:
         Get_Class_Pool()->Free_Block(ptr); \
         PROFILER_FREE_NAMED(ptr, #classname) \
     } \
-    void *operator new(size_t size, void *where) { \
-        PROFILER_ALLOC_NAMED(where, size, #classname) \
-        return where; \
-    } \
-    void operator delete(void *ptr, void *where) { \
-        PROFILER_FREE_NAMED(where, #classname) \
-    } 
+    void *operator new(size_t size, void *where) { return where; } \
+    void operator delete(void *ptr, void *where) {} 
 #else
 #define OPERATOR_IMPL(classname) \
     void *operator new(size_t size) { return operator new(size, classname##_GLUE_NOT_IMPLEMENTED); } \

--- a/src/game/common/system/subsysteminterface.cpp
+++ b/src/game/common/system/subsysteminterface.cpp
@@ -14,6 +14,7 @@
  */
 #include "subsysteminterface.h"
 #include "ini.h"
+#include "profiler.h"
 #include "xfer.h"
 
 #ifndef GAME_DLL
@@ -47,6 +48,10 @@ void SubsystemInterfaceList::Init_Subsystem(SubsystemInterface *sys,
     Xfer *xfer,
     Utf8String sys_name)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(sys_name.Str(), sys_name.Get_Length())
+#endif
     INI ini;
 
     sys->Set_Name(sys_name);

--- a/src/game/common/system/subsysteminterface.cpp
+++ b/src/game/common/system/subsysteminterface.cpp
@@ -49,6 +49,9 @@ void SubsystemInterfaceList::Init_Subsystem(SubsystemInterface *sys,
     Utf8String sys_name)
 {
 #ifdef USE_PROFILER
+    Utf8String msg = "Initializing subsystem: ";
+    msg.Concat(sys_name);
+    PROFILER_MSG(msg.Str())
     PROFILER_BLOCK_SCOPED
     PROFILER_BLOCK_TEXT(sys_name.Str(), sys_name.Get_Length())
 #endif

--- a/src/platform/stdlocalfilesystem.cpp
+++ b/src/platform/stdlocalfilesystem.cpp
@@ -13,6 +13,7 @@
  *            LICENSE
  */
 #include "stdlocalfilesystem.h"
+#include "profiler.h"
 #include "standardfile.h"
 #include "win32localfile.h"
 
@@ -77,6 +78,10 @@ void StdLocalFileSystem::Get_File_List_In_Directory(Utf8String const &subdir,
     std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist,
     bool search_subdirs) const
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(subdir.Str(), subdir.Get_Length())
+#endif
     Utf8String search_path = dirpath;
     search_path += subdir;
 

--- a/src/platform/win32bigfilesystem.cpp
+++ b/src/platform/win32bigfilesystem.cpp
@@ -18,6 +18,7 @@
 #include "endiantype.h"
 #include "file.h"
 #include "localfilesystem.h"
+#include "profiler.h"
 #include "registry.h"
 #include "rtsutils.h"
 #include "win32bigfile.h"
@@ -45,6 +46,11 @@ void Win32BIGFileSystem::Init()
 
 ArchiveFile *Win32BIGFileSystem::Open_Archive_File(const char *filename)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(filename, strlen(filename))
+#endif
+
     File *file = g_theLocalFileSystem->Open_File(filename, File::READ | File::BINARY);
     Utf8String fullname = filename;
     fullname.To_Lower();
@@ -148,6 +154,10 @@ ArchiveFile *Win32BIGFileSystem::Open_Archive_File(const char *filename)
 
 void Win32BIGFileSystem::Close_Archive_File(const char *filename)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(filename, strlen(filename))
+#endif
     auto it = m_archiveFiles.find(filename);
 
     if (!(it == m_archiveFiles.end())) {
@@ -171,6 +181,10 @@ void Win32BIGFileSystem::Close_Archive_File(const char *filename)
 
 bool Win32BIGFileSystem::Load_Big_Files_From_Directory(Utf8String dir, Utf8String filter, bool overwrite)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(dir.Str(), dir.Get_Length())
+#endif
     std::set<Utf8String, rts::less_than_nocase<Utf8String>> file_list;
 
     g_theLocalFileSystem->Get_File_List_In_Directory(dir, "", filter, file_list, true);

--- a/src/platform/win32localfilesystem.cpp
+++ b/src/platform/win32localfilesystem.cpp
@@ -13,6 +13,7 @@
  *            LICENSE
  */
 #include "win32localfilesystem.h"
+#include "profiler.h"
 #include "standardfile.h"
 #include "win32localfile.h"
 
@@ -83,6 +84,10 @@ void Win32LocalFileSystem::Get_File_List_In_Directory(Utf8String const &subdir,
     std::set<Utf8String, rts::less_than_nocase<Utf8String>> &filelist,
     bool search_subdirs) const
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+    PROFILER_BLOCK_TEXT(subdir.Str(), subdir.Get_Length())
+#endif
     Utf8String search_path = dirpath;
     search_path += subdir;
 

--- a/src/w3d/lib/iniclass.cpp
+++ b/src/w3d/lib/iniclass.cpp
@@ -16,6 +16,7 @@
 #include "iniclass.h"
 #include "filestraw.h"
 #include "nstrdup.h"
+#include "profiler.h"
 #include "rawfileclass.h"
 #include "readline.h"
 #include <captainslog.h>
@@ -162,6 +163,9 @@ int INIClass::Load(FileClass &file)
 
 int INIClass::Load(Straw &straw)
 {
+#ifdef USE_PROFILER
+    PROFILER_BLOCK_SCOPED
+#endif
     char buffer[MAX_LINE_LENGTH];
     // char section[64];
     bool merge = false;


### PR DESCRIPTION
A profiler giving us insight what time is spent on. Replaces / Closes #566 
The profiler is a standalone application that connects to Thyme. A trace can e.g look like this:
![image](https://user-images.githubusercontent.com/2104576/203060571-0b7ec3fa-bb83-4081-8bbe-f481f9e43c59.png)

Currently this only works in standalone mode and i've only adding "zones" to a few functions. This is what has been done in this PR:

- [x] profile every default new / delete operator 
- [x] profile every new / delete on a memory pool object. Pools will be tracked accordingly
- [x] profile some loading performance: `Subsystem`, `INI`,  `CRC`,  `GameText`
- [ ] get this working in standalone
- [ ] mark frame begin & end events
- [ ] profile important bottlenecks