### PR TITLE
Release texture on W3DLaserDraw destruction

### DIFF
--- a/src/platform/w3dengine/client/drawable/draw/w3dlaserdraw.cpp
+++ b/src/platform/w3dengine/client/drawable/draw/w3dlaserdraw.cpp
@@ -157,6 +157,8 @@ W3DLaserDraw::~W3DLaserDraw()
     }
 
     delete[] m_line3D;
+
+    Ref_Ptr_Release(m_texture);
 }
 
 float W3DLaserDraw::Get_Laser_Template_Width() const


### PR DESCRIPTION
Looks like m_texture would leak on destruction.