### PR TITLE
Add faster math functions and use them in places that seem safe to do so

### DIFF
--- a/src/game/client/baseheightmap.cpp
+++ b/src/game/client/baseheightmap.cpp
@@ -54,7 +54,7 @@ BaseHeightMapRenderObjClass::BaseHeightMapRenderObjClass() :
     m_needFullUpdate(false),
     m_showImpassableAreas(false),
     m_updating(false),
-    m_maxHeight((GameMath::Pow(256.0f, 1.0f) - 1.0f) * HEIGHTMAP_SCALE),
+    m_maxHeight((FastMath::Pow(256.0f, 1.0f) - 1.0f) * HEIGHTMAP_SCALE),
     m_minHeight(0.0f),
     m_shorelineTiles(nullptr),
     m_numShorelineBlendTiles(0),
@@ -449,19 +449,19 @@ bool BaseHeightMapRenderObjClass::Cast_Ray(RayCollisionTestClass &raytest)
         }
 
         if (p0.X > p1.X) {
-            start_cell_x = GameMath::Fast_To_Int_Floor(p1.X / 10.0f);
-            end_cell_x = GameMath::Fast_To_Int_Ceil(p0.X / 10.0f);
+            start_cell_x = FastMath::Fast_To_Int_Floor(p1.X / 10.0f);
+            end_cell_x = FastMath::Fast_To_Int_Ceil(p0.X / 10.0f);
         } else {
-            start_cell_x = GameMath::Fast_To_Int_Floor(p0.X / 10.0f);
-            end_cell_x = GameMath::Fast_To_Int_Ceil(p1.X / 10.0f);
+            start_cell_x = FastMath::Fast_To_Int_Floor(p0.X / 10.0f);
+            end_cell_x = FastMath::Fast_To_Int_Ceil(p1.X / 10.0f);
         }
 
         if (p0.Y > p1.Y) {
-            start_cell_y = GameMath::Fast_To_Int_Floor(p1.Y / 10.0f);
-            end_cell_y = GameMath::Fast_To_Int_Ceil(p0.Y / 10.0f);
+            start_cell_y = FastMath::Fast_To_Int_Floor(p1.Y / 10.0f);
+            end_cell_y = FastMath::Fast_To_Int_Ceil(p0.Y / 10.0f);
         } else {
-            start_cell_y = GameMath::Fast_To_Int_Floor(p0.Y / 10.0f);
-            end_cell_y = GameMath::Fast_To_Int_Ceil(p1.Y / 10.0f);
+            start_cell_y = FastMath::Fast_To_Int_Floor(p0.Y / 10.0f);
+            end_cell_y = FastMath::Fast_To_Int_Ceil(p1.Y / 10.0f);
         }
 
         int max_ht = m_map->Get_Max_Height_Value();
@@ -960,9 +960,9 @@ void BaseHeightMapRenderObjClass::Do_The_Light(VertexFormatXYZDUV2 *vb,
     shade_g = shade_g * 255.0f;
     shade_b = shade_b * 255.0f;
 
-    vb->diffuse = Make_Color(GameMath::Fast_To_Int_Truncate(shade_r),
-        GameMath::Fast_To_Int_Truncate(shade_g),
-        GameMath::Fast_To_Int_Truncate(shade_b),
+    vb->diffuse = Make_Color(FastMath::Fast_To_Int_Truncate(shade_r),
+        FastMath::Fast_To_Int_Truncate(shade_g),
+        FastMath::Fast_To_Int_Truncate(shade_b),
         alpha);
 }
 
@@ -979,12 +979,12 @@ float BaseHeightMapRenderObjClass::Get_Height_Map_Height(float x, float y, Coord
     if (map != nullptr) {
         float f1 = x * 0.1f;
         float f2 = y * 0.1f;
-        float f3 = GameMath::Fast_Float_Floor(f1);
-        float f4 = GameMath::Fast_Float_Floor(f2);
+        float f3 = FastMath::Fast_Float_Floor(f1);
+        float f4 = FastMath::Fast_Float_Floor(f2);
         float f5 = f1 - f3;
         float f6 = f2 - f4;
-        int i1 = map->Border_Size() + GameMath::Lrintf(f3);
-        int i2 = map->Border_Size() + GameMath::Lrintf(f4);
+        int i1 = map->Border_Size() + FastMath::Lrintf(f3);
+        int i2 = map->Border_Size() + FastMath::Lrintf(f4);
         int x_extent = map->Get_X_Extent();
 
         if (i1 <= x_extent - 3 && i2 <= map->Get_Y_Extent() - 3 && i2 >= 1 && i1 >= 1) {
@@ -1152,7 +1152,7 @@ void BaseHeightMapRenderObjClass::Draw_Scorches()
 
 bool BaseHeightMapRenderObjClass::Evaluate_As_Visible_Cliff(int x, int y, float height)
 {
-    static float distance[4] = { 0.0f, 10.0f, GameMath::Sqrt(2.0f) * 10.0f, 10.0f };
+    static float distance[4] = { 0.0f, 10.0f, FastMath::Sqrt(2.0f) * 10.0f, 10.0f };
     unsigned char heights[4];
     float fheights[4];
 
@@ -1248,10 +1248,10 @@ bool BaseHeightMapRenderObjClass::Is_Clear_Line_Of_Sight(const Coord3D &pos1, co
     }
 
     int border = map->Border_Size();
-    int x1 = border + GameMath::Fast_To_Int_Floor(0.1f * pos1.x);
-    int y1 = border + GameMath::Fast_To_Int_Floor(0.1f * pos1.y);
-    int x2 = border + GameMath::Fast_To_Int_Floor(0.1f * pos2.x);
-    int y2 = border + GameMath::Fast_To_Int_Floor(0.1f * pos2.y);
+    int x1 = border + FastMath::Fast_To_Int_Floor(0.1f * pos1.x);
+    int y1 = border + FastMath::Fast_To_Int_Floor(0.1f * pos1.y);
+    int x2 = border + FastMath::Fast_To_Int_Floor(0.1f * pos2.x);
+    int y2 = border + FastMath::Fast_To_Int_Floor(0.1f * pos2.y);
     int x_dist = abs(x2 - x1);
     int y_dist = abs(y2 - y1);
     int x_pos = x1;
@@ -2117,9 +2117,9 @@ void BaseHeightMapRenderObjClass::Update_Scorches()
         red *= 255.0f;
         green *= 255.0f;
         blue *= 255.0f;
-        unsigned int diffuse = Make_Color(GameMath::Fast_To_Int_Truncate(red),
-            GameMath::Fast_To_Int_Truncate(green),
-            GameMath::Fast_To_Int_Truncate(blue),
+        unsigned int diffuse = Make_Color(FastMath::Fast_To_Int_Truncate(red),
+            FastMath::Fast_To_Int_Truncate(green),
+            FastMath::Fast_To_Int_Truncate(blue),
             255);
         m_scorchesInBuffer = 0;
 
@@ -2137,8 +2137,8 @@ void BaseHeightMapRenderObjClass::Update_Scorches()
                 scorch_type = 0;
             }
 
-            int x_min = GameMath::Fast_To_Int_Floor((location.X - radius) / 10.0f);
-            int y_min = GameMath::Fast_To_Int_Floor((location.Y - radius) / 10.0f);
+            int x_min = FastMath::Fast_To_Int_Floor((location.X - radius) / 10.0f);
+            int y_min = FastMath::Fast_To_Int_Floor((location.Y - radius) / 10.0f);
 
             if (x_min < -m_map->Border_Size()) {
                 x_min = -m_map->Border_Size();
@@ -2148,8 +2148,8 @@ void BaseHeightMapRenderObjClass::Update_Scorches()
                 y_min = -m_map->Border_Size();
             }
 
-            int x_max = GameMath::Fast_To_Int_Ceil((location.X + radius) / 10.0f) + 1;
-            int y_max = GameMath::Fast_To_Int_Ceil((location.Y + radius) / 10.0f) + 1;
+            int x_max = FastMath::Fast_To_Int_Ceil((location.X + radius) / 10.0f) + 1;
+            int y_max = FastMath::Fast_To_Int_Ceil((location.Y + radius) / 10.0f) + 1;
 
             if (x_max > m_map->Get_X_Extent() - m_map->Border_Size()) {
                 x_max = m_map->Get_X_Extent() - m_map->Border_Size();
@@ -2362,7 +2362,7 @@ void BaseHeightMapRenderObjClass::Update_View_Impassable_Areas(bool unk, int min
         max_y = y_extent;
     }
 
-    float height = GameMath::Tan((m_cliffAngle / 360.0f + m_cliffAngle / 360.0f) * GAMEMATH_PI);
+    float height = FastMath::Tan((m_cliffAngle / 360.0f + m_cliffAngle / 360.0f) * GAMEMATH_PI);
 
     for (int y = max_x; y < max_y; y++) {
         for (int x = min_x; x < min_y; x++) {

--- a/src/game/client/camerashakesystem.cpp
+++ b/src/game/client/camerashakesystem.cpp
@@ -44,7 +44,7 @@ void CameraShakeSystemClass::CameraShakerClass::Compute_Rotations(const Vector3 
 
     if (m_radius * m_radius >= len2) {
 
-        float angle = (1.0f - GameMath::Sqrt(len2) / m_radius) * m_intensity * (1.0f - m_time / m_duration);
+        float angle = (1.0f - FastMath::Sqrt(len2) / m_radius) * m_intensity * (1.0f - m_time / m_duration);
 
         for (int i = 0; i < 3; ++i) {
 
@@ -52,7 +52,7 @@ void CameraShakeSystemClass::CameraShakerClass::Compute_Rotations(const Vector3 
             float f3 = angle * s_axis_rotation[i];
             float f4 = (f2 * m_time) + m_vector2[i];
 
-            (*set_angles)[i] += GameMath::Sin(f4) * f3;
+            (*set_angles)[i] += FastMath::Sin(f4) * f3;
 
             Vector3 angles;
 

--- a/src/game/client/draw/drawable.cpp
+++ b/src/game/client/draw/drawable.cpp
@@ -514,8 +514,8 @@ void Drawable::Draw_Ammo(IRegion2D const *region)
                 if (object->Get_Ammo_Pip_Showing_Info(clip_size, ammo_in_clip)) {
                     if (s_fullAmmo != nullptr && s_emptyAmmo != nullptr) {
                         float scale = 1.0f;
-                        int width = GameMath::Fast_To_Int_Truncate(s_emptyAmmo->Get_Image_Width() * scale);
-                        int height = GameMath::Fast_To_Int_Truncate(s_emptyAmmo->Get_Image_Height() * scale);
+                        int width = FastMath::Fast_To_Int_Truncate(s_emptyAmmo->Get_Image_Width() * scale);
+                        int height = FastMath::Fast_To_Int_Truncate(s_emptyAmmo->Get_Image_Height() * scale);
                         Coord3D pos = *object->Get_Position();
                         pos.x += g_theWriteableGlobalData->m_ammoPipWorldOffset.x;
                         pos.y += g_theWriteableGlobalData->m_ammoPipWorldOffset.y;
@@ -527,7 +527,7 @@ void Drawable::Draw_Ammo(IRegion2D const *region)
                             float radius = object->Get_Geometry_Info().Get_Bounding_Sphere_Radius() * scale;
                             int left = region->lo.x;
                             int top =
-                                GameMath::Fast_To_Int_Truncate(radius * g_theWriteableGlobalData->m_ammoPipScreenOffset.y)
+                                FastMath::Fast_To_Int_Truncate(radius * g_theWriteableGlobalData->m_ammoPipScreenOffset.y)
                                 + screen.y;
 
                             for (int i = 0; i < clip_size; i++) {
@@ -585,8 +585,8 @@ void Drawable::Draw_Contained(IRegion2D const *region)
                     }
 
                     float scale = 1.0f;
-                    int width = GameMath::Fast_To_Int_Truncate(s_emptyAmmo->Get_Image_Width() * scale);
-                    int height = GameMath::Fast_To_Int_Truncate(s_emptyAmmo->Get_Image_Height() * scale);
+                    int width = FastMath::Fast_To_Int_Truncate(s_emptyAmmo->Get_Image_Width() * scale);
+                    int height = FastMath::Fast_To_Int_Truncate(s_emptyAmmo->Get_Image_Height() * scale);
                     Coord3D pos = *object->Get_Position();
                     pos.x += g_theWriteableGlobalData->m_containerPipWorldOffset.x;
                     pos.y += g_theWriteableGlobalData->m_containerPipWorldOffset.y;
@@ -598,7 +598,7 @@ void Drawable::Draw_Contained(IRegion2D const *region)
                         float radius = object->Get_Geometry_Info().Get_Bounding_Sphere_Radius() * scale;
                         int left = region->lo.x;
                         int top =
-                            GameMath::Fast_To_Int_Truncate(radius * g_theWriteableGlobalData->m_containerPipScreenOffset.y)
+                            FastMath::Fast_To_Int_Truncate(radius * g_theWriteableGlobalData->m_containerPipScreenOffset.y)
                             + screen.y;
 
                         for (int i = 0; i < max; i++) {
@@ -678,9 +678,9 @@ void Drawable::Draw_Healing(IRegion2D const *region)
                     if (Get_Icon_Info()->anims[icon] != nullptr) {
                         int width = Get_Icon_Info()->anims[icon]->Get_Current_Frame_Width();
                         int height = Get_Icon_Info()->anims[icon]->Get_Current_Frame_Height();
-                        int x = GameMath::Fast_To_Int_Truncate(
+                        int x = FastMath::Fast_To_Int_Truncate(
                             region->lo.x + (region->hi.x - region->lo.x) * 0.75f - width * 0.5f);
-                        int y = GameMath::Fast_To_Int_Truncate(region->lo.y - height);
+                        int y = FastMath::Fast_To_Int_Truncate(region->lo.y - height);
                         Get_Icon_Info()->anims[icon]->Draw(x, y, width, height);
                     }
                 }
@@ -719,7 +719,7 @@ void Drawable::Draw_Enthusiastic(IRegion2D const *region)
 
             int width = Get_Icon_Info()->anims[icon]->Get_Current_Frame_Width() * scale;
             int height = Get_Icon_Info()->anims[icon]->Get_Current_Frame_Height() * scale;
-            int x = GameMath::Fast_To_Int_Truncate(region->lo.x + (region->hi.x - region->lo.x) * 0.25f - width * 0.5f);
+            int x = FastMath::Fast_To_Int_Truncate(region->lo.x + (region->hi.x - region->lo.x) * 0.25f - width * 0.5f);
             int y = region->hi.y + height * 0.25f;
             Get_Icon_Info()->anims[icon]->Draw(x, y, width, height);
         }
@@ -743,10 +743,10 @@ void Drawable::Draw_Bombed(IRegion2D const *region)
         if (Get_Icon_Info()->anims[ICON_CARBOMB] != nullptr && region != nullptr) {
             int fwidth = Get_Icon_Info()->anims[ICON_CARBOMB]->Get_Current_Frame_Width();
             int fheight = Get_Icon_Info()->anims[ICON_CARBOMB]->Get_Current_Frame_Height();
-            int width = GameMath::Fast_To_Int_Truncate((region->hi.x - region->lo.x) * 0.5f);
-            int height = GameMath::Fast_To_Int_Truncate((float)width / (float)(fwidth) * (float(fheight)));
-            int x = GameMath::Fast_To_Int_Truncate(region->lo.x + (region->hi.x - region->lo.x) * 0.5f - width * 0.5f);
-            int y = GameMath::Fast_To_Int_Truncate(region->lo.y + (region->hi.y - region->lo.y) * 0.5f) + 5;
+            int width = FastMath::Fast_To_Int_Truncate((region->hi.x - region->lo.x) * 0.5f);
+            int height = FastMath::Fast_To_Int_Truncate((float)width / (float)(fwidth) * (float(fheight)));
+            int x = FastMath::Fast_To_Int_Truncate(region->lo.x + (region->hi.x - region->lo.x) * 0.5f - width * 0.5f);
+            int y = FastMath::Fast_To_Int_Truncate(region->lo.y + (region->hi.y - region->lo.y) * 0.5f) + 5;
             Get_Icon_Info()->anims[ICON_CARBOMB]->Draw(x, y, width, height);
             Get_Icon_Info()->timings[ICON_CARBOMB] = 0x3FFFFFFF;
         }
@@ -769,7 +769,7 @@ void Drawable::Draw_Bombed(IRegion2D const *region)
                 Get_Icon_Info()->anims[ICON_BOMB_TIMED] =
                     new Anim2D(s_animationTemplates[ICON_BOMB_TIMED], g_theAnim2DCollection);
 
-                int i1 = GameMath::Fast_To_Int_Ceil((update->Get_Die_Frame() - frame) * (1.0f / 30.0f));
+                int i1 = FastMath::Fast_To_Int_Ceil((update->Get_Die_Frame() - frame) * (1.0f / 30.0f));
                 unsigned short frames = Get_Icon_Info()->anims[ICON_BOMB_TIMED]->Get_Template()->Get_Num_Frames();
 
                 if (i1 > frames - 1) {
@@ -783,10 +783,10 @@ void Drawable::Draw_Bombed(IRegion2D const *region)
             if (Get_Icon_Info()->anims[ICON_BOMB_TIMED] != nullptr && region != nullptr) {
                 int fwidth = Get_Icon_Info()->anims[ICON_BOMB_TIMED]->Get_Current_Frame_Width();
                 int fheight = Get_Icon_Info()->anims[ICON_BOMB_TIMED]->Get_Current_Frame_Height();
-                int width = GameMath::Fast_To_Int_Truncate((region->hi.x - region->lo.x) * 0.65f);
-                int height = GameMath::Fast_To_Int_Truncate((float)width / (float)fwidth * (float)fheight);
-                int x = GameMath::Fast_To_Int_Truncate(region->lo.x + (region->hi.x - region->lo.x) * 0.5f - width * 0.5f);
-                int y = GameMath::Fast_To_Int_Truncate(region->lo.y + (region->hi.y - region->lo.y) * 0.5f) + 5;
+                int width = FastMath::Fast_To_Int_Truncate((region->hi.x - region->lo.x) * 0.65f);
+                int height = FastMath::Fast_To_Int_Truncate((float)width / (float)fwidth * (float)fheight);
+                int x = FastMath::Fast_To_Int_Truncate(region->lo.x + (region->hi.x - region->lo.x) * 0.5f - width * 0.5f);
+                int y = FastMath::Fast_To_Int_Truncate(region->lo.y + (region->hi.y - region->lo.y) * 0.5f) + 5;
                 Get_Icon_Info()->anims[ICON_BOMB_REMOTE]->Draw(x, y, width, height);
                 Get_Icon_Info()->timings[ICON_BOMB_REMOTE] = frame + 1;
                 Get_Icon_Info()->anims[ICON_BOMB_TIMED]->Draw(x, y, width, height);
@@ -801,10 +801,10 @@ void Drawable::Draw_Bombed(IRegion2D const *region)
             if (Get_Icon_Info()->anims[ICON_BOMB_REMOTE] != nullptr && region != nullptr) {
                 int fwidth = Get_Icon_Info()->anims[ICON_BOMB_REMOTE]->Get_Current_Frame_Width();
                 int fheight = Get_Icon_Info()->anims[ICON_BOMB_REMOTE]->Get_Current_Frame_Height();
-                int width = GameMath::Fast_To_Int_Truncate((region->hi.x - region->lo.x) * 0.65f);
-                int height = GameMath::Fast_To_Int_Truncate((float)width / (float)fwidth * (float)fheight);
-                int x = GameMath::Fast_To_Int_Truncate(region->lo.x + (region->hi.x - region->lo.x) * 0.5f - width * 0.5f);
-                int y = GameMath::Fast_To_Int_Truncate(region->lo.y + (region->hi.y - region->lo.y) * 0.5f) + 5;
+                int width = FastMath::Fast_To_Int_Truncate((region->hi.x - region->lo.x) * 0.65f);
+                int height = FastMath::Fast_To_Int_Truncate((float)width / (float)fwidth * (float)fheight);
+                int x = FastMath::Fast_To_Int_Truncate(region->lo.x + (region->hi.x - region->lo.x) * 0.5f - width * 0.5f);
+                int y = FastMath::Fast_To_Int_Truncate(region->lo.y + (region->hi.y - region->lo.y) * 0.5f) + 5;
                 Get_Icon_Info()->anims[ICON_BOMB_REMOTE]->Draw(x, y, width, height);
                 Get_Icon_Info()->timings[ICON_BOMB_REMOTE] = frame + 1;
             }

--- a/src/game/client/draw/w3dlaserdraw.cpp
+++ b/src/game/client/draw/w3dlaserdraw.cpp
@@ -261,7 +261,7 @@ void W3DLaserDraw::Do_Draw_Module(const Matrix3D *transform)
 
                 float f5 = c3.Length();
                 float f6 = f5 / mid_length * GAMEMATH_PI * 0.5f;
-                float f7 = GameMath::Cos(f6);
+                float f7 = FastMath::Cos(f6);
                 f7 = f7 * data->m_arcHeight;
                 c4.z = c4.z + f7;
 
@@ -269,7 +269,7 @@ void W3DLaserDraw::Do_Draw_Module(const Matrix3D *transform)
                 c3.Sub(&c5);
                 float f8 = c3.Length();
                 float f9 = f8 / mid_length * GAMEMATH_PI * 0.5f;
-                f7 = GameMath::Cos(f9);
+                f7 = FastMath::Cos(f9);
                 f7 = f7 * data->m_arcHeight;
                 c5.z = c5.z + f7;
 

--- a/src/game/client/draw/w3dmodeldraw.cpp
+++ b/src/game/client/draw/w3dmodeldraw.cpp
@@ -1553,7 +1553,7 @@ void W3DModelDraw::Adjust_Animation(ModelConditionInfo const *prev_state, float 
                 } else if (Maintain_Frame_Across_States(m_curState->m_flags) && prev_state != nullptr
                     && prev_state != m_curState && Maintain_Frame_Across_States(prev_state->m_flags)
                     && Maintain_Frame_Across_States_2(m_curState->m_flags, prev_state->m_flags) && f >= 0.0f) {
-                    frame = GameMath::Fast_To_Int_Truncate(anim->Get_Num_Frames() * f - 1.0f);
+                    frame = FastMath::Fast_To_Int_Truncate(anim->Get_Num_Frames() * f - 1.0f);
                 }
 
                 m_renderObject->Set_Animation(anim, frame, m_curState->m_mode);
@@ -2718,7 +2718,7 @@ bool W3DModelDraw::Handle_Weapon_Fire_FX(WeaponSlotType wslot,
 void W3DModelDraw::Set_Animation_Loop_Duration(unsigned int num_frames)
 {
     m_loopDuration = -1;
-    Set_Cur_Anim_Duration_In_Msec(GameMath::Ceil(num_frames * MSEC_PER_LOGICFRAME_REAL));
+    Set_Cur_Anim_Duration_In_Msec(FastMath::Ceil(num_frames * MSEC_PER_LOGICFRAME_REAL));
 }
 
 void W3DModelDraw::Set_Animation_Completion_Time(unsigned int num_frames)
@@ -2727,7 +2727,7 @@ void W3DModelDraw::Set_Animation_Completion_Time(unsigned int num_frames)
         && m_nextState->m_transition && m_nextState->m_animations.size()) {
         float cur_fps = m_curState->m_animations.front().Get_Frames_Per_Second();
         float next_fps = m_nextState->m_animations.front().Get_Frames_Per_Second();
-        int duration = GameMath::Fast_To_Int_Floor(num_frames * cur_fps / (cur_fps + next_fps));
+        int duration = FastMath::Fast_To_Int_Floor(num_frames * cur_fps / (cur_fps + next_fps));
         Set_Animation_Loop_Duration(duration);
         m_loopDuration = num_frames - duration;
     } else {

--- a/src/game/client/draw/w3dropedraw.cpp
+++ b/src/game/client/draw/w3dropedraw.cpp
@@ -43,15 +43,15 @@ void W3DRopeDraw::Build_Segments()
 {
     captainslog_dbgassert(m_segments.empty(), "Segments expected empty");
     m_segments.clear();
-    int segment_count = (int)GameMath::Ceil(m_height / m_wobbleLen);
+    int segment_count = (int)FastMath::Ceil(m_height / m_wobbleLen);
     float segment_height = m_height / segment_count;
     Coord3D pos = *Get_Drawable()->Get_Position();
 
     for (int i = 0; i < segment_count; i++) {
         SegInfo segment;
         float angle = Get_Client_Random_Value_Real(0.0f, DEG_TO_RADF(360.0f));
-        segment.m_cosAngle = GameMath::Cos(angle);
-        segment.m_sinAngle = GameMath::Sin(angle);
+        segment.m_cosAngle = FastMath::Cos(angle);
+        segment.m_sinAngle = FastMath::Sin(angle);
 
         segment.m_line1 = new Line3DClass(Vector3(pos.x, pos.y, pos.z),
             Vector3(pos.x, pos.y, pos.z + segment_height),
@@ -132,7 +132,7 @@ void W3DRopeDraw::Do_Draw_Module(const Matrix3D *transform)
     }
 
     if (!m_segments.empty()) {
-        float wobble_sin_angle = GameMath::Sin(m_wobbleAngle) * m_wobbleAmplitude;
+        float wobble_sin_angle = FastMath::Sin(m_wobbleAngle) * m_wobbleAmplitude;
         const Coord3D *pos = Get_Drawable()->Get_Position();
         Vector3 start(pos->x, pos->y, pos->z + m_curDropHeight);
         float segment_length = m_ropeLength / m_segments.size();

--- a/src/game/client/draw/w3dsupplydraw.cpp
+++ b/src/game/client/draw/w3dsupplydraw.cpp
@@ -44,7 +44,7 @@ void W3DSupplyDraw::Update_Draw_Module_Supply_Status(int max, int current)
         m_currentSupplyBoneCount = m_totalSupplyBoneCount;
     }
 
-    int newcount = GameMath::Ceil((float)m_totalSupplyBoneCount * ((float)current / (float)max));
+    int newcount = FastMath::Ceil((float)m_totalSupplyBoneCount * ((float)current / (float)max));
     newcount = std::min(newcount, m_totalSupplyBoneCount);
 
     if (newcount != m_currentSupplyBoneCount) {

--- a/src/game/client/draw/w3dtankdraw.cpp
+++ b/src/game/client/draw/w3dtankdraw.cpp
@@ -112,7 +112,7 @@ void W3DTankDraw::Do_Draw_Module(const Matrix3D *transform)
                     Stop_Move_Debris();
                 }
 
-                len = GameMath::Sqrt(len);
+                len = FastMath::Sqrt(len);
                 Coord3D mul;
                 mul.x = 0.5f * len + 0.1f;
 
@@ -157,7 +157,7 @@ void W3DTankDraw::Do_Draw_Module(const Matrix3D *transform)
                             >= Get_W3D_Tank_Draw_Module_Data()->m_treadDriveSpeedFraction) {
                             for (int i = 0; i < m_treadCount; i++) {
                                 float offset = m_treads[i].m_materialSettings.m_customUVOffset.X - rate;
-                                offset -= GameMath::Floor(offset);
+                                offset -= FastMath::Floor(offset);
                                 m_treads[i].m_materialSettings.m_customUVOffset.Set(offset, 0.0f);
                             }
                         }
@@ -289,7 +289,7 @@ void W3DTankDraw::Update_Tread_Positions(float uv_delta)
             offset = m_treads[i].m_materialSettings.m_customUVOffset.X - uv_delta;
         }
 
-        offset -= GameMath::Floor(offset);
+        offset -= FastMath::Floor(offset);
         m_treads[i].m_materialSettings.m_customUVOffset.Set(offset, 0.0f);
     }
 }

--- a/src/game/client/draw/w3dtanktruckdraw.cpp
+++ b/src/game/client/draw/w3dtanktruckdraw.cpp
@@ -291,7 +291,7 @@ void W3DTankTruckDraw::Do_Draw_Module(const Matrix3D *transform)
                                     >= Get_W3D_Tank_Truck_Draw_Module_Data()->m_treadDriveSpeedFraction) {
                                     for (int i = 0; i < m_treadCount; i++) {
                                         float offset = m_treads[i].m_materialSettings.m_customUVOffset.X - rate;
-                                        offset -= GameMath::Floor(offset);
+                                        offset -= FastMath::Floor(offset);
                                         m_treads[i].m_materialSettings.m_customUVOffset.Set(offset, 0.0f);
                                     }
                                 }
@@ -581,7 +581,7 @@ void W3DTankTruckDraw::Update_Tread_Positions(float uv_delta)
             offset = m_treads[i].m_materialSettings.m_customUVOffset.X - uv_delta;
         }
 
-        offset -= GameMath::Floor(offset);
+        offset -= FastMath::Floor(offset);
         m_treads[i].m_materialSettings.m_customUVOffset.Set(offset, 0.0f);
     }
 }

--- a/src/game/client/globallanguage.cpp
+++ b/src/game/client/globallanguage.cpp
@@ -114,7 +114,7 @@ int GlobalLanguage::Adjust_Font_Size(int size)
     float adjustment = std::clamp(
         (((g_theWriteableGlobalData->m_xResolution / 800) - 1.0f) * m_resolutionFontAdjustment) + 1.0f, 1.0f, 2.0f);
 
-    return GameMath::Fast_To_Int_Floor(adjustment * size);
+    return FastMath::Fast_To_Int_Floor(adjustment * size);
 }
 
 // Was originally INI::parseLanguageDefinition

--- a/src/game/client/shader/motionblurfilter.cpp
+++ b/src/game/client/shader/motionblurfilter.cpp
@@ -119,7 +119,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
 
     if (mode < FM_VIEW_MB_PAN_ALPHA) {
         if (mode == FM_VIEW_MB_END_PAN_ALPHA) {
-            float f3 = GameMath::Sqrt(m_priorDelta.x * m_priorDelta.x + m_priorDelta.y * m_priorDelta.y);
+            float f3 = FastMath::Sqrt(m_priorDelta.x * m_priorDelta.x + m_priorDelta.y * m_priorDelta.y);
             f1 = m_priorDelta.x / f3 * 0.5f + f1;
             f2 = f2 - m_priorDelta.y / f3 * 0.5f;
             m_decrement = false;
@@ -131,7 +131,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
             b1 = true;
         }
     } else {
-        float f3 = GameMath::Sqrt(delta.x * delta.x + delta.y * delta.y);
+        float f3 = FastMath::Sqrt(delta.x * delta.x + delta.y * delta.y);
         f2 = f2 - 0.5f;
         m_decrement = false;
         m_maxCount = (f3 * 200.0f * m_panFactor / 30.0f);
@@ -181,7 +181,7 @@ bool ScreenMotionBlurFilter::Post_Render(FilterModes mode, Coord2D &delta, bool 
     if (!b1) {
         for (int i = 0; i < 4; i++) {
             float f3 = 1.0f - m_maxCount / 60.0f * 0.89999998f;
-            f3 = GameMath::Sqrt(f3);
+            f3 = FastMath::Sqrt(f3);
             vertex[i].u = (vertex[i].u - f1) * f3 + f1;
             vertex[i].v = (vertex[i].v - f2) * f3 + f2;
         }

--- a/src/game/client/shadow/w3dprojectedshadow.cpp
+++ b/src/game/client/shadow/w3dprojectedshadow.cpp
@@ -719,10 +719,10 @@ void W3DProjectedShadowManager::Queue_Decal(W3DProjectedShadow *shadow)
             vVector *= shadow->m_sizeY;
             float uOffset = shadow->m_offsetX + 0.5f;
             float vOffset = shadow->m_offsetY + 0.5f;
-            int startX = size + GameMath::Fast_To_Int_Floor((objPos.X + min_x) * f1);
-            int endX = size + GameMath::Fast_To_Int_Ceil((objPos.X + max_x) * f1);
-            int startY = size + GameMath::Fast_To_Int_Floor((objPos.Y + min_y) * f1);
-            int endY = size + GameMath::Fast_To_Int_Ceil((objPos.Y + max_y) * f1);
+            int startX = size + FastMath::Fast_To_Int_Floor((objPos.X + min_x) * f1);
+            int endX = size + FastMath::Fast_To_Int_Ceil((objPos.X + max_x) * f1);
+            int startY = size + FastMath::Fast_To_Int_Floor((objPos.Y + min_y) * f1);
+            int endY = size + FastMath::Fast_To_Int_Ceil((objPos.Y + max_y) * f1);
 
             if (startX <= g_drawStartX) {
                 startX = g_drawStartX;
@@ -759,7 +759,7 @@ void W3DProjectedShadowManager::Queue_Decal(W3DProjectedShadow *shadow)
             int i5 = endX - startX - 103;
 
             if (i5 > 0) {
-                int i6 = GameMath::Fast_To_Int_Floor((float)i5 / 2.0f);
+                int i6 = FastMath::Fast_To_Int_Floor((float)i5 / 2.0f);
                 startX += i6;
                 endX -= i5 - i6;
             }
@@ -767,7 +767,7 @@ void W3DProjectedShadowManager::Queue_Decal(W3DProjectedShadow *shadow)
             int i7 = endY - startY - 103;
 
             if (i7 > 0) {
-                int i8 = GameMath::Fast_To_Int_Floor((float)i7 / 2.0f);
+                int i8 = FastMath::Fast_To_Int_Floor((float)i7 / 2.0f);
                 startY += i8;
                 endY -= i7 - i8;
             }

--- a/src/game/client/shadow/w3dshadow.h
+++ b/src/game/client/shadow/w3dshadow.h
@@ -110,9 +110,9 @@ public:
             m_color2 = (opacity << 24) + (m_color1 & 0xFFFFFF);
         } else if ((m_type & SHADOW_ADDITIVE_DECAL) != 0) {
             float o = m_opacity / 255.0f;
-            m_color2 = GameMath::Fast_To_Int_Truncate(((m_color1 >> 16) & 0xFF) * o)
-                | GameMath::Fast_To_Int_Truncate(((m_color1 >> 8) & 0xFF) * o)
-                | GameMath::Fast_To_Int_Truncate((m_color1 & 0xFF) * o);
+            m_color2 = FastMath::Fast_To_Int_Truncate(((m_color1 >> 16) & 0xFF) * o)
+                | FastMath::Fast_To_Int_Truncate(((m_color1 >> 8) & 0xFF) * o)
+                | FastMath::Fast_To_Int_Truncate((m_color1 & 0xFF) * o);
         }
     }
 

--- a/src/game/client/system/particlesystem/particlesys.cpp
+++ b/src/game/client/system/particlesystem/particlesys.cpp
@@ -24,10 +24,10 @@
 #include <algorithm>
 #include <captainslog.h>
 
-using GameMath::Cos;
+using FastMath::Cos;
+using FastMath::Sin;
+using FastMath::Sqrt;
 using GameMath::Fabs;
-using GameMath::Sin;
-using GameMath::Sqrt;
 
 /**
  * 0x004CDA10

--- a/src/game/client/water/w3dwater.cpp
+++ b/src/game/client/water/w3dwater.cpp
@@ -1369,7 +1369,7 @@ void WaterRenderObjClass::Render_Sky_Body(Matrix3D *mat)
     Vector3::Normalized_Cross_Product(v3, v2, &v4);
 
     Matrix3D m(true);
-    m.Set(v4, GameMath::Acos(v3 * v2));
+    m.Set(v4, FastMath::Acos(v3 * v2));
     m.Adjust_Translation(Vector3(150.0f, 550.0f, 30.0f));
     DX8Wrapper::Set_Transform(D3DTS_WORLD, m);
 
@@ -1456,7 +1456,7 @@ void WaterRenderObjClass::Render_Water_Mesh()
         unsigned int color2 = (s->water_diffuse & 0xFF000000) >> 24;
         color2 -= 32;
         color |= color2 << 24;
-        float f1 = GameMath::Cos(3.0f * m_riverVOrigin) * 0.02f;
+        float f1 = FastMath::Cos(3.0f * m_riverVOrigin) * 0.02f;
         float f2 = 25.0f * m_riverVOrigin;
         float f3 = m_riverVOrigin / v;
         WaterMeshData *mesh = &m_meshData[x + 3];
@@ -1544,25 +1544,25 @@ void WaterRenderObjClass::Add_Velocity(float world_x, float world_y, float z_vel
         float gy;
 
         if (World_To_Grid_Space(world_x, world_y, gx, gy)) {
-            float minx = GameMath::Floor(gx - m_gridChangeMaxRange);
+            float minx = FastMath::Floor(gx - m_gridChangeMaxRange);
 
             if (minx < 0.0f) {
                 minx = 0.0f;
             }
 
-            float maxx = GameMath::Ceil(gx + m_gridChangeMaxRange);
+            float maxx = FastMath::Ceil(gx + m_gridChangeMaxRange);
 
             if (m_gridCellsX < maxx) {
                 maxx = m_gridCellsX;
             }
 
-            float miny = GameMath::Floor(gy - m_gridChangeMaxRange);
+            float miny = FastMath::Floor(gy - m_gridChangeMaxRange);
 
             if (miny < 0.0f) {
                 miny = 0.0f;
             }
 
-            float maxy = GameMath::Ceil(gy + m_gridChangeMaxRange);
+            float maxy = FastMath::Ceil(gy + m_gridChangeMaxRange);
 
             if (m_gridCellsY < maxy) {
                 maxy = m_gridCellsY;
@@ -1588,25 +1588,25 @@ void WaterRenderObjClass::Change_Grid_Height(float wx, float wy, float delta)
     float gy;
 
     if (World_To_Grid_Space(wx, wy, gx, gy)) {
-        float minx = GameMath::Floor(gx - m_gridChangeMaxRange);
+        float minx = FastMath::Floor(gx - m_gridChangeMaxRange);
 
         if (minx < 0.0f) {
             minx = 0.0f;
         }
 
-        float maxx = GameMath::Ceil(gx + m_gridChangeMaxRange);
+        float maxx = FastMath::Ceil(gx + m_gridChangeMaxRange);
 
         if (m_gridCellsX < maxx) {
             maxx = m_gridCellsX;
         }
 
-        float miny = GameMath::Floor(gy - m_gridChangeMaxRange);
+        float miny = FastMath::Floor(gy - m_gridChangeMaxRange);
 
         if (miny < 0.0f) {
             miny = 0.0f;
         }
 
-        float maxy = GameMath::Ceil(gy + m_gridChangeMaxRange);
+        float maxy = FastMath::Ceil(gy + m_gridChangeMaxRange);
 
         if (m_gridCellsY < maxy) {
             maxy = m_gridCellsY;
@@ -1615,7 +1615,7 @@ void WaterRenderObjClass::Change_Grid_Height(float wx, float wy, float delta)
         for (int i = miny; i < maxy; i++) {
             for (int j = minx; j < maxx; j++) {
                 WaterMeshData *mesh = &m_meshData[(m_gridCellsX + 3) * (i + 1) + j + 1];
-                float dist = GameMath::Sqrt((gx - j) * (gx - j) + (gy - i) * (gy - i));
+                float dist = FastMath::Sqrt((gx - j) * (gx - j) + (gy - i) * (gy - i));
                 float height = 1.0f / (dist * m_gridChangeAtt1 + m_gridChangeAtt0 + dist * dist * m_gridChangeAtt2) * delta
                     + mesh->height;
 
@@ -1710,8 +1710,8 @@ float WaterRenderObjClass::Get_Water_Height(float x, float y)
     const WaterHandle *h = nullptr;
     float z = 0.0f;
     ICoord3D point;
-    point.x = GameMath::Fast_To_Int_Floor(x + 0.5f);
-    point.y = GameMath::Fast_To_Int_Floor(y + 0.5f);
+    point.x = FastMath::Fast_To_Int_Floor(x + 0.5f);
+    point.y = FastMath::Fast_To_Int_Floor(y + 0.5f);
     point.z = 0;
 
     for (PolygonTrigger *i = PolygonTrigger::Get_First_Polygon_Trigger(); i; i = i->Get_Next()) {
@@ -1827,8 +1827,8 @@ void WaterRenderObjClass::Draw_River_Water(PolygonTrigger *ptrig)
             }
         }
 
-        int color = (GameMath::Fast_To_Int_Truncate(red) << 16) | (GameMath::Fast_To_Int_Truncate(green) << 8)
-            | GameMath::Fast_To_Int_Truncate(blue);
+        int color = (FastMath::Fast_To_Int_Truncate(red) << 16) | (FastMath::Fast_To_Int_Truncate(green) << 8)
+            | FastMath::Fast_To_Int_Truncate(blue);
         color |= m_settings[m_tod].water_diffuse & 0xFF000000;
 
         int inner = ptrig->Get_River_Start();
@@ -2141,8 +2141,8 @@ void WaterRenderObjClass::Draw_Trapezoid_Water(Vector3 *const points)
         }
     }
 
-    int color = (GameMath::Fast_To_Int_Truncate(red) << 16) | (GameMath::Fast_To_Int_Truncate(green) << 8)
-        | GameMath::Fast_To_Int_Truncate(blue);
+    int color = (FastMath::Fast_To_Int_Truncate(red) << 16) | (FastMath::Fast_To_Int_Truncate(green) << 8)
+        | FastMath::Fast_To_Int_Truncate(blue);
     color |= m_settings[m_tod].water_diffuse & 0xFF000000;
 
     DynamicVBAccessClass dyn_vb_access(VertexBufferClass::BUFFER_TYPE_DYNAMIC_DX8,
@@ -2195,11 +2195,11 @@ void WaterRenderObjClass::Draw_Trapezoid_Water(Vector3 *const points)
                     dest_verts->x = pos.X;
                     dest_verts->y = pos.Y;
                     f1 = pos.X * f2 + 25.0f * m_riverVOrigin;
-                    f3 = (GameMath::Sin(f1) - 1.0f) * f4;
+                    f3 = (FastMath::Sin(f1) - 1.0f) * f4;
                     dest_verts->z = pos.Z + f3;
                     dest_verts->diffuse = color2;
-                    dest_verts->u1 = GameMath::Cos(11.0f * m_riverVOrigin) * double(0.02) * f3 + pos.X / 150.0f;
-                    dest_verts->v1 = GameMath::Cos(5.0f * m_riverVOrigin) * double(0.02) * f3 + pos.Y / 150.0f;
+                    dest_verts->u1 = FastMath::Cos(11.0f * m_riverVOrigin) * double(0.02) * f3 + pos.X / 150.0f;
+                    dest_verts->v1 = FastMath::Cos(5.0f * m_riverVOrigin) * double(0.02) * f3 + pos.Y / 150.0f;
                     dest_verts->u2 = pos.X / 50.0f;
                     dest_verts->v2 = 0.30000001f * pos.X / 50.0f + pos.Y / 50.0f;
                     dest_verts->nx = 0.0f;
@@ -2213,8 +2213,8 @@ void WaterRenderObjClass::Draw_Trapezoid_Water(Vector3 *const points)
         {
             DynamicVBAccessClass::WriteLockClass lock(&dyn_vb_access);
             VertexFormatXYZNDUV2 *dest_verts = lock.Get_Formatted_Vertex_Array();
-            float f1 = GameMath::Cos(11.0f * m_riverVOrigin) * double(0.02);
-            float f2 = GameMath::Cos(5.0f * m_riverVOrigin) * double(0.02);
+            float f1 = FastMath::Cos(11.0f * m_riverVOrigin) * double(0.02);
+            float f2 = FastMath::Cos(5.0f * m_riverVOrigin) * double(0.02);
             float f3 = 25.0f * m_riverVOrigin;
             float f4 = 1.0f / 150.0f;
             float f5 = GAMEMATH_PI / 40.f;

--- a/src/game/client/water/w3dwatertracks.cpp
+++ b/src/game/client/water/w3dwatertracks.cpp
@@ -137,7 +137,7 @@ void WaterTracksObj::Init(
     m_timeUntilBreak = (m_distanceFromShore - m_width) / m_velocity;
     m_velocityUnk = -(m_velocity * m_velocity) / (2.0f * m_width);
     m_timingUnk2 = -m_velocity / m_velocityUnk;
-    m_timingUnk3 = GameMath::Sqrt(GameMath::Fabs(2.0f * m_width / m_velocityUnk));
+    m_timingUnk3 = FastMath::Sqrt(GameMath::Fabs(2.0f * m_width / m_velocityUnk));
     m_totalMs = (int)(m_timeUntilBreak + m_timingUnk2 + m_timingUnk3);
     m_scaleUnk = 2.0f * m_heightFraction / (m_timingUnk2 * m_timingUnk2);
     m_timeToCompress = s_waveTypeInfo[m_type].time_to_compress;
@@ -264,7 +264,7 @@ int WaterTracksObj::Render(DX8VertexBufferClass *vertex_buffer, int batch_start)
     verts->x = vertex.X;
     verts->y = vertex.Y;
     verts->z = waterz + 1.5f;
-    verts->diffuse = (GameMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | 0xFFFFFF;
+    verts->diffuse = (FastMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | 0xFFFFFF;
 
     if (m_flipUV == 0.0f) {
         verts->u1 = 0.0f;
@@ -279,7 +279,7 @@ int WaterTracksObj::Render(DX8VertexBufferClass *vertex_buffer, int batch_start)
     verts->x = vertex.X;
     verts->y = vertex.Y;
     verts->z = waterz + 1.5f;
-    verts->diffuse = (GameMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | 0xFFFFFF;
+    verts->diffuse = (FastMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | 0xFFFFFF;
 
     if (m_flipUV == 0.0f) {
         verts->u1 = 1.0f;
@@ -294,7 +294,7 @@ int WaterTracksObj::Render(DX8VertexBufferClass *vertex_buffer, int batch_start)
     verts->x = vertex.X;
     verts->y = vertex.Y;
     verts->z = waterz + 1.5f;
-    verts->diffuse = (GameMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | 0xFFFFFF;
+    verts->diffuse = (FastMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | 0xFFFFFF;
 
     if (m_flipUV == 0.0f) {
         verts->u1 = 0.0f;
@@ -309,7 +309,7 @@ int WaterTracksObj::Render(DX8VertexBufferClass *vertex_buffer, int batch_start)
     verts->x = vertex.X;
     verts->y = vertex.Y;
     verts->z = waterz + 1.5f;
-    verts->diffuse = (GameMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | 0xFFFFFF;
+    verts->diffuse = (FastMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | 0xFFFFFF;
 
     if (m_flipUV == 0.0f) {
         verts->u1 = 1.0f;
@@ -534,7 +534,7 @@ void Test_Water_Update()
             int x = terrain_point_end.x - terrain_point_start.x;
             int y = terrain_point_end.y - terrain_point_start.y;
 
-            if (s_waveTypeInfo[current_wave_type].final_width >= GameMath::Sqrt(x * x + y * y)) {
+            if (s_waveTypeInfo[current_wave_type].final_width >= FastMath::Sqrt(x * x + y * y)) {
                 g_theDisplay->Draw_Line(mouse_anchor.x, mouse_anchor.y, point.x, point.y, 1.0f, 0xFFCCCCFF);
                 DX8Wrapper::Invalidate_Cached_Render_States();
                 ShaderClass::Invalidate();
@@ -717,8 +717,8 @@ void WaterTracksRenderSystem::Flush(RenderInfoClass &rinfo)
                 g = g * 255.0f;
                 b = b * 255.0f;
                 // TODO investigate this, seems that color is leftover code
-                int color = (GameMath::Fast_To_Int_Truncate(r) << 16) | (GameMath::Fast_To_Int_Truncate(g) << 8)
-                    | GameMath::Fast_To_Int_Truncate(b);
+                int color = (FastMath::Fast_To_Int_Truncate(r) << 16) | (FastMath::Fast_To_Int_Truncate(g) << 8)
+                    | FastMath::Fast_To_Int_Truncate(b);
                 Matrix3D m(true);
                 DX8Wrapper::Set_Transform(D3DTS_WORLD, m);
                 DX8Wrapper::Set_Material(m_vertexMaterialClass);

--- a/src/game/client/worldheightmap.cpp
+++ b/src/game/client/worldheightmap.cpp
@@ -1490,9 +1490,9 @@ bool WorldHeightMap::Get_UV_For_Tile_Index(int ndx, short tile_ndx, float *const
             }
 
             float f15 = (float)(i6 - i5) * HEIGHT_SCALE;
-            float f16 = GameMath::Sqrt(f15 * f15 + 1.0f);
+            float f16 = FastMath::Sqrt(f15 * f15 + 1.0f);
             float f17 = (float)(i6 - i3) * HEIGHT_SCALE;
-            float f18 = GameMath::Sqrt(f17 * f17 + 1.0f);
+            float f18 = FastMath::Sqrt(f17 * f17 + 1.0f);
 
             if (f16 < (float)STRETCH_LIMIT) {
                 f16 = 1.0f;
@@ -1522,9 +1522,9 @@ bool WorldHeightMap::Get_UV_For_Tile_Index(int ndx, short tile_ndx, float *const
             v[3] = min_v;
 
             float f21 = (float)(i4 - i3) * HEIGHT_SCALE;
-            float f22 = GameMath::Sqrt(f21 * f21 + 1.0f);
+            float f22 = FastMath::Sqrt(f21 * f21 + 1.0f);
             float f23 = (float)(i5 - i4) * HEIGHT_SCALE;
-            float f24 = GameMath::Sqrt(f23 * f23 + 1.0f);
+            float f24 = FastMath::Sqrt(f23 * f23 + 1.0f);
 
             if (f22 < (float)STRETCH_LIMIT) {
                 f22 = 1.0f;
@@ -1951,8 +1951,8 @@ void WorldHeightMap::Set_Cell_Cliff_Flag_From_Heights(int x_index, int y_index)
 
 void WorldHeightMap::Get_Terrain_Color_At(float x, float y, RGBColor *color)
 {
-    int i1 = GameMath::Fast_To_Int_Floor(x / 10.0f);
-    int i2 = GameMath::Fast_To_Int_Floor(y / 10.0f);
+    int i1 = FastMath::Fast_To_Int_Floor(x / 10.0f);
+    int i2 = FastMath::Fast_To_Int_Floor(y / 10.0f);
     int i3 = m_borderSize + i1;
     int i4 = m_borderSize + i2;
     color->blue = 0.0f;
@@ -1991,8 +1991,8 @@ void WorldHeightMap::Get_Terrain_Color_At(float x, float y, RGBColor *color)
 
 Utf8String WorldHeightMap::Get_Terrain_Name_At(float x, float y)
 {
-    int i1 = GameMath::Fast_To_Int_Floor(x / 10.0f);
-    int i2 = GameMath::Fast_To_Int_Floor(y / 10.0f);
+    int i1 = FastMath::Fast_To_Int_Floor(x / 10.0f);
+    int i2 = FastMath::Fast_To_Int_Floor(y / 10.0f);
     int i3 = m_borderSize + i1;
     int i4 = m_borderSize + i2;
 

--- a/src/game/logic/object/update/swayclientupdate.cpp
+++ b/src/game/logic/object/update/swayclientupdate.cpp
@@ -86,7 +86,7 @@ void SwayClientUpdate::Client_Update()
         if (m_curValue > GAMEMATH_PI2) {
             m_curValue -= GAMEMATH_PI2;
         }
-        const float angle = GameMath::Cos(m_curValue);
+        const float angle = FastMath::Cos(m_curValue);
         const float new_angle = angle * m_curAngleLimit + m_leanAngle;
         const float delta_angle = new_angle - m_curAngle;
         // #TODO Negate -delta_angle to make trees sway in same direction as trees not using this module.

--- a/src/platform/audio/milesaudiomanager.cpp
+++ b/src/platform/audio/milesaudiomanager.cpp
@@ -21,7 +21,7 @@
 #include "videoplayer.h"
 #include "view.h"
 
-using GameMath::Fast_To_Int_Truncate;
+using FastMath::Fast_To_Int_Truncate;
 
 /**
  * 0x0077C700

--- a/src/platform/w3dengine/client/w3dbibbuffer.cpp
+++ b/src/platform/w3dengine/client/w3dbibbuffer.cpp
@@ -110,8 +110,8 @@ void W3DBibBuffer::Load_Bibs_In_Vertex_And_Index_Buffers()
                 grn = grn * 255.0f;
                 blu = blu * 255.0f;
 
-                unsigned int color = (GameMath::Fast_To_Int_Truncate(red) << 16) | (GameMath::Fast_To_Int_Truncate(grn) << 8)
-                    | GameMath::Fast_To_Int_Truncate(blu) | 0xFF000000;
+                unsigned int color = (FastMath::Fast_To_Int_Truncate(red) << 16) | (FastMath::Fast_To_Int_Truncate(grn) << 8)
+                    | FastMath::Fast_To_Int_Truncate(blu) | 0xFF000000;
 
                 for (int i = 0; i <= 1; ++i) {
 

--- a/src/platform/w3dengine/client/w3dbridgebuffer.cpp
+++ b/src/platform/w3dengine/client/w3dbridgebuffer.cpp
@@ -324,7 +324,7 @@ int W3DBridge::Get_Model_Vertices_Fixed(VertexFormatXYZNDUV1 *destination_vb,
     Vector3 normal(-vec.Y, vec.X, 0.0f);
     normal.Normalize();
     float f = (m_end.Z - m_start.Z) / vec.Length();
-    Vector3 vec_z(-f, 0.0f, GameMath::Sqrt(1.0f - f * f));
+    Vector3 vec_z(-f, 0.0f, FastMath::Sqrt(1.0f - f * f));
     vec /= m_length;
     normal *= m_scale;
     vec_z *= m_scale;
@@ -485,14 +485,14 @@ void W3DBridge::Get_Indices_And_Vertices(unsigned short *destination_ib,
         vec_normal *= m_scale;
 
         float f = (m_end.Z - m_start.Z) / vec.Length();
-        Vector3 vec_z(-f, 0.0f, GameMath::Sqrt(1.0f - f * f));
+        Vector3 vec_z(-f, 0.0f, FastMath::Sqrt(1.0f - f * f));
         vec_z *= m_scale;
         float section_span_length = m_rightMinX - m_leftMaxX;
         int section_span_count = 1;
 
         if (m_bridgeType == SECTIONAL_BRIDGE) {
             float f3 = vec.Length() - (m_length - section_span_length);
-            section_span_count = GameMath::Fast_To_Int_Floor((section_span_length / 2.0f + f3) / section_span_length);
+            section_span_count = FastMath::Fast_To_Int_Floor((section_span_length / 2.0f + f3) / section_span_length);
         }
 
         vec /= (float)(section_span_count - 1) * section_span_length + m_length;

--- a/src/platform/w3dengine/client/w3ddisplay.cpp
+++ b/src/platform/w3dengine/client/w3ddisplay.cpp
@@ -301,10 +301,10 @@ void Draw_Graphical_Framerate_Bar()
     float f1 = 1000.0f / (float)(time - lastTime) / (1000.0f / (float)g_theWriteableGlobalData->m_framesPerSecondLimit);
     f1 = std::clamp(f1, 0.0f, 1.0f);
 
-    unsigned int red = GameMath::Fast_To_Int_Truncate((1.0f - f1) * 255.0f);
-    unsigned int green = GameMath::Fast_To_Int_Truncate(f1 * 255.0f);
+    unsigned int red = FastMath::Fast_To_Int_Truncate((1.0f - f1) * 255.0f);
+    unsigned int green = FastMath::Fast_To_Int_Truncate(f1 * 255.0f);
     unsigned int color = Make_Color(red, green, 0, 127);
-    g_theDisplay->Draw_Fill_Rect(1, 1, GameMath::Fast_To_Int_Truncate((float)g_theDisplay->Get_Width() * f1), 15, color);
+    g_theDisplay->Draw_Fill_Rect(1, 1, FastMath::Fast_To_Int_Truncate((float)g_theDisplay->Get_Width() * f1), 15, color);
     lastTime = time;
 }
 

--- a/src/platform/w3dengine/client/w3droadbuffer.cpp
+++ b/src/platform/w3dengine/client/w3droadbuffer.cpp
@@ -2575,7 +2575,7 @@ void W3DRoadBuffer::Insert_Curve_Segment_At(int ndx1, int ndx2)
             b = true;
         }
 
-        float f4 = GameMath::Acos(f2) / 0.52359879f;
+        float f4 = FastMath::Acos(f2) / 0.52359879f;
         if (f4 < 0.9f || m_roads[ndx1].m_pt1.is_angled) {
             Miter(ndx1, ndx2);
             return;

--- a/src/platform/w3dengine/client/w3dshroud.cpp
+++ b/src/platform/w3dengine/client/w3dshroud.cpp
@@ -87,13 +87,13 @@ void W3DShroud::Init(WorldHeightMap *map, float world_cell_size_x, float world_c
     m_cellHeight = world_cell_size_y;
 
     if (map != nullptr) {
-        m_numCellsX = GameMath::Fast_To_Int_Ceil(
+        m_numCellsX = FastMath::Fast_To_Int_Ceil(
             (float)(int)((map->Get_X_Extent() - 1) - 2 * map->Border_Size()) * 10.0f / m_cellWidth);
-        m_numCellsY = GameMath::Fast_To_Int_Ceil(
+        m_numCellsY = FastMath::Fast_To_Int_Ceil(
             (float)(int)((map->Get_Y_Extent() - 1) - 2 * map->Border_Size()) * 10.0f / m_cellHeight);
-        m_numMaxVisibleCellsX = GameMath::Fast_To_Int_Floor((float)(map->Get_Draw_Width() - 1) * 10.0f / m_cellWidth) + 1;
+        m_numMaxVisibleCellsX = FastMath::Fast_To_Int_Floor((float)(map->Get_Draw_Width() - 1) * 10.0f / m_cellWidth) + 1;
         width = m_numMaxVisibleCellsX;
-        m_numMaxVisibleCellsY = GameMath::Fast_To_Int_Floor((float)(map->Get_Draw_Height() - 1) * 10.0f / m_cellHeight) + 1;
+        m_numMaxVisibleCellsY = FastMath::Fast_To_Int_Floor((float)(map->Get_Draw_Height() - 1) * 10.0f / m_cellHeight) + 1;
         height = m_numMaxVisibleCellsY;
         width = m_numCellsX;
         height = m_numCellsY;

--- a/src/platform/w3dengine/client/w3dterraintracks.cpp
+++ b/src/platform/w3dengine/client/w3dterraintracks.cpp
@@ -359,8 +359,8 @@ void TerrainTracksRenderObjClassSystem::Flush()
             g = g * 255.0f;
             b = b * 255.0f;
 
-            int color = (GameMath::Fast_To_Int_Truncate(r) << 16) | (GameMath::Fast_To_Int_Truncate(g) << 8)
-                | GameMath::Fast_To_Int_Truncate(b);
+            int color = (FastMath::Fast_To_Int_Truncate(r) << 16) | (FastMath::Fast_To_Int_Truncate(g) << 8)
+                | FastMath::Fast_To_Int_Truncate(b);
 
             float edges = (float)(m_maxTankTrackEdges - m_maxTankTrackOpaqueEdges);
 
@@ -393,7 +393,7 @@ void TerrainTracksRenderObjClassSystem::Flush()
                             vertices->z = vert->Z;
                             vertices->u1 = uv->X;
                             vertices->v1 = uv->Y;
-                            vertices->diffuse = (GameMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | color;
+                            vertices->diffuse = (FastMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | color;
                             vertices++;
 
                             vert = &mod->m_edges[j].end_point_pos[1];
@@ -404,7 +404,7 @@ void TerrainTracksRenderObjClassSystem::Flush()
                             vertices->z = vert->Z;
                             vertices->u1 = uv->X;
                             vertices->v1 = uv->Y;
-                            vertices->diffuse = (GameMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | color;
+                            vertices->diffuse = (FastMath::Fast_To_Int_Truncate(alpha * 255.0f) << 24) | color;
                             vertices++;
                         }
                     }

--- a/src/platform/w3dengine/client/w3dtreebuffer.cpp
+++ b/src/platform/w3dengine/client/w3dtreebuffer.cpp
@@ -244,8 +244,8 @@ void W3DTreeBuffer::Add_Tree(
         float random_high = 1.0f + random;
         float random_low = 1.0f - random;
         float random_scale = Get_Client_Random_Value_Real(random_low, random_high);
-        m_trees[m_numTrees].sin = GameMath::Sin(angle);
-        m_trees[m_numTrees].cos = GameMath::Cos(angle);
+        m_trees[m_numTrees].sin = FastMath::Sin(angle);
+        m_trees[m_numTrees].cos = FastMath::Cos(angle);
 
         if (random > 0.0f) {
             m_trees[m_numTrees].scale = scale * random_scale;
@@ -296,8 +296,8 @@ int W3DTreeBuffer::Get_Partition_Bucket(const Coord3D *loc) const
         y = m_partitionRegion.hi.y;
     }
 
-    int x_index = GameMath::Fast_To_Int_Floor(x / (m_partitionRegion.hi.x - m_partitionRegion.lo.x) * 99.9f);
-    int y_index = GameMath::Fast_To_Int_Floor(y / (m_partitionRegion.hi.y - m_partitionRegion.lo.y) * 99.9f);
+    int x_index = FastMath::Fast_To_Int_Floor(x / (m_partitionRegion.hi.x - m_partitionRegion.lo.x) * 99.9f);
+    int y_index = FastMath::Fast_To_Int_Floor(y / (m_partitionRegion.hi.y - m_partitionRegion.lo.y) * 99.9f);
     captainslog_dbgassert(
         x_index >= 0 && y_index >= 0 && x_index < PARTITION_WIDTH_HEIGHT && y_index < PARTITION_WIDTH_HEIGHT,
         "Invalid range.");
@@ -504,8 +504,8 @@ bool W3DTreeBuffer::Update_Tree_Position(DrawableID drawable, Coord3D pos, float
     for (int i = 0; i < m_numTrees; i++) {
         if (m_trees[i].drawable_id == drawable) {
             m_trees[i].location = Vector3(pos.x, pos.y, pos.z);
-            m_trees[i].sin = GameMath::Sin(angle);
-            m_trees[i].cos = GameMath::Cos(angle);
+            m_trees[i].sin = FastMath::Sin(angle);
+            m_trees[i].cos = FastMath::Cos(angle);
             m_trees[i].bounds = m_treeTypes[m_trees[i].tree_type].bounds;
             m_trees[i].bounds.Center *= m_trees[i].scale;
             m_trees[i].bounds.Radius *= m_trees[i].scale;
@@ -521,10 +521,10 @@ bool W3DTreeBuffer::Update_Tree_Position(DrawableID drawable, Coord3D pos, float
 void W3DTreeBuffer::Update_Sway(const BreezeInfo &info)
 {
     for (int i = 0; i < 100; i++) {
-        float angle = GameMath::Cos((i + i) * GAMEMATH_PI / 101.0f);
+        float angle = FastMath::Cos((i + i) * GAMEMATH_PI / 101.0f);
         float angle2 = angle * info.intensity + info.lean;
-        float sin = GameMath::Sin(angle2);
-        float cos = GameMath::Cos(angle2);
+        float sin = FastMath::Sin(angle2);
+        float cos = FastMath::Cos(angle2);
         m_swayVector[i].X = sin * info.sway_direction.x;
         m_swayVector[i].Y = sin * info.sway_direction.y;
         m_swayVector[i].Z = cos - 1.0f;
@@ -619,9 +619,9 @@ int W3DTreeBuffer::Do_Lighting(
     green = green * 255.0f;
     blue = blue * 255.0f;
 
-    return Make_Color(GameMath::Fast_To_Int_Truncate(red),
-        GameMath::Fast_To_Int_Truncate(green),
-        GameMath::Fast_To_Int_Truncate(blue),
+    return Make_Color(FastMath::Fast_To_Int_Truncate(red),
+        FastMath::Fast_To_Int_Truncate(green),
+        FastMath::Fast_To_Int_Truncate(blue),
         255);
 }
 
@@ -1287,8 +1287,8 @@ void W3DTreeBuffer::Unit_Moved(Object *unit)
             y = m_partitionRegion.hi.y;
         }
 
-        int min_x_index = GameMath::Fast_To_Int_Floor(x / (m_partitionRegion.hi.x - m_partitionRegion.lo.x) * 99.9f);
-        int min_y_index = GameMath::Fast_To_Int_Floor(y / (m_partitionRegion.hi.y - m_partitionRegion.lo.y) * 99.9f);
+        int min_x_index = FastMath::Fast_To_Int_Floor(x / (m_partitionRegion.hi.x - m_partitionRegion.lo.x) * 99.9f);
+        int min_y_index = FastMath::Fast_To_Int_Floor(y / (m_partitionRegion.hi.y - m_partitionRegion.lo.y) * 99.9f);
         captainslog_dbgassert(min_x_index >= 0 && min_y_index >= 0 && min_x_index < PARTITION_WIDTH_HEIGHT
                 && min_y_index < PARTITION_WIDTH_HEIGHT,
             "Invalid range.");
@@ -1312,8 +1312,8 @@ void W3DTreeBuffer::Unit_Moved(Object *unit)
             y = m_partitionRegion.hi.y;
         }
 
-        int max_x_index = GameMath::Fast_To_Int_Ceil(x / (m_partitionRegion.hi.x - m_partitionRegion.lo.x) * 99.9f);
-        int max_y_index = GameMath::Fast_To_Int_Ceil(y / (m_partitionRegion.hi.y - m_partitionRegion.lo.y) * 99.9f);
+        int max_x_index = FastMath::Fast_To_Int_Ceil(x / (m_partitionRegion.hi.x - m_partitionRegion.lo.x) * 99.9f);
+        int max_y_index = FastMath::Fast_To_Int_Ceil(y / (m_partitionRegion.hi.y - m_partitionRegion.lo.y) * 99.9f);
         captainslog_dbgassert(max_x_index >= 0 && max_y_index >= 0 && max_x_index <= PARTITION_WIDTH_HEIGHT
                 && max_y_index <= PARTITION_WIDTH_HEIGHT,
             "Invalid range.");
@@ -1380,7 +1380,7 @@ void W3DTreeBuffer::Draw_Trees(CameraClass *camera, RefMultiListIterator<class R
                 }
             }
 
-            int sway_current = GameMath::Fast_To_Int_Floor(m_swayCurrent[i]);
+            int sway_current = FastMath::Fast_To_Int_Floor(m_swayCurrent[i]);
 
             if (sway_current >= 0 && sway_current + 1 < 100) {
                 float f1 = m_swayCurrent[i] - sway_current;

--- a/src/platform/w3dengine/client/w3dwaypointbuffer.cpp
+++ b/src/platform/w3dengine/client/w3dwaypointbuffer.cpp
@@ -232,8 +232,8 @@ void W3DWaypointBuffer::Draw_Waypoints(RenderInfoClass &rinfo)
 
                                         if (pos5.x * pos3.x + pos5.y * pos3.y > 0.0f) {
                                             float orientation = obj->Get_Orientation();
-                                            float cos = GameMath::Cos(orientation);
-                                            float sin = GameMath::Sin(orientation);
+                                            float cos = FastMath::Cos(orientation);
+                                            float sin = FastMath::Sin(orientation);
                                             float f1 = info.Get_Major_Radius() * cos;
                                             float f2 = info.Get_Minor_Radius() * cos;
                                             float f3 = info.Get_Major_Radius() * sin;

--- a/src/w3d/math/vp.cpp
+++ b/src/w3d/math/vp.cpp
@@ -209,13 +209,13 @@ void VectorProcessorClass::DotProduct(float *dst, const Vector3 &a, const Vector
 void VectorProcessorClass::ClampMin(float *dst, float *src, float min, int count)
 {
     for (int i = 0; i < count; i++) {
-        dst[i] = GameMath::Max(src[i], min);
+        dst[i] = FastMath::Max(src[i], min);
     }
 }
 
 void VectorProcessorClass::Power(float *dst, float *src, float pow, int count)
 {
     for (int i = 0; i < count; i++) {
-        dst[i] = GameMath::Pow(src[i], pow);
+        dst[i] = FastMath::Pow(src[i], pow);
     }
 }

--- a/src/w3d/renderer/aabtreebuilder.cpp
+++ b/src/w3d/renderer/aabtreebuilder.cpp
@@ -167,7 +167,7 @@ AABTreeBuilderClass::SplitChoiceStruct AABTreeBuilderClass::Select_Splitting_Pla
     SplitChoiceStruct best_plane_stats;
     SplitChoiceStruct considered_plane_stats;
 
-    for (int trys = 0; trys < GameMath::Min(NUM_TRYS, polycount); trys++) {
+    for (int trys = 0; trys < FastMath::Min(NUM_TRYS, polycount); trys++) {
         AAPlaneClass plane;
 
         int poly_index = polyindices[rand() % polycount];

--- a/src/w3d/renderer/camera.cpp
+++ b/src/w3d/renderer/camera.cpp
@@ -113,13 +113,13 @@ void CameraClass::Set_View_Plane(const Vector2 &vmin, const Vector2 &vmax)
 
 void CameraClass::Set_View_Plane(float hfov, float vfov)
 {
-    float width_half = GameMath::Tan(hfov / 2.0f);
+    float width_half = FastMath::Tan(hfov / 2.0f);
     float height_half = 0.0f;
 
     if (vfov == -1) {
         height_half = (1.0f / m_aspectRatio) * width_half;
     } else {
-        height_half = GameMath::Tan(vfov / 2.0f);
+        height_half = FastMath::Tan(vfov / 2.0f);
         m_aspectRatio = width_half / height_half;
     }
 
@@ -342,12 +342,12 @@ void CameraClass::Get_Clip_Planes(float &znear, float &zfar) const
 
 float CameraClass::Get_Horizontal_FOV() const
 {
-    return 2 * GameMath::Atan2(m_viewPlane.Width(), 2.0f);
+    return 2 * FastMath::Atan2(m_viewPlane.Width(), 2.0f);
 }
 
 float CameraClass::Get_Vertical_FOV() const
 {
-    return 2 * GameMath::Atan2(m_viewPlane.Height(), 2.0f);
+    return 2 * FastMath::Atan2(m_viewPlane.Height(), 2.0f);
 }
 
 float CameraClass::Get_Aspect_Ratio() const

--- a/src/w3d/renderer/colorspace.cpp
+++ b/src/w3d/renderer/colorspace.cpp
@@ -87,7 +87,7 @@ void HSV_To_RGB(Vector3 &rgb, const Vector3 &hsv)
     }
 
     float sector = hsv.X / 60.0f;
-    int i = GameMath::Floor(sector);
+    int i = FastMath::Floor(sector);
     float f = sector - i;
     float p = hsv.Z * (1.0f - hsv.Y);
     float q = hsv.Z * (1.0f - (hsv.Y * f));

--- a/src/w3d/renderer/linegroup.cpp
+++ b/src/w3d/renderer/linegroup.cpp
@@ -140,9 +140,9 @@ void LineGroupClass::Render(RenderInfoClass &rinfo)
     const bool sort = m_shader.Get_Dst_Blend_Func() != ShaderClass::DSTBLEND_ZERO
         && m_shader.Get_Alpha_Test() == ShaderClass::ALPHATEST_DISABLE && W3D::Is_Sorting_Enabled();
 
-    static Vector3 _offset_a(GameMath::Cos(DEG_TO_RADF(90.f)), GameMath::Sin(DEG_TO_RADF(90.f)), 0);
-    static Vector3 _offset_b(GameMath::Cos(DEG_TO_RADF(210.f)), GameMath::Sin(DEG_TO_RADF(210.f)), 0);
-    static Vector3 _offset_c(GameMath::Cos(DEG_TO_RADF(330.f)), GameMath::Sin(DEG_TO_RADF(330.f)), 0);
+    static Vector3 _offset_a(FastMath::Cos(DEG_TO_RADF(90.f)), FastMath::Sin(DEG_TO_RADF(90.f)), 0);
+    static Vector3 _offset_b(FastMath::Cos(DEG_TO_RADF(210.f)), FastMath::Sin(DEG_TO_RADF(210.f)), 0);
+    static Vector3 _offset_c(FastMath::Cos(DEG_TO_RADF(330.f)), FastMath::Sin(DEG_TO_RADF(330.f)), 0);
     static Vector3 _offset[3];
 
     _offset[0].Set(_offset_a);

--- a/src/w3d/renderer/mapper.cpp
+++ b/src/w3d/renderer/mapper.cpp
@@ -127,8 +127,8 @@ void LinearOffsetTextureMapperClass::Calculate_Texture_Matrix(Matrix4 &matrix)
         offset_u = std::clamp(offset_u, -m_scale.X, m_scale.X);
         offset_v = std::clamp(offset_v, -m_scale.Y, m_scale.Y);
     } else {
-        offset_u -= GameMath::Floor(offset_u);
-        offset_v -= GameMath::Floor(offset_v);
+        offset_u -= FastMath::Floor(offset_u);
+        offset_v -= FastMath::Floor(offset_v);
     }
 
     matrix.Make_Identity();
@@ -306,8 +306,8 @@ void RotateTextureMapperClass::Calculate_Texture_Matrix(Matrix4 &mat)
         m_currentAngle += 2 * GAMEMATH_PI;
     }
 
-    float c = GameMath::Cos(m_currentAngle);
-    float s = GameMath::Sin(m_currentAngle);
+    float c = FastMath::Cos(m_currentAngle);
+    float s = FastMath::Sin(m_currentAngle);
 
     mat.Make_Identity();
     mat[0].Set(m_scale.X * c, -m_scale.X * s, -m_scale.X * (c * m_center.U - s * m_center.V - m_center.U), 0.0f);
@@ -356,8 +356,8 @@ void SineLinearOffsetTextureMapperClass::Calculate_Texture_Matrix(Matrix4 &mat)
 
     m_currentAngle += delta * ms_to_radians;
 
-    float offset_u = m_uafp.X * GameMath::Sin(m_uafp.Y * m_currentAngle + m_uafp.Z * GAMEMATH_PI);
-    float offset_v = m_vafp.X * GameMath::Sin(m_vafp.Y * m_currentAngle + m_vafp.Z * GAMEMATH_PI);
+    float offset_u = m_uafp.X * FastMath::Sin(m_uafp.Y * m_currentAngle + m_uafp.Z * GAMEMATH_PI);
+    float offset_v = m_vafp.X * FastMath::Sin(m_vafp.Y * m_currentAngle + m_vafp.Z * GAMEMATH_PI);
 
     mat.Make_Identity();
     mat[0].Z = offset_u;
@@ -420,8 +420,8 @@ void StepLinearOffsetTextureMapperClass::Calculate_Texture_Matrix(Matrix4 &mat)
         m_currentStep.U = std::clamp(m_currentStep.U, -m_scale.X, m_scale.X);
         m_currentStep.V = std::clamp(m_currentStep.V, -m_scale.Y, m_scale.Y);
     } else {
-        m_currentStep.U -= GameMath::Floor(m_currentStep.U);
-        m_currentStep.V -= GameMath::Floor(m_currentStep.V);
+        m_currentStep.U -= FastMath::Floor(m_currentStep.U);
+        m_currentStep.V -= FastMath::Floor(m_currentStep.V);
     }
 
     mat.Make_Identity();
@@ -579,7 +579,7 @@ void EdgeMapperClass::Calculate_Texture_Matrix(Matrix4 &mat)
     m_lastUsedSyncTime = now;
 
     m_vOffset += delta * m_vSpeed;
-    m_vOffset -= GameMath::Floor(m_vOffset);
+    m_vOffset -= FastMath::Floor(m_vOffset);
 
     mat = Matrix4(0.0f, 0.0f, 0.5f, 0.5f, 0.0f, 0.0f, 0.0f, m_vOffset, 0.0f, 0.0f, 1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f);
 }
@@ -740,8 +740,8 @@ void ScreenMapperClass::Calculate_Texture_Matrix(Matrix4 &mat)
         offset_u = std::clamp(offset_u, -m_scale.X, m_scale.X);
         offset_v = std::clamp(offset_v, -m_scale.Y, m_scale.Y);
     } else {
-        offset_u = offset_u - GameMath::Floor(offset_u);
-        offset_v = offset_v - GameMath::Floor(offset_v);
+        offset_u = offset_u - FastMath::Floor(offset_u);
+        offset_v = offset_v - FastMath::Floor(offset_v);
     }
 
 #ifdef BUILD_WITH_D3D8
@@ -827,8 +827,8 @@ void RandomTextureMapperClass::Calculate_Texture_Matrix(Matrix4 &mat)
         }
     }
 
-    float sin = GameMath::Sin(m_currentAngle);
-    float cos = GameMath::Cos(m_currentAngle);
+    float sin = FastMath::Sin(m_currentAngle);
+    float cos = FastMath::Cos(m_currentAngle);
 
     mat.Make_Identity();
     mat[0][0] = sin * m_scale.X;

--- a/src/w3d/renderer/mesh.cpp
+++ b/src/w3d/renderer/mesh.cpp
@@ -405,13 +405,13 @@ void MeshClass::Render_Material_Pass(MaterialPassClass *pass, IndexBufferClass *
                     indices[i * 3 + 1] = (unsigned short)v1;
                     indices[i * 3 + 2] = (unsigned short)v2;
 
-                    min_v = GameMath::Min(v0, min_v);
-                    min_v = GameMath::Min(v1, min_v);
-                    min_v = GameMath::Min(v2, min_v);
+                    min_v = FastMath::Min(v0, min_v);
+                    min_v = FastMath::Min(v1, min_v);
+                    min_v = FastMath::Min(v2, min_v);
 
-                    max_v = GameMath::Max(v0, max_v);
-                    max_v = GameMath::Max(v1, max_v);
-                    max_v = GameMath::Max(v2, max_v);
+                    max_v = FastMath::Max(v0, max_v);
+                    max_v = FastMath::Max(v1, max_v);
+                    max_v = FastMath::Max(v2, max_v);
                 }
             }
 

--- a/src/w3d/renderer/motchan.cpp
+++ b/src/w3d/renderer/motchan.cpp
@@ -453,7 +453,7 @@ AdaptiveDeltaMotionChannelClass::AdaptiveDeltaMotionChannelClass() :
     if (!g_tableValid) {
         const double quarter_rot = DEG_TO_RAD(90.0);
         for (int i = 0; i < 240; ++i) {
-            g_filterTable[i + 16] = 1.0f - GameMath::Sin((i / 240.0f) * quarter_rot);
+            g_filterTable[i + 16] = 1.0f - FastMath::Sin((i / 240.0f) * quarter_rot);
         }
         g_tableValid = true;
     }

--- a/src/w3d/renderer/part_emt.cpp
+++ b/src/w3d/renderer/part_emt.cpp
@@ -587,7 +587,7 @@ void ParticleEmitterClass::Initialize_Particle(
         float pos_l2 = rand_pos.Length2();
 
         if (pos_l2) {
-            outwards = rand_pos * (m_outwardVel * GameMath::Inv_Sqrt(pos_l2));
+            outwards = rand_pos * (m_outwardVel * FastMath::Inv_Sqrt(pos_l2));
         } else {
             outwards.X = m_outwardVel;
             outwards.Y = 0.0f;

--- a/src/w3d/renderer/projector.cpp
+++ b/src/w3d/renderer/projector.cpp
@@ -45,8 +45,8 @@ void ProjectorClass::Set_Perspective_Projection(float hfov, float vfov, float zn
     m_mapper->Set_Type(MatrixMapperClass::PERSPECTIVE_PROJECTION);
     m_projection.Init_Perspective(hfov, vfov, 0.1f, zfar);
 
-    float tan_hfov2 = GameMath::Tan(hfov) * 0.5f;
-    float tan_vfov2 = GameMath::Tan(vfov) * 0.5f;
+    float tan_hfov2 = FastMath::Tan(hfov) * 0.5f;
+    float tan_vfov2 = FastMath::Tan(vfov) * 0.5f;
 
     m_lcalBoundingVolume.m_center.Set(0.0f, 0.0f, -(zfar + znear) * 0.5f);
     m_lcalBoundingVolume.m_extent.X = zfar * tan_hfov2;

--- a/src/w3d/renderer/seglinerenderer.cpp
+++ b/src/w3d/renderer/seglinerenderer.cpp
@@ -188,8 +188,8 @@ void SegLineRendererClass::Render(RenderInfoClass &rinfo,
     DX8Wrapper::Set_Transform(D3DTS_WORLD, m);
     DX8Wrapper::Set_Transform(D3DTS_VIEW, m);
     Vector2 uv_offset = m_currentUVOffset + (m_UVOffsetDeltaPerMS * (W3D::Get_Sync_Time() - m_lastUsedSyncTime));
-    uv_offset.X = uv_offset.X - GameMath::Floor(uv_offset.X);
-    uv_offset.Y = uv_offset.Y - GameMath::Floor(uv_offset.Y);
+    uv_offset.X = uv_offset.X - FastMath::Floor(uv_offset.X);
+    uv_offset.Y = uv_offset.Y - FastMath::Floor(uv_offset.Y);
     m_currentUVOffset.Set(uv_offset);
     m_lastUsedSyncTime = W3D::Get_Sync_Time();
     unsigned int chunk_size = (1 << MAX_SEGLINE_SUBDIV_LEVELS >> m_subdivisionLevel) + 1;

--- a/src/w3d/renderer/texproject.cpp
+++ b/src/w3d/renderer/texproject.cpp
@@ -365,8 +365,8 @@ bool TexProjectClass::Compute_Perspective_Projection(
 
     float tan_hfov2 = GameMath::Fabs(box.m_extent.X / (box.m_center.Z + box.m_extent.Z));
     float tan_vfov2 = GameMath::Fabs(box.m_extent.Y / (box.m_center.Z + box.m_extent.Z));
-    float hfov = 2.0f * GameMath::Atan(tan_hfov2);
-    float vfov = 2.0f * GameMath::Atan(tan_vfov2);
+    float hfov = 2.0f * FastMath::Atan(tan_hfov2);
+    float vfov = 2.0f * FastMath::Atan(tan_vfov2);
 
     Set_Perspective_Projection(hfov, vfov, znear, zfar);
     Set_Transform(texture_tm);


### PR DESCRIPTION
Notes on these new FastMath functions:
Lrintf uses Float_To_Long from TT scripts for x86 and original ww Float_To_Long for other platforms.

Max/Min use TT scripts implementation on x86 and original ww implementation on other platforms.

Pow didn't exist in original wwmath code but the places that call Pow in our code use CRT pow and I did the same.

Sin/Cos use the implementation from TT scripts (which just calls the CRT functions). Original WW code used fsin/fcos instructions on x86 but with our code using SSE, it's better to just call CRT (which is why TT scripts does that)

Inv_Sin is just a copy of the one from GameMath but calling FastMath::Sin.

Sqrt uses TT scripts implementation on x86 and original ww implementation on other platforms.

Inv_Sqrt is just a copy of the one from GameMath but calling FastMath::Sqrt.

Acos/Asin/Atan/Atan2 use original WW implementation.

Tan didn't exist in original wwmath code but the places that call Tan in our code use CRT tan and I did the same.

Ceil/Floor use original WW implementation.

Fast_Is_Float_Positive is just a copy of the one from GameMath.

Truncf is (or at least is supposed to be) a clone of the function at 00403A00 in zh wb. Unclear if its correctly cloned but it does seem to produce the right output.

Fast_To_Int_Floor, Fast_To_Int_Ceil, Fast_To_Int_Truncate, Fast_Float_Floor and Fast_Float_Ceil are copies of the ones from GameMath but calling FastMath::Truncf and FastMath::Lrintf

I used these new math functions in any place that seemed like it was safe to do so and where it didn't look like the result got stored in a file or sent over the network in some way.

Fixes #864
