### PR TITLE
Revert "Remove always.h from hot include files to reduce compile time"

### DIFF
--- a/deps/baseconfig/src/unichar.h
+++ b/deps/baseconfig/src/unichar.h
@@ -14,8 +14,6 @@
  */
 #ifndef BASE_UNICHAR_H
 #define BASE_UNICHAR_H
-
-#include "macros.h"
 #include <wchar.h>
 
 #ifdef U_CHAR

--- a/src/game/common/bitflags.h
+++ b/src/game/common/bitflags.h
@@ -14,6 +14,7 @@
  */
 #pragma once
 
+#include "always.h"
 #include "asciistring.h"
 #include "ini.h"
 #include "xfer.h"

--- a/src/game/common/system/asciistring.h
+++ b/src/game/common/system/asciistring.h
@@ -14,7 +14,7 @@
  */
 #pragma once
 
-#include "unichar.h"
+#include "always.h"
 #include <cstdarg>
 #include <cstddef>
 #include <cstdlib>

--- a/src/game/common/system/unicodestring.h
+++ b/src/game/common/system/unicodestring.h
@@ -14,8 +14,8 @@
  */
 #pragma once
 
+#include "always.h"
 #include "critsection.h"
-#include "unichar.h"
 #include <cstdarg>
 #include <cstddef>
 


### PR DESCRIPTION
This reverts commit 30cc43174d879316e312a6905720fb87ba801ce1.

It broke string class because of missing PLATFORM_WINDOWS define.