### PR TITLE
Boolean Fixes

### DIFF
--- a/src/game/client/drawable.cpp
+++ b/src/game/client/drawable.cpp
@@ -3185,7 +3185,7 @@ void Drawable::Update_Drawable()
                 (*modules)->Set_Terrain_Decal_Opacity(m_terrainDecalOpacity);
             }
 
-            if (m_terrainDecalFadeTarget2 < 0.0f || m_terrainDecalOpacity <= 0.0f) {
+            if (m_terrainDecalFadeTarget2 < 0.0f && m_terrainDecalOpacity <= 0.0f) {
                 m_terrainDecalFadeTarget2 = 0.0f;
                 m_terrainDecalOpacity = 0.0f;
                 Set_Terrain_Decal(TERRAIN_DECAL_8);

--- a/src/game/common/rts/player.cpp
+++ b/src/game/common/rts/player.cpp
@@ -2998,7 +2998,7 @@ void Player::Do_Bounty_For_Kill(const Object *killer, const Object *killed)
 {
     if (killer != nullptr && killed != nullptr && !killed->Get_Status(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
         unsigned int amount =
-            GameMath::Fast_To_Int_Round(killed->Get_Template()->Calc_Cost_To_Build(this) * m_bountyCostToBuild);
+            GameMath::Fast_To_Int_Floor(killed->Get_Template()->Calc_Cost_To_Build(this) * m_bountyCostToBuild);
 
         if (amount != 0) {
             Get_Money()->Deposit(amount, true);

--- a/src/game/common/rts/player.cpp
+++ b/src/game/common/rts/player.cpp
@@ -2998,7 +2998,7 @@ void Player::Do_Bounty_For_Kill(const Object *killer, const Object *killed)
 {
     if (killer != nullptr && killed != nullptr && !killed->Get_Status(OBJECT_STATUS_UNDER_CONSTRUCTION)) {
         unsigned int amount =
-            GameMath::Fast_To_Int_Ceil(killed->Get_Template()->Calc_Cost_To_Build(this) * m_bountyCostToBuild);
+            GameMath::Fast_To_Int_Round(killed->Get_Template()->Calc_Cost_To_Build(this) * m_bountyCostToBuild);
 
         if (amount != 0) {
             Get_Money()->Deposit(amount, true);

--- a/src/w3d/math/gamemath.h
+++ b/src/w3d/math/gamemath.h
@@ -378,6 +378,23 @@ inline int Fast_To_Int_Truncate(float val)
 #endif
 }
 
+inline int Fast_To_Int_Round(float val)
+{
+    static const float _exactly_half = 0.5f;
+
+    if (Fast_Is_Float_Positive(val)) {
+        val += _exactly_half;
+    } else {
+        val -= _exactly_half;
+    }
+
+#ifdef BUILD_WITH_GAMEMATH
+    return gm_lrintf(gm_truncf(val));
+#else
+    return lrintf(truncf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
+#endif
+}
+
 inline float Random_Float()
 {
     return float((float(rand() & 0xFFF)) / float(0xFFF));

--- a/src/w3d/math/gamemath.h
+++ b/src/w3d/math/gamemath.h
@@ -378,23 +378,6 @@ inline int Fast_To_Int_Truncate(float val)
 #endif
 }
 
-inline int Fast_To_Int_Round(float val)
-{
-    static const float _exactly_half = 0.5f;
-
-    if (Fast_Is_Float_Positive(val)) {
-        val += _exactly_half;
-    } else {
-        val -= _exactly_half;
-    }
-
-#ifdef BUILD_WITH_GAMEMATH
-    return gm_lrintf(gm_truncf(val));
-#else
-    return lrintf(truncf(val)); // TODO reimplement based on fdlibm for cross platform reproducibility.
-#endif
-}
-
 inline float Random_Float()
 {
     return float((float(rand() & 0xFFF)) / float(0xFFF));


### PR DESCRIPTION
Fixes #884
More faithful to Ghidra code would be addition of GameMath::Round() function, but since float errors are << 0.5 there is no difference compared to Floor.

Fixes #1081 and similar problem with America chemsuits. Suprisingly #911 remains broken