### PR TITLE
Fix misplaced nullptr checks after creating textures in W3DProjectedShadowManager

### DIFF
--- a/src/platform/w3dengine/client/shadow/w3dbuffermanager.cpp
+++ b/src/platform/w3dengine/client/shadow/w3dbuffermanager.cpp
@@ -290,7 +290,7 @@ void W3DBufferManager::Release_Slot(W3DVertexBufferSlot *vb_slot)
 
 W3DBufferManager::W3DVertexBufferSlot *W3DBufferManager::Allocate_Slot_Storage(VBM_FVF_TYPES fvf_type, int size)
 {
-    captainslog_dbgassert(m_numEmptyVertexSlotsAllocated < MAX_NUMBER_SLOTS, "Nore more VB Slots");
+    captainslog_dbgassert(m_numEmptyVertexSlotsAllocated < MAX_NUMBER_SLOTS, "No more VB Slots");
 
     for (W3DVertexBuffer *vb = m_W3DVertexBuffers[fvf_type]; vb != nullptr; vb = vb->m_nextVB) {
 
@@ -395,7 +395,7 @@ void W3DBufferManager::Release_Slot(W3DIndexBufferSlot *ib_slot)
 
 W3DBufferManager::W3DIndexBufferSlot *W3DBufferManager::Allocate_Slot_Storage(int size)
 {
-    captainslog_dbgassert(m_numEmptyIndexSlotsAllocated < MAX_NUMBER_SLOTS, "Nore more IB Slots");
+    captainslog_dbgassert(m_numEmptyIndexSlotsAllocated < MAX_NUMBER_SLOTS, "No more IB Slots");
 
     for (W3DIndexBuffer *ib = m_W3DIndexBuffers; ib != nullptr; ib = ib->m_nextIB) {
 

--- a/src/platform/w3dengine/client/shadow/w3dprojectedshadow.cpp
+++ b/src/platform/w3dengine/client/shadow/w3dprojectedshadow.cpp
@@ -1271,14 +1271,14 @@ Shadow *W3DProjectedShadowManager::Add_Decal(Shadow::ShadowTypeInfo *shadow_info
 
     if (!tex) {
         TextureClass *t = W3DAssetManager::Get_Instance()->Get_Texture(fname);
+        captainslog_dbgassert(t != nullptr, "Could not load decal texture: %s", fname);
+        if (t == nullptr) {
+            return nullptr;
+        }
+
         t->Get_Texture_Filter()->Set_U_Address_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
         t->Get_Texture_Filter()->Set_V_Address_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
         t->Get_Texture_Filter()->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
-        captainslog_dbgassert(t, "Could not load decal texture: %s", fname);
-
-        if (!t) {
-            return nullptr;
-        }
 
         tex = new W3DShadowTexture();
         tex->Set_Name(fname);
@@ -1364,14 +1364,14 @@ Shadow *W3DProjectedShadowManager::Add_Decal(RenderObjClass *robj, Shadow::Shado
 
     if (!tex) {
         TextureClass *t = W3DAssetManager::Get_Instance()->Get_Texture(fname);
+        captainslog_dbgassert(t != nullptr, "Could not load decal texture: %s", fname);
+        if (t == nullptr) {
+            return nullptr;
+        }
+
         t->Get_Texture_Filter()->Set_U_Address_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
         t->Get_Texture_Filter()->Set_V_Address_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
         t->Get_Texture_Filter()->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
-        captainslog_dbgassert(t, "Could not load decal texture: %s", fname);
-
-        if (!t) {
-            return nullptr;
-        }
 
         tex = new W3DShadowTexture();
         tex->Set_Name(fname);
@@ -1492,14 +1492,14 @@ W3DProjectedShadow *W3DProjectedShadowManager::Add_Shadow(
 
             if (!tex) {
                 TextureClass *t = W3DAssetManager::Get_Instance()->Get_Texture(fname);
+                captainslog_dbgassert(t != nullptr, "Could not load decal texture: %s", fname);
+                if (t == nullptr) {
+                    return nullptr;
+                }
+
                 t->Get_Texture_Filter()->Set_U_Address_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
                 t->Get_Texture_Filter()->Set_V_Address_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
                 t->Get_Texture_Filter()->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
-                captainslog_dbgassert(t, "Could not load decal texture: %s", fname);
-
-                if (!t) {
-                    return nullptr;
-                }
 
                 tex = new W3DShadowTexture();
                 tex->Set_Name(fname);
@@ -1527,10 +1527,9 @@ W3DProjectedShadow *W3DProjectedShadowManager::Add_Shadow(
             if (!tex) {
                 m_W3DShadowTextureManager->Create_Texture(robj, fname);
                 tex = m_W3DShadowTextureManager->Get_Texture(fname);
-                captainslog_dbgassert(tex, "Could not create shadow texture");
-
-                if (!tex) {
-                    return 0;
+                captainslog_dbgassert(tex != nullptr, "Could not create shadow texture: %s", fname);
+                if (tex == nullptr) {
+                    return nullptr;
                 }
             }
 
@@ -1649,14 +1648,14 @@ W3DProjectedShadow *W3DProjectedShadowManager::Create_Decal_Shadow(Shadow::Shado
 
     if (!tex) {
         TextureClass *t = W3DAssetManager::Get_Instance()->Get_Texture(fname);
+        captainslog_dbgassert(t != nullptr, "Could not load decal texture: %s", fname);
+        if (t == nullptr) {
+            return nullptr;
+        }
+
         t->Get_Texture_Filter()->Set_U_Address_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
         t->Get_Texture_Filter()->Set_V_Address_Mode(TextureFilterClass::TEXTURE_ADDRESS_CLAMP);
         t->Get_Texture_Filter()->Set_Mip_Mapping(TextureFilterClass::FILTER_TYPE_NONE);
-        captainslog_dbgassert(t, "Could not load decal texture");
-
-        if (!t) {
-            return nullptr;
-        }
 
         tex = new W3DShadowTexture();
         tex->Set_Name(fname);


### PR DESCRIPTION
This change fixes misplaced tests in various functions of W3DProjectedShadowManager class.

Originally, the allocated textures would be accessed first, and then tested against null.

It needs to be the other way around, otherwise this would crash.

Additionally this change fixes some mistakes in relevant shadow assert messages.
