### PR TITLE
Fix vs2022 clang format

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -24,7 +24,6 @@ BraceWrapping:
   AfterFunction:   true
   AfterControlStatement: false
   AfterEnum:       true
-  AfterFunction:   true
   AfterNamespace:  true
   AfterStruct:     true
   AfterUnion:      true


### PR DESCRIPTION
VS 2022 pops up an error dialog on every format about this duplicate record.