### PR TITLE
Fix math bug in Quick_Distance function

### DIFF
--- a/src/w3d/math/vector2.h
+++ b/src/w3d/math/vector2.h
@@ -308,8 +308,9 @@ __forceinline float Quick_Distance(float x1, float y1, float x2, float y2)
 {
     float x_diff = x1 - x2;
     float y_diff = y1 - y2;
-    GameMath::Fabs(x_diff);
-    GameMath::Fabs(y_diff);
+    // #BUGFIX Actually use the return values.
+    x_diff = GameMath::Fabs(x_diff);
+    y_diff = GameMath::Fabs(y_diff);
 
     if (x_diff > y_diff) {
         return (y_diff / 2) + x_diff;


### PR DESCRIPTION
* Split off of #796

This is addressing supposed original game bug.

This function appears to be yet unused in Thyme.
