### PR TITLE
Remove redundant nullptr assignment in W3DProjectedShadowManager destructor

### DIFF
--- a/src/platform/w3dengine/client/shadow/w3dprojectedshadow.cpp
+++ b/src/platform/w3dengine/client/shadow/w3dprojectedshadow.cpp
@@ -440,7 +440,7 @@ W3DProjectedShadowManager::W3DProjectedShadowManager() :
 W3DProjectedShadowManager::~W3DProjectedShadowManager()
 {
     Release_Resources();
-    m_dynamicRenderTarget = nullptr;
+
     m_renderTargetHasAlpha = false;
 
     if (m_shadowContext) {


### PR DESCRIPTION
Removes redundant assignment. `W3DProjectedShadowManager::Release_Resources` already calls `Ref_Ptr_Release(m_dynamicRenderTarget)` on this member.