### PR TITLE
Release all textures on WorldHeightMap destruction

### DIFF
--- a/src/platform/w3dengine/client/worldheightmap.cpp
+++ b/src/platform/w3dengine/client/worldheightmap.cpp
@@ -234,6 +234,7 @@ WorldHeightMap::~WorldHeightMap()
 
     Ref_Ptr_Release(m_terrainTex);
     Ref_Ptr_Release(m_alphaTerrainTex);
+    Ref_Ptr_Release(m_alphaEdgeTex);
 }
 
 void WorldHeightMap::Free_List_Of_Map_Objects()


### PR DESCRIPTION
Looks like `m_alphaEdgeTex` would leak on destruction.