### PR TITLE
Free resources on TerrainTracksRenderObjClass destruction

### DIFF
--- a/src/platform/w3dengine/client/w3dterraintracks.h
+++ b/src/platform/w3dengine/client/w3dterraintracks.h
@@ -33,7 +33,7 @@ class TerrainTracksRenderObjClass : public W3DMPO, public RenderObjClass
 
 public:
     TerrainTracksRenderObjClass();
-    virtual ~TerrainTracksRenderObjClass() override {}
+    virtual ~TerrainTracksRenderObjClass() override { Free_Terrain_Tracks_Resources(); }
     virtual RenderObjClass *Clone() const override { return nullptr; }
     virtual int Class_ID() const override { return CLASSID_TERRAINTRACKS; }
     virtual void Render(RenderInfoClass &rinfo) override;


### PR DESCRIPTION
`Free_Terrain_Tracks_Resources` frees texture with `Ref_Ptr_Release(m_stageZeroTexture)`. When not called in destructor, then we run risk of leak.