### PR TITLE
Avoid stlport compile error with Visual Studio 2022

### DIFF
--- a/deps/stlport/exception
+++ b/deps/stlport/exception
@@ -57,9 +57,7 @@
 # if defined (_STLP_NO_NEW_NEW_HEADER)
 #  include _STLP_NATIVE_CPP_RUNTIME_HEADER(exception.h)
 # else
-#   if defined (_STLP_MSVC) && (_STLP_MSVC >= 1900)
-#     include _STLP_NATIVE_CPP_RUNTIME_HEADER(xstddef)
-#   endif
+//#   include _STLP_NATIVE_CPP_RUNTIME_HEADER(xstddef)
 #   include _STLP_NATIVE_CPP_RUNTIME_HEADER(exception)
 # endif
 


### PR DESCRIPTION
This change ~~fixes~~ avoids stlport compile error with Visual Studio 2022.

`xstddef` file does not exist in Visual Studio 2022. It does exist in Visual Studio 2019 however. But Visual Studio 2019 also compiles without `xstddef` included in `exception` from stlport.

Unclear what is going on.

```
Visual Studio 2019: _STLP_MSVC = 1929
Visual Studio 2022: _STLP_MSVC = 1938
```

This include was already touched prior with 9d9908f3a28a9b46a25c216b41fc43bb383b740b
