### PR TITLE
Fix error in SortingRendererClass::Deinit

### DIFF
--- a/src/w3d/renderer/sortingrenderer.cpp
+++ b/src/w3d/renderer/sortingrenderer.cpp
@@ -564,7 +564,7 @@ void SortingRendererClass::Deinit()
 
     while (g_cleanList.Head() != nullptr) {
         auto head = g_cleanList.Head();
-        g_sortedList.Remove_Head();
+        g_cleanList.Remove_Head();
         delete head;
     }
 


### PR DESCRIPTION
* Split off of #796

This claims to be a fix for a Thyme specific issue.
