### PR TITLE
Removed incorrect assert

### DIFF
--- a/src/game/logic/object/object.cpp
+++ b/src/game/logic/object/object.cpp
@@ -4203,10 +4203,11 @@ void Object::Do_Command_Button(const CommandButton *button, CommandSourceType ty
                     const UpgradeTemplate *upgrade = button->Get_Upgrade_Template();
                     captainslog_dbgassert(upgrade != nullptr, "Undefined upgrade '%s' in player upgrade command", "UNKNOWN");
 
-                    if (upgrade == nullptr
-                        || upgrade->Get_Type() == UPGRADE_TYPE_OBJECT
+                    if (upgrade != nullptr
+                        && upgrade->Get_Type() == UPGRADE_TYPE_OBJECT
                             && (Has_Upgrade(upgrade) || !Affected_By_Upgrade(upgrade))) {
-                        goto l1;
+                        break;
+
                     }
 
                     ProductionUpdateInterface *production = Get_Production_Update_Interface();


### PR DESCRIPTION
In the original code this branch leads to assert("WARNING: Script doCommandButton for button %s not implemented. Doing nothing"). This If exists to check if an AIteam member can doCommandButton (for example barracks building China radar), not Whether given command itself is valid. After change doCommandButton for button %s becomes implemented.
Fixes AI using America ControlRods, China Mines, China Radar and GLA CamoNetting (likely more) in skirmish. 