### PR TITLE
Speed up compilation with Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,9 @@ if(MSVC)
         string(REGEX REPLACE "/RTC[^ ]*" "" ${flag_var} "${${flag_var}}")
     endforeach(flag_var)
     
+    # Build with multiple processes: speeds up build on multi core processors
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /MP")
+
     # Use x87 floating point instructions
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /arch:IA32")
 


### PR DESCRIPTION
This change speeds up compilation with Visual Studio.

Tested on CPU: 8 Cores, 16 Threads

## Compile time in Debug configuration:

### Status Quo

Visual Studio 2019 : 390s

### This change

Visual Studio 2019 : 56s
Visual Studio 2022 : 50s

+600% Compile speed
