### PR TITLE
Disable Crashpad build on Linux to avoid compile error

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -56,7 +56,7 @@ jobs:
           CC: ${{ steps.vars.outputs.cc }}
           CXX: ${{ steps.vars.outputs.cxx }}
         run: |
-          cmake -DBUILD_TOOLS=ON -DLOGGING=ON -DSTANDALONE=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_COVERAGE=ON -DUSE_CRASHPAD=ON -DUSE_SANITIZER=ON -B build -G Ninja
+          cmake -DBUILD_TOOLS=ON -DLOGGING=ON -DSTANDALONE=ON -DCMAKE_BUILD_TYPE=Debug -DBUILD_TESTS=ON -DBUILD_COVERAGE=ON -DUSE_CRASHPAD=OFF -DUSE_SANITIZER=ON -B build -G Ninja
 
       - name: Formatting check
         if: matrix.os != 'ubuntu-22.04'


### PR DESCRIPTION
Workaround to keep going.

```
[157/998] Building CXX object _deps/crashpad_cmake-build/CMakeFiles/minichromium.dir/__/mini_chromium_git-src/base/files/file_path.cc.o
FAILED: _deps/crashpad_cmake-build/CMakeFiles/minichromium.dir/__/mini_chromium_git-src/base/files/file_path.cc.o 
/usr/bin/clang++ -DCRASHPAD_LSS_SOURCE_EXTERNAL -DCRASHPAD_ZLIB_SOURCE_SYSTEM -D_FILE_OFFSET_BITS=64 -I/home/runner/work/Thyme/Thyme/build/_deps/crashpad_git-src -I/home/runner/work/Thyme/Thyme/build/_deps/mini_chromium_git-src -Wno-invalid-offsetof -g -std=gnu++14 -fPIC -fvisibility=hidden -fvisibility-inlines-hidden -Wall -Wendif-labels -Werror -Wextra -Wno-missing-field-initializers -Wno-noexcept-type -Wno-unused-parameter -Wno-implicit-fallthrough -Wsign-compare -Wno-multichar -fno-exceptions -fno-rtti -fno-strict-aliasing -fstack-protector-all -fdata-sections -ffunction-sections -MD -MT _deps/crashpad_cmake-build/CMakeFiles/minichromium.dir/__/mini_chromium_git-src/base/files/file_path.cc.o -MF _deps/crashpad_cmake-build/CMakeFiles/minichromium.dir/__/mini_chromium_git-src/base/files/file_path.cc.o.d -o _deps/crashpad_cmake-build/CMakeFiles/minichromium.dir/__/mini_chromium_git-src/base/files/file_path.cc.o -c /home/runner/work/Thyme/Thyme/build/_deps/mini_chromium_git-src/base/files/file_path.cc
In file included from /home/runner/work/Thyme/Thyme/build/_deps/mini_chromium_git-src/base/files/file_path.cc:10:
/home/runner/work/Thyme/Thyme/build/_deps/mini_chromium_git-src/base/logging.h:24:28: error: unknown type name 'uint32_t'
using LoggingDestination = uint32_t;
                           ^
/home/runner/work/Thyme/Thyme/build/_deps/mini_chromium_git-src/base/logging.h:30:8: error: unknown type name 'LoggingDestination'
enum : LoggingDestination {
       ^
/home/runner/work/Thyme/Thyme/build/_deps/mini_chromium_git-src/base/logging.h:48:3: error: unknown type name 'LoggingDestination'
  LoggingDestination logging_dest = LOG_DEFAULT;
  ^
3 errors.
```