### PR TITLE
Fix error in SysTimeClass::Get

### DIFF
--- a/src/w3d/lib/systimer.cpp
+++ b/src/w3d/lib/systimer.cpp
@@ -38,13 +38,13 @@ int SysTimeClass::Get()
         _is_init = true;
     }
 
-    int time = rts::Get_Time();
+    unsigned int time = rts::Get_Time();
 
-    if (time < m_startTime) {
-        return m_negTime + time;
+    if (time > m_startTime) {
+        return time - m_startTime;
     }
 
-    return time - m_startTime;
+    return time + m_negTime;
 }
 
 bool SysTimeClass::Is_Getting_Late()


### PR DESCRIPTION
* Split off of #796

This claims to be a fix for a Thyme specific issue.
